### PR TITLE
Fix Instagram rule editing and foreground checks

### DIFF
--- a/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
@@ -146,8 +146,9 @@ class NudgeAccessibilityService : AccessibilityService() {
         refreshCounterCacheIfNeeded()
 
         when (event.eventType) {
-            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> {
-                handleWindowStateChanged(packageName)
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> {
+                evaluateForegroundPackage(packageName)
             }
             AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> {
                 handleWindowContentChanged(packageName, event)
@@ -165,9 +166,8 @@ class NudgeAccessibilityService : AccessibilityService() {
      * Original flow: foreground app changed. Evaluate whole-app rules.
      * Also handles grayscale toggle when navigating away from a grayscale-blocked app.
      */
-    private fun handleWindowStateChanged(packageName: String) {
+    private fun evaluateForegroundPackage(packageName: String) {
         val now = System.currentTimeMillis()
-        entryPoint.nudgeLogger().i("foreground app changed package=$packageName")
 
         // If user navigated away from a grayscale-enabled app, disable grayscale
         val grayscalePkg = grayscaleActiveForPackage
@@ -202,6 +202,7 @@ class NudgeAccessibilityService : AccessibilityService() {
             return
         }
 
+        entryPoint.nudgeLogger().i("foreground evaluation package=$packageName")
         lastPackage = packageName
         lastEvalTime = now
 
@@ -225,6 +226,10 @@ class NudgeAccessibilityService : AccessibilityService() {
     private fun handleWindowContentChanged(packageName: String, event: AccessibilityEvent) {
         // Only inspect supported packages
         if (packageName !in InAppDetector.SUPPORTED_PACKAGES) return
+
+        // Some apps change foreground surfaces without reliably emitting TYPE_WINDOW_STATE_CHANGED.
+        // This keeps whole-app rules enforced while feature-specific rules remain feature-gated.
+        evaluateForegroundPackage(packageName)
 
         // Post-overlay passthrough applies to in-app detection too
         if (shouldSkipEvaluationForPassthrough(packageName)) {

--- a/app/src/main/java/com/astraedus/nudge/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/navigation/NavGraph.kt
@@ -31,8 +31,9 @@ import kotlinx.coroutines.launch
 sealed class Screen(val route: String) {
     data object Home : Screen("home")
     data object Apps : Screen("apps")
-    data object RuleEditor : Screen("rule_editor/{packageName}") {
+    data object RuleEditor : Screen("rule_editor/{packageName}?ruleId={ruleId}") {
         fun createRoute(packageName: String) = "rule_editor/$packageName"
+        fun createRoute(packageName: String, ruleId: Long) = "rule_editor/$packageName?ruleId=$ruleId"
     }
     data object Groups : Screen("groups")
     data object Stats : Screen("stats")
@@ -95,7 +96,13 @@ fun NudgeNavGraph(
 
         composable(
             route = Screen.RuleEditor.route,
-            arguments = listOf(navArgument("packageName") { type = NavType.StringType })
+            arguments = listOf(
+                navArgument("packageName") { type = NavType.StringType },
+                navArgument("ruleId") {
+                    type = NavType.LongType
+                    defaultValue = -1L
+                }
+            )
         ) {
             val viewModel: RuleEditorViewModel = hiltViewModel()
             RuleEditorScreen(
@@ -109,8 +116,8 @@ fun NudgeNavGraph(
             ActiveRulesScreen(
                 viewModel = viewModel,
                 onNavigateBack = { navController.popBackStack() },
-                onNavigateToRuleEditor = { pkg ->
-                    navController.navigate(Screen.RuleEditor.createRoute(pkg))
+                onNavigateToRuleEditor = { pkg, ruleId ->
+                    navController.navigate(Screen.RuleEditor.createRoute(pkg, ruleId))
                 }
             )
         }

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/rules/ActiveRulesScreen.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/rules/ActiveRulesScreen.kt
@@ -36,7 +36,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 fun ActiveRulesScreen(
     viewModel: ActiveRulesViewModel,
     onNavigateBack: () -> Unit,
-    onNavigateToRuleEditor: (String) -> Unit
+    onNavigateToRuleEditor: (String, Long) -> Unit
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -78,13 +78,15 @@ fun ActiveRulesScreen(
                         fontWeight = FontWeight.Medium,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onNavigateToRuleEditor(group.packageName) }
+                            .clickable { onNavigateToRuleEditor(group.packageName, group.rules.first().id) }
                             .padding(vertical = 4.dp)
                     )
 
                     group.rules.forEach { rule ->
                         Card(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onNavigateToRuleEditor(group.packageName, rule.id) },
                             colors = CardDefaults.cardColors(
                                 containerColor = if (rule.enabled)
                                     MaterialTheme.colorScheme.surfaceVariant

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorViewModel.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorViewModel.kt
@@ -62,6 +62,8 @@ class RuleEditorViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val packageName: String = savedStateHandle.get<String>("packageName") ?: ""
+    private val requestedRuleId: Long? = savedStateHandle.get<Long>("ruleId")
+        ?.takeIf { it > 0L }
 
     private val _uiState = MutableStateFlow(
         RuleEditorUiState(
@@ -79,7 +81,8 @@ class RuleEditorViewModel @Inject constructor(
     private fun loadExistingRule() {
         viewModelScope.launch {
             val rules = blockRuleRepository.getAllRules().firstOrNull() ?: emptyList()
-            val existing = rules.find { it.packageName == packageName }
+            val existing = rules.find { it.id == requestedRuleId }
+                ?: rules.find { it.packageName == packageName }
             if (existing != null) {
                 val days = existing.scheduleDays
                     ?.split(",")

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged|typeViewClicked|typeViewScrolled"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowsChanged|typeWindowContentChanged|typeViewClicked|typeViewScrolled"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:accessibilityFlags="flagDefault"
     android:canRetrieveWindowContent="true"

--- a/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineTest.kt
@@ -118,4 +118,41 @@ class BlockEngineTest {
         assertEquals(BlockMode.DELAY, block.mode)
         assertEquals(10, block.delaySeconds)
     }
+
+    @Test
+    fun `feature-scoped rule does not block whole app launch`() {
+        val rules = listOf(
+            ActiveRule(
+                mode = BlockMode.DELAY,
+                delaySeconds = 15,
+                dailyLimitMinutes = null,
+                enabled = true,
+                inAppFeatures = listOf("REELS")
+            )
+        )
+
+        val decision = engine.evaluate("com.instagram.android", rules, 0L)
+
+        assertTrue(decision is BlockDecision.Allow)
+    }
+
+    @Test
+    fun `feature-scoped rule blocks when matching feature is detected`() {
+        val rules = listOf(
+            ActiveRule(
+                mode = BlockMode.DELAY,
+                delaySeconds = 15,
+                dailyLimitMinutes = null,
+                enabled = true,
+                inAppFeatures = listOf("REELS")
+            )
+        )
+
+        val decision = engine.evaluate("com.instagram.android", rules, 0L, detectedFeature = "REELS")
+
+        assertTrue(decision is BlockDecision.Block)
+        val block = decision as BlockDecision.Block
+        assertEquals(BlockMode.DELAY, block.mode)
+        assertEquals(15, block.delaySeconds)
+    }
 }


### PR DESCRIPTION
## Summary
- Add TYPE_WINDOWS_CHANGED and supported-app content fallback foreground evaluation so whole-app rules are enforced more reliably.
- Make Active Rules cards navigate to the exact saved rule via an optional ruleId route parameter.
- Add BlockEngine tests documenting feature-scoped rules versus whole-app launches.

## Test plan
- ./gradlew testDebugUnitTest :app:installDebug
- Pixel 3 ADB smoke: Active Rules -> Instagram row opens Edit Rule with Reels/Explore Delay selected.
- Pixel 3 ADB smoke: Instagram launch with current Reels/Explore-only rule logs Allow for whole-app launch.
- Pixel 3 ADB smoke: Chrome whole-app hard block still shows App Blocked overlay.