### PR TITLE
ci: cap workflow artifact retention at 3 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
             nudge-v*.apk
             nudge-v*.aab
           if-no-files-found: error
+          # The APK/AAB's durable home is the GitHub Release below; the run
+          # artifact is a redundant copy, so keep it short-lived.
+          retention-days: 3
 
       - name: Create or update GitHub Release
         if: github.ref_type == 'tag'


### PR DESCRIPTION
GitHub emailed a 90%-of-0.5GB Actions storage warning (2026-07-13). Cause: `upload-artifact` steps had no `retention-days`, so every CI APK/AAB sat for the 90-day default, private-repo artifacts bill against storage as GB-months. 1.8GB of old artifacts were deleted account-wide, and repo-level default retention was set to 3 days in Settings→Actions; this PR pins the same cap explicitly in the workflow files so it survives settings drift.

Shipped builds are unaffected: AABs live on Google Play, release APKs on GitHub Releases (free storage). Run artifacts only need to survive the immediate download-to-device window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)