### PR TITLE
Support layered whole-app and in-app rules

### DIFF
--- a/app/src/main/java/com/astraedus/nudge/domain/engine/BlockEngine.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/engine/BlockEngine.kt
@@ -14,9 +14,9 @@ class BlockEngine @Inject constructor(
     /**
      * Evaluate whether a package should be blocked based on active rules and daily usage.
      *
-     * @param detectedFeature If non-null, only rules whose [ActiveRule.inAppFeatures] list
-     *   contains this feature (or whose inAppFeatures is null/empty, meaning whole-app block)
-     *   will be considered.
+     * @param detectedFeature If non-null, feature-scoped rules whose [ActiveRule.inAppFeatures]
+     *   list contains this feature will be considered. Whole-app rules are also considered unless
+     *   [includeWholeAppRulesForFeature] is false.
      *
      * Priority: HARD_BLOCK > time budget exceeded > DELAY > BREATHING > Allow
      */
@@ -24,11 +24,13 @@ class BlockEngine @Inject constructor(
         packageName: String,
         activeRules: List<ActiveRule>,
         dailyUsageMs: Long,
-        detectedFeature: String? = null
+        detectedFeature: String? = null,
+        includeWholeAppRulesForFeature: Boolean = true
     ): BlockDecision {
         logger.d(
             "evaluate package=$packageName rules=${activeRules.size} " +
-                "dailyUsageMs=$dailyUsageMs detectedFeature=$detectedFeature"
+                "dailyUsageMs=$dailyUsageMs detectedFeature=$detectedFeature " +
+                "includeWholeAppRulesForFeature=$includeWholeAppRulesForFeature"
         )
 
         val applicableRules = activeRules
@@ -37,9 +39,10 @@ class BlockEngine @Inject constructor(
             .filter { rule ->
                 if (detectedFeature != null) {
                     // In-app detection active: match rules that target this feature
-                    // or whole-app rules (inAppFeatures == null/empty)
+                    // and, unless suppressed by passthrough, whole-app rules.
                     val features = rule.inAppFeatures
-                    features == null || features.isEmpty() || detectedFeature in features
+                    detectedFeature in (features ?: emptyList()) ||
+                        (includeWholeAppRulesForFeature && (features == null || features.isEmpty()))
                 } else {
                     // No in-app detection: only apply whole-app rules
                     rule.inAppFeatures == null || rule.inAppFeatures.isEmpty()

--- a/app/src/main/java/com/astraedus/nudge/domain/usecase/EvaluateBlockUseCase.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/usecase/EvaluateBlockUseCase.kt
@@ -24,8 +24,15 @@ class EvaluateBlockUseCase @Inject constructor(
      *
      * @param detectedFeature If the accessibility service detected an in-app feature
      *   (e.g. "REELS", "SHORTS"), pass it here so the engine can match feature-level rules.
+     * @param includeWholeAppRulesForFeature Whether feature evaluation should also consider
+     *   whole-app rules. This is disabled after a whole-app delay has completed so in-app rules
+     *   can still fire without looping the whole-app gate.
      */
-    suspend fun invoke(packageName: String, detectedFeature: String? = null): BlockDecision {
+    suspend fun invoke(
+        packageName: String,
+        detectedFeature: String? = null,
+        includeWholeAppRulesForFeature: Boolean = true
+    ): BlockDecision {
         val allRules = blockRuleRepository.getEnabledRules().first()
         val allGroups = blockRuleRepository.getAllGroups().first()
 
@@ -59,6 +66,12 @@ class EvaluateBlockUseCase @Inject constructor(
         val activeRules = ruleEvaluator.resolveRulesForPackage(packageName, ruleDataList, memberships)
         val dailyUsageMs = usageRepository.getDailyUsage(packageName).first()
 
-        return blockEngine.evaluate(packageName, activeRules, dailyUsageMs, detectedFeature)
+        return blockEngine.evaluate(
+            packageName = packageName,
+            activeRules = activeRules,
+            dailyUsageMs = dailyUsageMs,
+            detectedFeature = detectedFeature,
+            includeWholeAppRulesForFeature = includeWholeAppRulesForFeature
+        )
     }
 }

--- a/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
@@ -93,15 +93,19 @@ class NudgeAccessibilityService : AccessibilityService() {
         @Volatile
         var lastPassthroughPackage: String? = null
         @Volatile
+        var lastPassthroughFeature: String? = null
+        @Volatile
         var lastPassthroughTime: Long = 0L
 
-        fun grantPassthrough(packageName: String) {
+        fun grantPassthrough(packageName: String, featureKey: String? = null) {
             lastPassthroughPackage = packageName
+            lastPassthroughFeature = featureKey
             lastPassthroughTime = System.currentTimeMillis()
         }
 
         internal fun resetPassthroughForTests() {
             lastPassthroughPackage = null
+            lastPassthroughFeature = null
             lastPassthroughTime = 0L
         }
 
@@ -109,13 +113,21 @@ class NudgeAccessibilityService : AccessibilityService() {
             return packageName == lastPassthroughPackage
         }
 
-        internal fun shouldSkipEvaluationForPassthrough(packageName: String): Boolean {
+        internal fun shouldSkipForegroundEvaluationForPassthrough(packageName: String): Boolean {
             return isPassthroughGranted(packageName)
+        }
+
+        internal fun shouldSkipFeatureEvaluationForPassthrough(
+            packageName: String,
+            featureKey: String
+        ): Boolean {
+            return isPassthroughGranted(packageName) && lastPassthroughFeature == featureKey
         }
 
         internal fun clearPassthroughIfAppChanged(packageName: String): Boolean {
             if (lastPassthroughPackage == null || packageName == lastPassthroughPackage) return false
             lastPassthroughPackage = null
+            lastPassthroughFeature = null
             lastPassthroughTime = 0L
             return true
         }
@@ -186,7 +198,7 @@ class NudgeAccessibilityService : AccessibilityService() {
         }
 
         // Post-overlay passthrough: user completed delay/breathing, let them use app until they leave
-        if (shouldSkipEvaluationForPassthrough(packageName)) {
+        if (shouldSkipForegroundEvaluationForPassthrough(packageName)) {
             entryPoint.nudgeLogger().d("skip evaluation package=$packageName reason=passthrough")
             return
         }
@@ -231,12 +243,6 @@ class NudgeAccessibilityService : AccessibilityService() {
         // This keeps whole-app rules enforced while feature-specific rules remain feature-gated.
         evaluateForegroundPackage(packageName)
 
-        // Post-overlay passthrough applies to in-app detection too
-        if (shouldSkipEvaluationForPassthrough(packageName)) {
-            entryPoint.nudgeLogger().d("skip in-app detection package=$packageName reason=passthrough")
-            return
-        }
-
         val now = System.currentTimeMillis()
 
         // Rate limit
@@ -250,6 +256,13 @@ class NudgeAccessibilityService : AccessibilityService() {
 
         // Only re-evaluate if a specific feature was detected
         if (feature != null) {
+            if (shouldSkipFeatureEvaluationForPassthrough(packageName, feature.key)) {
+                entryPoint.nudgeLogger().d(
+                    "skip feature evaluation package=$packageName feature=${feature.key} reason=passthrough"
+                )
+                return
+            }
+
             serviceScope.launch {
                 val globalEnabled = entryPoint.nudgePreferences().isGlobalEnabled.first()
                 if (!globalEnabled) {
@@ -257,16 +270,24 @@ class NudgeAccessibilityService : AccessibilityService() {
                     return@launch
                 }
 
-                val decision = entryPoint.evaluateBlockUseCase().invoke(packageName, feature.key)
+                val decision = entryPoint.evaluateBlockUseCase().invoke(
+                    packageName = packageName,
+                    detectedFeature = feature.key,
+                    includeWholeAppRulesForFeature = !shouldSkipForegroundEvaluationForPassthrough(packageName)
+                )
                 entryPoint.nudgeLogger().d(
                     "feature decision package=$packageName feature=${feature.key} decision=$decision"
                 )
-                handleDecision(decision, packageName)
+                handleDecision(decision, packageName, feature.key)
             }
         }
     }
 
-    private suspend fun handleDecision(decision: BlockDecision, packageName: String) {
+    private suspend fun handleDecision(
+        decision: BlockDecision,
+        packageName: String,
+        featureKey: String? = null
+    ) {
         when (decision) {
             is BlockDecision.Block -> {
                 entryPoint.nudgeLogger().i(
@@ -294,6 +315,7 @@ class NudgeAccessibilityService : AccessibilityService() {
                     putExtra(BlockOverlayActivity.EXTRA_BLOCK_MODE, decision.mode.name)
                     putExtra(BlockOverlayActivity.EXTRA_DELAY_SECONDS, decision.delaySeconds)
                     putExtra(BlockOverlayActivity.EXTRA_PACKAGE_NAME, packageName)
+                    putExtra(BlockOverlayActivity.EXTRA_FEATURE_KEY, featureKey)
                 }
                 applicationContext.startActivity(overlayIntent)
             }

--- a/app/src/main/java/com/astraedus/nudge/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/navigation/NavGraph.kt
@@ -34,6 +34,7 @@ sealed class Screen(val route: String) {
     data object RuleEditor : Screen("rule_editor/{packageName}?ruleId={ruleId}") {
         fun createRoute(packageName: String) = "rule_editor/$packageName"
         fun createRoute(packageName: String, ruleId: Long) = "rule_editor/$packageName?ruleId=$ruleId"
+        fun createNewRoute(packageName: String) = "rule_editor/$packageName?ruleId=0"
     }
     data object Groups : Screen("groups")
     data object Stats : Screen("stats")
@@ -107,7 +108,13 @@ fun NudgeNavGraph(
             val viewModel: RuleEditorViewModel = hiltViewModel()
             RuleEditorScreen(
                 viewModel = viewModel,
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                onNavigateToRuleEditor = { pkg, ruleId ->
+                    navController.navigate(Screen.RuleEditor.createRoute(pkg, ruleId))
+                },
+                onCreateNewRule = { pkg ->
+                    navController.navigate(Screen.RuleEditor.createNewRoute(pkg))
+                }
             )
         }
 

--- a/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
@@ -24,6 +24,7 @@ class BlockOverlayActivity : ComponentActivity() {
         const val EXTRA_BLOCK_MODE = "block_mode"
         const val EXTRA_DELAY_SECONDS = "delay_seconds"
         const val EXTRA_PACKAGE_NAME = "package_name"
+        const val EXTRA_FEATURE_KEY = "feature_key"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,7 +75,10 @@ class BlockOverlayActivity : ComponentActivity() {
     private fun onTimerComplete() {
         val pkg = intent.getStringExtra(EXTRA_PACKAGE_NAME) ?: ""
         if (pkg.isNotEmpty()) {
-            NudgeAccessibilityService.grantPassthrough(pkg)
+            NudgeAccessibilityService.grantPassthrough(
+                packageName = pkg,
+                featureKey = intent.getStringExtra(EXTRA_FEATURE_KEY)
+            )
         }
         NudgeAccessibilityService.isOverlayActive = false
         finish()

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorScreen.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
@@ -61,7 +62,9 @@ import kotlinx.coroutines.launch
 @Composable
 fun RuleEditorScreen(
     viewModel: RuleEditorViewModel,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    onNavigateToRuleEditor: (String, Long) -> Unit,
+    onCreateNewRule: (String) -> Unit
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -75,7 +78,7 @@ fun RuleEditorScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Edit Rule") },
+                title = { Text(if (state.existingRuleId == null) "New Rule" else "Edit Rule") },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -112,7 +115,9 @@ fun RuleEditorScreen(
 
                     state.allRulesForPackage.forEach { rule ->
                         Card(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onNavigateToRuleEditor(state.packageName, rule.id) },
                             colors = CardDefaults.cardColors(
                                 containerColor = if (rule.enabled)
                                     MaterialTheme.colorScheme.surfaceVariant
@@ -141,6 +146,15 @@ fun RuleEditorScreen(
                                     onCheckedChange = { viewModel.toggleRuleEnabled(rule.id, rule.enabled) }
                                 )
                             }
+                        }
+                    }
+
+                    if (state.existingRuleId != null) {
+                        OutlinedButton(
+                            onClick = { onCreateNewRule(state.packageName) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text("Add Rule")
                         }
                     }
                 }
@@ -587,7 +601,7 @@ fun RuleEditorScreen(
                 onClick = { viewModel.save() },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Save Rule")
+                Text(if (state.existingRuleId == null) "Create Rule" else "Save Rule")
             }
 
             if (state.existingRuleId != null) {

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorViewModel.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorViewModel.kt
@@ -62,8 +62,9 @@ class RuleEditorViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val packageName: String = savedStateHandle.get<String>("packageName") ?: ""
-    private val requestedRuleId: Long? = savedStateHandle.get<Long>("ruleId")
-        ?.takeIf { it > 0L }
+    private val routeRuleId: Long = savedStateHandle.get<Long>("ruleId") ?: -1L
+    private val requestedRuleId: Long? = routeRuleId.takeIf { it > 0L }
+    private val isCreatingNewRule: Boolean = routeRuleId == 0L
 
     private val _uiState = MutableStateFlow(
         RuleEditorUiState(
@@ -79,6 +80,8 @@ class RuleEditorViewModel @Inject constructor(
     }
 
     private fun loadExistingRule() {
+        if (isCreatingNewRule) return
+
         viewModelScope.launch {
             val rules = blockRuleRepository.getAllRules().firstOrNull() ?: emptyList()
             val existing = rules.find { it.id == requestedRuleId }

--- a/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineTest.kt
@@ -155,4 +155,34 @@ class BlockEngineTest {
         assertEquals(BlockMode.DELAY, block.mode)
         assertEquals(15, block.delaySeconds)
     }
+
+    @Test
+    fun `feature evaluation can ignore whole-app rules after whole-app passthrough`() {
+        val rules = listOf(
+            ActiveRule(
+                mode = BlockMode.DELAY,
+                delaySeconds = 15,
+                dailyLimitMinutes = null,
+                enabled = true
+            ),
+            ActiveRule(
+                mode = BlockMode.HARD_BLOCK,
+                delaySeconds = 0,
+                dailyLimitMinutes = null,
+                enabled = true,
+                inAppFeatures = listOf("REELS")
+            )
+        )
+
+        val decision = engine.evaluate(
+            packageName = "com.instagram.android",
+            activeRules = rules,
+            dailyUsageMs = 0L,
+            detectedFeature = "REELS",
+            includeWholeAppRulesForFeature = false
+        )
+
+        assertTrue(decision is BlockDecision.Block)
+        assertEquals(BlockMode.HARD_BLOCK, (decision as BlockDecision.Block).mode)
+    }
 }

--- a/app/src/test/java/com/astraedus/nudge/service/PassthroughTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/service/PassthroughTest.kt
@@ -29,14 +29,45 @@ class PassthroughTest {
 
         assertTrue(cleared)
         assertNull(NudgeAccessibilityService.lastPassthroughPackage)
+        assertNull(NudgeAccessibilityService.lastPassthroughFeature)
         assertFalse(NudgeAccessibilityService.isPassthroughGranted("com.example.alpha"))
     }
 
     @Test
-    fun `passthrough prevents re-evaluation`() {
+    fun `package passthrough prevents foreground re-evaluation`() {
         NudgeAccessibilityService.grantPassthrough("com.example.alpha")
 
-        assertTrue(NudgeAccessibilityService.shouldSkipEvaluationForPassthrough("com.example.alpha"))
-        assertFalse(NudgeAccessibilityService.shouldSkipEvaluationForPassthrough("com.example.beta"))
+        assertTrue(NudgeAccessibilityService.shouldSkipForegroundEvaluationForPassthrough("com.example.alpha"))
+        assertFalse(NudgeAccessibilityService.shouldSkipForegroundEvaluationForPassthrough("com.example.beta"))
+    }
+
+    @Test
+    fun `whole-app passthrough does not skip feature evaluation`() {
+        NudgeAccessibilityService.grantPassthrough("com.example.alpha")
+
+        assertFalse(
+            NudgeAccessibilityService.shouldSkipFeatureEvaluationForPassthrough(
+                "com.example.alpha",
+                "REELS"
+            )
+        )
+    }
+
+    @Test
+    fun `feature passthrough skips the matching feature only`() {
+        NudgeAccessibilityService.grantPassthrough("com.example.alpha", "REELS")
+
+        assertTrue(
+            NudgeAccessibilityService.shouldSkipFeatureEvaluationForPassthrough(
+                "com.example.alpha",
+                "REELS"
+            )
+        )
+        assertFalse(
+            NudgeAccessibilityService.shouldSkipFeatureEvaluationForPassthrough(
+                "com.example.alpha",
+                "EXPLORE"
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Let one package have multiple editable rules by adding an Add Rule path from the rule editor.
- Preserve exact-rule editing while allowing a new rule route for the same package.
- Split passthrough semantics so completing a whole-app delay does not suppress feature-specific rules, while completing a feature-specific delay still avoids loops for that feature.
- Add tests for layered rule evaluation and passthrough behavior.

## Test plan
- ./gradlew testDebugUnitTest
- ./gradlew :app:installDebug
- Pixel 3 ADB smoke: Active Rules -> Instagram -> Edit Rule shows Add Rule.
- Pixel 3 ADB smoke: Add Rule opens a New Rule screen for com.instagram.android.