### PR TITLE
feat(ext): Nudge for Chrome, MV3 extension MVP

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -1,0 +1,96 @@
+name: Extension CI
+
+# The Chrome extension (extension/) is a separate product from the Android app and has its
+# own pipeline. The Android workflow (release.yml) carries the mirror-image
+# `paths-ignore: ['extension/**']` so the two never trigger each other.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'extension/**'
+      - '.github/workflows/extension-ci.yml'
+  pull_request:
+    paths:
+      - 'extension/**'
+      - '.github/workflows/extension-ci.yml'
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: extension
+
+jobs:
+  check:
+    name: Lint, typecheck, unit tests, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      # The loadable artifact, so a failing e2e run can be reproduced against the exact
+      # build that failed.
+      - name: Upload built extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: nudge-extension-chrome-mv3
+          path: extension/.output/chrome-mv3
+          if-no-files-found: error
+          retention-days: 7
+
+  e2e:
+    name: Playwright e2e
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build extension
+        run: npm run build
+
+      # Chrome loads extensions only in a HEADFUL persistent context, so the suite runs
+      # under a virtual display rather than headless.
+      - name: Run e2e under xvfb
+        run: xvfb-run -a npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: extension/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,16 @@ on:
       - main
     tags:
       - 'v*'
+    # The Chrome extension lives in extension/ and has its own pipeline
+    # (.github/workflows/extension-ci.yml), so a commit that only touches it must not
+    # spend a runner rebuilding the Android app.
+    #
+    # SAFE FOR THE v* RELEASE FLOW: GitHub does not evaluate path filters for TAG
+    # pushes, so `v*` tags still trigger this workflow regardless of what changed.
+    # (And even if that behaviour ever changed, a release tag is always cut on an
+    # Android version bump, which is never an extension-only diff.)
+    paths-ignore:
+      - 'extension/**'
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ local.properties
 keystore.properties
 .kotlin/
 *.apk
+
+# Chrome extension (extension/ has its own .gitignore too)
+extension/node_modules/
+extension/.output/
+extension/.wxt/

--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.output
+.wxt
+stats.html
+coverage
+test-results
+playwright-report
+*.zip

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -133,6 +133,22 @@ xvfb), scoped with `paths: ['extension/**']`. The Android workflow carries the m
 - **Return `true` from the `onMessage` listener** to keep the channel open for an async
   response, and always send *something* — otherwise callers hang forever.
 - **Gate settings changes in the WORKER, not the UI.** A gate a page can skip is not a gate.
+- **ENGINE INVARIANT: if any rule applies, the verdict is a BLOCK.** ALLOW means "no rule
+  applies here" and nothing else. DNR has already redirected by the time the engine runs, so
+  an ALLOW while a rule still applies is not a harmless no-op — it bounces the user back to
+  the site, straight into the redirect again: an infinite loop that also hammers the worker.
+  Any new mode or qualifier MUST get its own branch in `blockEngine.ts`.
+- **A test that asserts the bug is worse than no test.** The Hard-Block-plus-Daily-Limit
+  redirect loop survived 400 unit tests and 24 e2e specs because TWO unit tests had encoded
+  the buggy `ALLOW` as the expected result — they were written from a spec sentence
+  ("a Hard Block rule with a limit is NOT unconditional") that described the implementation
+  rather than the desired behaviour. When writing a test from a spec, state the USER-VISIBLE
+  outcome ("the site is blocked"), never the internal branch it should take. The engine now
+  has an exhaustive mode x limit x usage matrix asserting the invariant directly, so the
+  whole class is covered rather than the one reported instance.
+- **A meaningless field combination is a UI bug, not just an engine one.** A daily limit on a
+  Hard Block can never mean anything; `RuleEditor` now explains that instead of offering the
+  control, so the invalid state cannot be authored in the first place.
 - **React hooks before early returns.** `DelayView`/`BreathingView` returned `null` before
   calling their hooks; `react-hooks/rules-of-hooks` caught it. The fix needed an `enabled`
   flag on `useCompleteOnZero`, because a disarmed view has a zero-length countdown and

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -143,6 +143,13 @@ xvfb), scoped with `paths: ['extension/**']`. The Android workflow carries the m
 - **"Browser has been closed" in an e2e fixture usually means OOM**, not a code bug — this
   machine runs `earlyoom` with `--prefer ^chrome$`. The lean Chrome flags in `e2e/fixtures.ts`
   exist for that reason.
+- **A `<button>` inside `role="tablist"` is exposed as role `tab`, not `button`.** The
+  dashboard's Stats/Settings tabs are invisible to `getByRole('button')` and only match
+  `getByRole('tab')`. Correct behaviour, surprising in tests — when a locator finds nothing
+  that plainly exists in the DOM, dump the a11y roles before assuming the page is broken.
+- **The dashboard paints a loading state first** and fills in when `GET_DASHBOARD_STATE`
+  resolves, which is slower when the worker was asleep. e2e must wait for loaded content,
+  not assume an instant render.
 - The React Compiler advisory lint rules (`set-state-in-effect`,
   `preserve-manual-memoization`, `use-memo`) are deliberately **off**; `rules-of-hooks` is
   deliberately **on** and has already earned its keep.

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -1,0 +1,161 @@
+# Nudge for Chrome — MV3 Extension
+
+The browser sibling of the Nudge Android app. Same philosophy: **friction, not walls** —
+delay-to-open and breathing pauses instead of only hard blocks, plus daily time budgets,
+schedules, YouTube Shorts controls, and local-only usage stats.
+
+Free, GPL-3.0, **no account, zero telemetry, zero network requests.**
+
+- Product spec: `~/ops/routes/nudge/research/ext-07-prd.md` (the MVP feature cut)
+- Architecture: `~/ops/routes/nudge/research/ext-08-architecture.md` (fixed decisions)
+- MV3 recipes: `~/ops/routes/nudge/research/ext-01-mv3-architecture.md`
+- YouTube techniques: `~/ops/routes/nudge/research/ext-03-youtube-techniques.md`
+- Android semantics being ported: `~/ops/routes/nudge/research/ext-05-android-feature-inventory.md`
+
+## Commands
+
+```bash
+cd extension
+npm install            # postinstall runs `wxt prepare` (generates .wxt/ types)
+npm run dev            # WXT dev server with hot reload
+npm run build          # production build -> .output/chrome-mv3
+npm run zip            # packaged zip for the Chrome Web Store
+
+npm run lint           # eslint
+npm run typecheck      # wxt prepare && tsc --noEmit
+npm test               # vitest (unit + fixture tests)
+npm run e2e            # Playwright (needs `npm run build` first)
+```
+
+**Node/npm only — never bun/bunx.**
+
+E2E locally needs a display; use `xvfb-run -a npm run e2e` (that is what CI does).
+Run `npx playwright install chromium` once.
+
+### Load unpacked in Chrome
+
+1. `npm run build`
+2. `chrome://extensions` → enable **Developer mode**
+3. **Load unpacked** → select `extension/.output/chrome-mv3`
+
+To test in Incognito you must explicitly turn on **Allow in Incognito** for the extension —
+Chrome disables extensions there by default. (The onboarding page tells users this; it was a
+recurring complaint about competitors.)
+
+## Architecture
+
+```
+src/
+  core/         PURE TypeScript. ZERO chrome.* imports. Ported from Android's pure-Kotlin
+                domain layer, along with its test intent.
+    types.ts, settingsSchema.ts, protocol.ts
+    blockEngine.ts      <- domain/engine/BlockEngine.kt
+    scheduleEvaluator.ts<- domain/engine/ScheduleEvaluator.kt
+    domainMatcher.ts    <- domain/WebDomainMatcher.kt
+    strictMode.ts       <- domain/lock/StrictModeChallenge.kt + RuleWeakening.kt
+    emergencyPass.ts    <- domain/emergency/EmergencyPass.kt
+    stats.ts            <- ui/screens/stats/StatsCalculator.kt
+    budgets.ts, messages.ts, ruleResolver.ts
+  background/   The service worker: dnr, tracker, tempAllow, alarmsHub, badge,
+                messagesRouter, storage.
+  content/      YouTube: selectors.ts (ALL selectors), youtube.ts, youtube.css
+  entrypoints/  WXT entrypoints: background, blocked/, popup/, dashboard/, onboarding/,
+                youtube.content.ts
+  ui/           Shared React primitives + design tokens + typed rpc wrapper
+tests/          vitest (core/, ui/, content/ + DOM fixtures)
+e2e/            Playwright against a real Chrome with the extension loaded
+```
+
+**Dependency rule:** `core/` never imports from `background/`, `content/`, `ui/` or
+`chrome.*`. Everything else may import `core/`. That is what keeps the engine exhaustively
+unit-testable, exactly as the Android domain layer is.
+
+### How blocking actually works
+
+1. Settings change → `background/dnr.ts` recompiles **dynamic** DNR rules. Every enabled
+   rule becomes ONE `main_frame` redirect to `blocked.html`. Hard Block, Delay and Breathing
+   all start at the interstitial, so the network layer is mode-agnostic.
+2. The block page asks the worker (`GET_BLOCK_CONTEXT`); the **engine** decides which of the
+   three to render. The page never decides.
+3. Completing a Delay/Breathing pause → `COMPLETE_PAUSE` → a **session** allow-rule at a
+   higher priority + an expiry alarm. On expiry the allow-rule is removed so the *next*
+   navigation re-blocks (the open page is never yanked away mid-read).
+4. Crossing a Daily Time Limit inside an accounting step immediately revokes any grant and
+   pushes open tabs on that domain to the block page.
+5. YouTube SPA navigation is invisible to DNR, so `content/youtube.ts` handles in-page
+   Shorts with 3-layer nav detection (`yt-navigate-finish` + `popstate` + debounced
+   observer).
+
+## Non-negotiables
+
+- **Zero network requests.** No telemetry, no remote config, no CDN. All selectors are
+  bundled. `no-restricted-globals` bans `fetch` in lint so this stays true, not aspirational.
+- **Usage data never leaves the device.** Settings go to `storage.sync` (free cross-device
+  sync via the user's Chrome account); usage rollups are `storage.local` ONLY.
+- Android naming parity: "Hard Block" / "Delay" / "Breathing", "Daily Time Limit",
+  "Scheduled Override", "Commitment Lock", "Escape Hatch", "I changed my mind", "Rule: X".
+- Teal in-app palette (`src/ui/tokens.css`), light + dark. The maroon palette is
+  **marketing only** and never appears in the UI.
+- **No emoji as icons.** Inline SVG or nothing.
+- Every feature ships with tests (repo rule). Bug fix ⇒ a regression test that fails before.
+
+## Release
+
+Version lives in `extension/package.json` and is independent of the Android app's.
+Tag format is **`ext-v*`** (e.g. `ext-v0.1.0`) so it can never collide with the Android
+`v*` release flow.
+
+**No `ext-v*` tag exists yet and none should be created until the extension is ready to
+publish.** CI does not currently build releases from tags — wire that up together with the
+Chrome Web Store upload when the listing is ready (ext-04 §5).
+
+CI: `.github/workflows/extension-ci.yml` (lint → typecheck → unit → build → Playwright under
+xvfb), scoped with `paths: ['extension/**']`. The Android workflow carries the mirror-image
+`paths-ignore: ['extension/**']`.
+
+## Lessons
+
+- **A DNR redirect target MUST be in `web_accessible_resources`.** Redirecting to a page the
+  extension owns still fails *silently* otherwise (w3c/webextensions#604).
+- **`regexSubstitution` needs `regexFilter`, and `\0` is the ENTIRE match** — so the pattern
+  must be anchored `^...$` for `\0` to be the whole URL rather than just its prefix. This is
+  how the original URL reaches the block page.
+- **Never parse that target with `URLSearchParams`.** `regexSubstitution` cannot
+  percent-encode, so the target arrives verbatim and routinely contains its own `?`/`&`/`#`.
+  URLSearchParams truncated `watch?v=abc&t=30` to `watch?v=abc` and sent users to the wrong
+  page after a pause. Read `location.href` and slice after the marker. Regression tests:
+  `tests/ui/blockPage.test.tsx` → "target parsing".
+- **Never accumulate elapsed time in a service-worker global.** The worker dies after ~30s
+  idle. Every accounting step is an atomic read-modify-write against `storage.session`.
+- **Re-arm alarms on every worker wake.** Alarms are not guaranteed to survive a restart.
+  Midnight self-reschedules on an absolute `when`, because `periodInMinutes: 1440` drifts off
+  local midnight across a DST change.
+- **Return `true` from the `onMessage` listener** to keep the channel open for an async
+  response, and always send *something* — otherwise callers hang forever.
+- **Gate settings changes in the WORKER, not the UI.** A gate a page can skip is not a gate.
+- **React hooks before early returns.** `DelayView`/`BreathingView` returned `null` before
+  calling their hooks; `react-hooks/rules-of-hooks` caught it. The fix needed an `enabled`
+  flag on `useCompleteOnZero`, because a disarmed view has a zero-length countdown and
+  "remaining === 0" would otherwise complete the pause instantly and grant real access.
+- **e2e needs real hostnames without a network.** `--host-resolver-rules=MAP *.test
+  127.0.0.1:<port>` maps arbitrary hosts onto a local server, so DNR sees ordinary
+  navigations. Extensions load only via `launchPersistentContext` + `--load-extension`.
+- **"Browser has been closed" in an e2e fixture usually means OOM**, not a code bug — this
+  machine runs `earlyoom` with `--prefer ^chrome$`. The lean Chrome flags in `e2e/fixtures.ts`
+  exist for that reason.
+- The React Compiler advisory lint rules (`set-state-in-effect`,
+  `preserve-manual-memoization`, `use-memo`) are deliberately **off**; `rules-of-hooks` is
+  deliberately **on** and has already earned its keep.
+
+## Known gaps (MVP)
+
+- **A rule always blocks in some mode; there is no "allow by default, block only during the
+  window" schedule.** Outside a Scheduled Override the rule's own "Default Behavior" applies
+  — faithful to Android, but users asking for "block only during work hours" cannot express
+  it yet. Likely the first schedule follow-up.
+- Strict Mode cannot stop removal from `chrome://extensions`. The dashboard says so plainly
+  rather than pretending; honesty is the differentiator (ext-02).
+- YouTube fixtures in `tests/content/fixtures/` are hand-authored from the ext-03 taxonomy,
+  not live DOM captures. Refresh them from real YouTube DOM when possible.
+- v1.1 scope (channel whitelist/blacklist, gray-screen mode, Instagram/TikTok/X surfaces) is
+  specified in the PRD but not built.

--- a/extension/e2e/blocking.spec.ts
+++ b/extension/e2e/blocking.spec.ts
@@ -1,0 +1,53 @@
+import { baseSettings, expect, rule, test } from './fixtures';
+
+test.describe('site blocking', () => {
+  test('a site with no rule loads normally', async ({ context, setSettings, siteUrl }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('allowed.test'));
+
+    await expect(page.locator('#host')).toHaveText('allowed.test');
+  });
+
+  test('a Hard Block rule redirects the navigation to the block page', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    // The DNR redirect must carry the original URL through to the block page.
+    await expect(page).toHaveURL(/blocked\.html\?target=http:\/\/blocked\.test\//);
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+  });
+
+  test('subdomains of a blocked domain are blocked by the same rule', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('www.blocked.test'));
+
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+  });
+
+  test('the master toggle off lets a blocked site through', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(baseSettings({ globalEnabled: false, rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.locator('#host')).toHaveText('blocked.test');
+  });
+});

--- a/extension/e2e/budget.spec.ts
+++ b/extension/e2e/budget.spec.ts
@@ -1,0 +1,93 @@
+import {
+  baseSettings,
+  expect,
+  rule,
+  seedTrackerInterval,
+  sendFromExtensionPage,
+  test,
+} from './fixtures';
+import type { NudgeSettings } from '../src/core/settingsSchema';
+
+test.describe('Daily Time Limit', () => {
+  test('an exhausted budget forces a Hard Block on the next navigation', async ({
+    context,
+    setSettings,
+    seedUsage,
+    siteUrl,
+  }) => {
+    const settings = baseSettings({
+      rules: [rule('blocked.test', { mode: 'DELAY', delaySeconds: 2, dailyLimitMinutes: 1 })],
+    });
+    await setSettings(settings);
+    // Exactly at the limit is over it (the engine uses >=).
+    await seedUsage('blocked.test', 60);
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+    // Escalated to Hard Block despite the rule being a Delay: no countdown, no way through.
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+    await expect(page.getByText('Daily limit reached')).toBeVisible();
+    // The rule name carries the Android-parity suffix.
+    await expect(page.getByText('Rule: blocked.test (limit reached)')).toBeVisible();
+  });
+
+  test('an under-budget site still gets its configured Delay, not a Hard Block', async ({
+    context,
+    setSettings,
+    seedUsage,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [rule('blocked.test', { mode: 'DELAY', delaySeconds: 60, dailyLimitMinutes: 5 })],
+      }),
+    );
+    await seedUsage('blocked.test', 10);
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByRole('button', { name: 'I changed my mind' })).toBeVisible();
+    await expect(page.getByText(/limit reached/i)).toHaveCount(0);
+  });
+
+  test('crossing the limit mid-browsing redirects the already-open tab', async ({
+    context,
+    extensionId,
+    serviceWorker,
+    setSettings,
+    seedUsage,
+    siteUrl,
+  }) => {
+    // The whole point of this feature: DNR only sees REQUESTS, so a page already open when
+    // the budget runs out would stay readable until the next navigation. The worker has to
+    // actively push open tabs to the block page.
+    const settings = baseSettings({
+      tempAllowMinutes: 30,
+      rules: [rule('blocked.test', { mode: 'DELAY', delaySeconds: 1, dailyLimitMinutes: 1 })],
+    });
+    await setSettings(settings);
+
+    // Get onto the site legitimately by completing the pause, so a real tab is sitting open.
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page.locator('#host')).toHaveText('blocked.test', { timeout: 20_000 });
+
+    // Put usage just under the 1-minute limit, with a 10s interval in flight.
+    await seedUsage('blocked.test', 55);
+    await seedTrackerInterval(serviceWorker, 'blocked.test', 10_000);
+
+    // Any settings save runs an accounting step, which is the real production trigger for
+    // the budget check (SAVE_SETTINGS -> onActivityEvent -> accountAndSwitch).
+    await sendFromExtensionPage(context, extensionId, {
+      type: 'SAVE_SETTINGS',
+      settings: settings as NudgeSettings,
+    });
+
+    // The open tab is pushed to the block page without the user navigating.
+    await expect(page).toHaveURL(/blocked\.html\?target=/, { timeout: 15_000 });
+    await expect(page.getByText('Daily limit reached')).toBeVisible();
+  });
+});

--- a/extension/e2e/commitmentLock.spec.ts
+++ b/extension/e2e/commitmentLock.spec.ts
@@ -1,0 +1,90 @@
+import { baseSettings, expect, rule, sendFromExtensionPage, test } from './fixtures';
+import type { NudgeSettings } from '../src/core/settingsSchema';
+import type { SaveResult } from '../src/core/protocol';
+import { normalize } from '../src/core/strictMode';
+
+test.describe('Commitment Lock (Strict Mode)', () => {
+  test('gates a weakening change behind a typed challenge, then accepts the answer', async ({
+    context,
+    extensionId,
+    setSettings,
+  }) => {
+    const locked = baseSettings({
+      strictMode: { enabled: true, challengeLength: 12 },
+      rules: [rule('blocked.test')],
+    });
+    await setSettings(locked);
+
+    // Removing a rule weakens protection.
+    const weakened = { ...locked, rules: [] } as NudgeSettings;
+    const refused = await sendFromExtensionPage<SaveResult>(context, extensionId, {
+      type: 'SAVE_SETTINGS',
+      settings: weakened,
+    });
+
+    expect(refused.ok).toBe(false);
+    expect(refused.challenge).toBeTruthy();
+    expect(normalize(refused.challenge!)).toHaveLength(12);
+
+    // A wrong answer is refused, and the SAME challenge is offered again so the user can
+    // keep typing the code in front of them.
+    const wrong = await sendFromExtensionPage<SaveResult>(context, extensionId, {
+      type: 'SAVE_SETTINGS',
+      settings: weakened,
+      challengeResponse: 'definitely-not-it',
+    });
+    expect(wrong.ok).toBe(false);
+    expect(wrong.challenge).toBe(refused.challenge);
+
+    // The correct answer goes through.
+    const accepted = await sendFromExtensionPage<SaveResult>(context, extensionId, {
+      type: 'SAVE_SETTINGS',
+      settings: weakened,
+      challengeResponse: refused.challenge!,
+    });
+    expect(accepted.ok).toBe(true);
+  });
+
+  test('never gates a strengthening change', async ({ context, extensionId, setSettings }) => {
+    const locked = baseSettings({
+      strictMode: { enabled: true, challengeLength: 12 },
+      rules: [rule('blocked.test')],
+    });
+    await setSettings(locked);
+
+    // Adding a rule strengthens protection — no challenge.
+    const strengthened = {
+      ...locked,
+      rules: [rule('blocked.test'), rule('other.test')],
+    } as NudgeSettings;
+
+    const result = await sendFromExtensionPage<SaveResult>(context, extensionId, {
+      type: 'SAVE_SETTINGS',
+      settings: strengthened,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.challenge).toBeUndefined();
+  });
+
+  test('hides the Escape Hatch entirely while the lock is on', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        strictMode: { enabled: true, challengeLength: 12 },
+        emergencyPass: { enabled: true },
+        rules: [rule('blocked.test')],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+
+    // A commitment lock must not have a one-tap bypass.
+    await expect(page.getByRole('button', { name: /2 minutes|daily pass/i })).toHaveCount(0);
+  });
+});

--- a/extension/e2e/escapeHatch.spec.ts
+++ b/extension/e2e/escapeHatch.spec.ts
@@ -1,0 +1,63 @@
+import { baseSettings, expect, rule, test } from './fixtures';
+
+test.describe('Escape Hatch (daily 2-minute pass)', () => {
+  test('lets the user through once, then shows a spent, disabled button', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        emergencyPass: { enabled: true },
+        rules: [rule('blocked.test')],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    const pass = page.getByRole('button', { name: 'Use for 2 minutes · once a day' });
+    await expect(pass).toBeVisible();
+    await pass.click();
+
+    // The grant takes effect immediately: the blocked site loads.
+    await expect(page.locator('#host')).toHaveText('blocked.test', { timeout: 15_000 });
+
+    // The lockout is GLOBAL and lasts 24h, so a second site is barred too — this is the
+    // property that makes it an escape hatch rather than a free pass per site.
+    await setSettings(
+      baseSettings({
+        emergencyPass: { enabled: true },
+        rules: [rule('blocked.test'), rule('other.test')],
+      }),
+    );
+
+    const second = await context.newPage();
+    await second.goto(siteUrl('other.test'));
+    await expect(second).toHaveURL(/blocked\.html\?target=/);
+
+    // Spent state stays VISIBLE but disabled, rather than vanishing.
+    const spent = second.getByRole('button', { name: /daily pass used/i });
+    await expect(spent).toBeVisible();
+    await expect(spent).toBeDisabled();
+  });
+
+  test('is absent entirely when the Escape Hatch is turned off', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        emergencyPass: { enabled: false },
+        rules: [rule('blocked.test')],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+
+    await expect(page.getByRole('button', { name: /2 minutes|daily pass/i })).toHaveCount(0);
+  });
+});

--- a/extension/e2e/fixtures.ts
+++ b/extension/e2e/fixtures.ts
@@ -1,0 +1,284 @@
+/**
+ * Playwright fixtures for the extension e2e suite.
+ *
+ * Two things make this work:
+ *
+ * 1. **Extensions require a persistent context.** `chromium.launch()` cannot load one —
+ *    only `launchPersistentContext` with `--load-extension` (ext-01 §7). The extension id
+ *    is read off the service worker's URL.
+ *
+ * 2. **Real hostnames without a network.** The extension blocks by DOMAIN, so the suite
+ *    needs pages served from distinguishable hosts. Chrome's `--host-resolver-rules` maps
+ *    every `*.test` hostname onto a local server, so `http://blocked.test/` and
+ *    `http://allowed.test/` are ordinary navigations to real hosts with zero DNS and zero
+ *    internet — and, critically, they travel the normal network stack, so DNR sees them
+ *    exactly as it would see youtube.com.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  test as base,
+  chromium,
+  type BrowserContext,
+  type Worker,
+} from '@playwright/test';
+import type { NudgeSettings, SiteRule } from '../src/core/settingsSchema';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const EXTENSION_PATH = path.resolve(here, '../.output/chrome-mv3');
+
+/** The storage key the extension persists settings under (see background/storage.ts). */
+const SETTINGS_KEY = 'nudge:settings';
+
+function startTestServer(): Promise<Server> {
+  const server = createServer((req, res) => {
+    const host = (req.headers.host ?? 'unknown').split(':')[0]!;
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(
+      `<!doctype html><html><head><title>${host}</title></head>` +
+        `<body><h1 id="host">${host}</h1><p id="path">${req.url}</p></body></html>`,
+    );
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+/**
+ * The `usage:<yyyy-mm-dd>` storage key for today.
+ *
+ * Computed in Node rather than inside the worker: the browser is a child process on the
+ * same machine so it shares this timezone, and MV3's CSP forbids `eval` in a service worker
+ * (which any string-built expression would need).
+ */
+export function todayUsageKey(now: Date = new Date()): string {
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `usage:${now.getFullYear()}-${month}-${day}`;
+}
+
+export interface ExtensionFixtures {
+  context: BrowserContext;
+  extensionId: string;
+  serviceWorker: Worker;
+  /** Overwrite the extension's settings and wait until DNR has actually caught up. */
+  setSettings: (settings: Partial<NudgeSettings>) => Promise<void>;
+  /** Seed today's usage rollup for a domain. */
+  seedUsage: (domain: string, activeSec: number) => Promise<void>;
+  /** URL of a page on `host`, served locally. */
+  siteUrl: (host: string, pathname?: string) => string;
+}
+
+export const test = base.extend<ExtensionFixtures>({
+  // eslint-disable-next-line no-empty-pattern
+  context: async ({}, use) => {
+    const server = await startTestServer();
+    const { port } = server.address() as AddressInfo;
+
+    const context = await chromium.launchPersistentContext('', {
+      channel: 'chromium',
+      args: [
+        `--disable-extensions-except=${EXTENSION_PATH}`,
+        `--load-extension=${EXTENSION_PATH}`,
+        // Any *.test hostname resolves to the local server, so page URLs stay clean
+        // (`http://blocked.test/`) and domain matching is realistic.
+        `--host-resolver-rules=MAP *.test 127.0.0.1:${port}`,
+        // Keep each browser's footprint small. The suite launches one persistent context
+        // per test, and on a developer machine that is competing with a real browser for
+        // memory; a bloated test browser gets OOM-killed and surfaces as the confusing
+        // "Target page, context or browser has been closed" during fixture setup.
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-background-networking',
+        '--disable-features=Translate,MediaRouter,OptimizationHints',
+        '--no-first-run',
+        '--no-default-browser-check',
+      ],
+    });
+
+    await use(context);
+
+    await context.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  },
+
+  serviceWorker: async ({ context }, use) => {
+    let [worker] = context.serviceWorkers();
+    // An explicit timeout here turns "the whole test timed out in setup" into a specific,
+    // actionable failure when the worker never registers.
+    worker ??= await context.waitForEvent('serviceworker', { timeout: 20_000 });
+    await use(worker);
+  },
+
+  extensionId: async ({ serviceWorker }, use) => {
+    await use(serviceWorker.url().split('/')[2]!);
+  },
+
+  siteUrl: async ({ context }, use) => {
+    void context;
+    await use((host: string, pathname = '/') => `http://${host}${pathname}`);
+  },
+
+  setSettings: async ({ serviceWorker }, use) => {
+    await use(async (partial: Partial<NudgeSettings>) => {
+      await serviceWorker.evaluate(
+        async ([key, patch]) => {
+          const existing = await chrome.storage.local.get(key);
+          const merged = { ...((existing[key] as object | undefined) ?? {}), ...patch };
+          // Writing to local fires the worker's storage.onChanged -> recompile path, which
+          // is the same code path a real settings save takes.
+          await chrome.storage.local.set({ [key]: merged });
+          await chrome.storage.sync.set({ [key]: merged });
+        },
+        [SETTINGS_KEY, partial] as const,
+      );
+
+      // Wait until the DNR rule set actually reflects the new settings rather than
+      // sleeping and hoping.
+      const enabledRules = (partial.rules ?? []).filter((r) => r.enabled !== false).length;
+      const expected = partial.globalEnabled === false ? 0 : enabledRules;
+      await waitForRuleCount(serviceWorker, expected);
+    });
+  },
+
+  seedUsage: async ({ serviceWorker }, use) => {
+    await use(async (domain: string, activeSec: number) => {
+      await serviceWorker.evaluate(
+        async ([key, dom, secs]) => {
+          const stored = await chrome.storage.local.get(key);
+          const day = (stored[key] ?? {}) as Record<string, unknown>;
+          day[dom] = {
+            activeSec: secs,
+            blocked: 0,
+            walkedAway: 0,
+            hourly: Array.from({ length: 24 }, () => 0),
+          };
+          await chrome.storage.local.set({ [key]: day });
+        },
+        [todayUsageKey(), domain, activeSec] as const,
+      );
+    });
+  },
+});
+
+/** Poll the worker until the dynamic rule set has the expected size. */
+export async function waitForRuleCount(worker: Worker, expected: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    const count = await worker.evaluate(() =>
+      chrome.declarativeNetRequest.getDynamicRules().then((rules) => rules.length),
+    );
+    if (count === expected) return;
+    if (Date.now() > deadline) {
+      throw new Error(`DNR rule count settled at ${count}, expected ${expected}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** Read a counter out of today's rollup for one domain. */
+export async function readTodayCounter(
+  worker: Worker,
+  domain: string,
+  field: 'blocked' | 'walkedAway' | 'activeSec',
+): Promise<number> {
+  return worker.evaluate(
+    async ([key, dom, name]) => {
+      const stored = await chrome.storage.local.get(key);
+      const day = (stored[key] ?? {}) as Record<string, Record<string, number>>;
+      return day[dom]?.[name] ?? 0;
+    },
+    [todayUsageKey(), domain, field] as const,
+  );
+}
+
+/** Seed the tracker's in-flight interval, so the next accounting step attributes `elapsedMs`. */
+export async function seedTrackerInterval(
+  worker: Worker,
+  domain: string,
+  elapsedMs: number,
+): Promise<void> {
+  await worker.evaluate(
+    async ([dom, elapsed]) => {
+      await chrome.storage.session.set({
+        'nudge:tracker': { domain: dom, since: Date.now() - elapsed },
+      });
+    },
+    [domain, elapsedMs] as const,
+  );
+}
+
+/** Poll until every temporary grant has lapsed and its DNR allow-rule is gone. */
+export async function waitForNoTempAllows(
+  worker: Worker,
+  timeoutMs = 150_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const remaining = await worker.evaluate(() =>
+      chrome.declarativeNetRequest.getSessionRules().then((rules) => rules.length),
+    );
+    if (remaining === 0) return;
+    if (Date.now() > deadline) throw new Error('temporary access never expired');
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+}
+
+/**
+ * Send a runtime message from a real extension page.
+ *
+ * The service worker cannot message itself — `chrome.runtime.sendMessage` from the worker
+ * does not reach its own `onMessage` listener — so requests are issued from an extension
+ * page exactly as the real UI does.
+ */
+export async function sendFromExtensionPage<T>(
+  context: BrowserContext,
+  extensionId: string,
+  request: unknown,
+): Promise<T> {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/dashboard.html`);
+  const result = await page.evaluate(
+    (req) => chrome.runtime.sendMessage(req) as Promise<unknown>,
+    request,
+  );
+  await page.close();
+  return result as T;
+}
+
+/** A minimal valid settings object for tests to spread over. */
+export function baseSettings(overrides: Partial<NudgeSettings> = {}): Partial<NudgeSettings> {
+  return {
+    schemaVersion: 1,
+    globalEnabled: true,
+    onboardingComplete: true,
+    rules: [],
+    messages: { delayTitles: [], delaySubtitles: [], hardBlockMessages: [] },
+    strictMode: { enabled: false, challengeLength: 24 },
+    emergencyPass: { enabled: true },
+    youtube: { shortsMode: 'INHERIT', hideShortsShelf: false, shortsDelaySeconds: 15 },
+    tempAllowMinutes: 10,
+    ...overrides,
+  };
+}
+
+/** A site rule with sensible defaults. */
+export function rule(domain: string, overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: `rule-${domain}`,
+    domain,
+    mode: 'HARD_BLOCK',
+    delaySeconds: 15,
+    dailyLimitMinutes: null,
+    enabled: true,
+    createdAt: 0,
+    showTimeRemaining: false,
+    schedule: null,
+    ...overrides,
+  };
+}
+
+export const expect = test.expect;

--- a/extension/e2e/pause.spec.ts
+++ b/extension/e2e/pause.spec.ts
@@ -1,0 +1,105 @@
+import {
+  baseSettings,
+  expect,
+  readTodayCounter,
+  rule,
+  test,
+  waitForNoTempAllows,
+} from './fixtures';
+
+test.describe('Delay and Breathing pauses', () => {
+  test('a Delay countdown completes, grants temporary access, and expires back to blocked', async ({
+    context,
+    setSettings,
+    siteUrl,
+    serviceWorker,
+  }) => {
+    // The expiry half of this test waits on the REAL chrome.alarms expiry rather than
+    // simulating it, because the alarm re-arm path is exactly what has historically broken
+    // in MV3. tempAllowMinutes is clamped to a 1-minute minimum, hence the long timeout.
+    test.setTimeout(180_000);
+
+    await setSettings(
+      baseSettings({
+        tempAllowMinutes: 1,
+        rules: [rule('blocked.test', { mode: 'DELAY', delaySeconds: 2 })],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+
+    // The countdown runs, then the page sends itself on to the original target.
+    await expect(page.locator('#host')).toHaveText('blocked.test', { timeout: 20_000 });
+
+    // Temporary access is per-origin, so a fresh navigation goes straight through.
+    await page.goto(siteUrl('blocked.test', '/second-visit'));
+    await expect(page.locator('#host')).toHaveText('blocked.test');
+    await expect(page.locator('#path')).toHaveText('/second-visit');
+
+    // Wait for the grant to lapse, then confirm the next navigation re-blocks.
+    await waitForNoTempAllows(serviceWorker);
+    await page.goto(siteUrl('blocked.test', '/third-visit'));
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+  });
+
+  test('a Breathing pause cycles and then lets the user through', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        tempAllowMinutes: 5,
+        rules: [rule('blocked.test', { mode: 'BREATHING', delaySeconds: 2 })],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+    await expect(page.getByText(/breathe (in|out)/i)).toBeVisible();
+
+    await expect(page.locator('#host')).toHaveText('blocked.test', { timeout: 20_000 });
+  });
+
+  test('"I changed my mind" bails out and records a Walked Away', async ({
+    context,
+    setSettings,
+    siteUrl,
+    serviceWorker,
+  }) => {
+    await setSettings(
+      baseSettings({ rules: [rule('blocked.test', { mode: 'DELAY', delaySeconds: 120 })] }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await page.getByRole('button', { name: 'I changed my mind' }).click();
+
+    // The user is taken off the block page, and never reaches the blocked site.
+    await expect(page).not.toHaveURL(/blocked\.html/);
+    expect(page.url()).not.toContain('blocked.test');
+
+    const walkedAway = await readTodayCounter(serviceWorker, 'blocked.test', 'walkedAway');
+    expect(walkedAway).toBeGreaterThan(0);
+  });
+
+  test('showing the block page records a Blocked event', async ({
+    context,
+    setSettings,
+    siteUrl,
+    serviceWorker,
+  }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+
+    const blocked = await readTodayCounter(serviceWorker, 'blocked.test', 'blocked');
+    expect(blocked).toBeGreaterThan(0);
+  });
+});

--- a/extension/e2e/redirectLoop.spec.ts
+++ b/extension/e2e/redirectLoop.spec.ts
@@ -1,0 +1,86 @@
+import { baseSettings, expect, rule, test } from './fixtures';
+
+/**
+ * Regression: Hard Block + Daily Time Limit used to be an INFINITE REDIRECT LOOP.
+ *
+ * The engine had no branch for "Hard Block, has a limit, still under it", so it fell through
+ * to ALLOW. DNR redirects the domain regardless of mode, so the sequence was:
+ * navigate -> DNR redirect -> block page asks the engine -> ALLOW -> page sends the user to
+ * the target -> DNR redirects again -> forever, hammering the service worker.
+ *
+ * Live-Chrome QA found this on 3 domains; 400 unit tests and 24 e2e specs did not, because
+ * two unit tests had encoded the buggy ALLOW as the expected result.
+ */
+test.describe('Hard Block + Daily Time Limit (redirect-loop regression)', () => {
+  test('renders the block page once and does not bounce', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [rule('blocked.test', { mode: 'HARD_BLOCK', dailyLimitMinutes: 30 })],
+      }),
+    );
+
+    const page = await context.newPage();
+
+    // Count every committed main-frame navigation. A loop shows up as an unbounded climb.
+    let navigations = 0;
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) navigations += 1;
+    });
+
+    await page.goto(siteUrl('blocked.test'));
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+
+    const afterLoad = navigations;
+
+    // Give any loop a generous window to run away.
+    await page.waitForTimeout(3_000);
+
+    // Settled: the block page stayed put rather than bouncing back to the site.
+    expect(navigations).toBe(afterLoad);
+    await expect(page).toHaveURL(/blocked\.html\?target=/);
+    expect(page.url()).not.toMatch(/^http:\/\/blocked\.test/);
+  });
+
+  test('under budget it is a plain Hard Block, not a "limit reached" block', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [rule('blocked.test', { mode: 'HARD_BLOCK', dailyLimitMinutes: 30 })],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+    // The budget is untouched, so nothing should claim it was exhausted.
+    await expect(page.getByText('Daily limit reached')).toHaveCount(0);
+  });
+
+  test('the same rule over budget still reports limit reached', async ({
+    context,
+    setSettings,
+    seedUsage,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [rule('blocked.test', { mode: 'HARD_BLOCK', dailyLimitMinutes: 30 })],
+      }),
+    );
+    await seedUsage('blocked.test', 30 * 60);
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByText('Daily limit reached')).toBeVisible();
+  });
+});

--- a/extension/e2e/schedule.spec.ts
+++ b/extension/e2e/schedule.spec.ts
@@ -1,0 +1,103 @@
+import { baseSettings, expect, rule, test } from './fixtures';
+
+/** Minutes from local midnight, offset by `deltaMinutes`, wrapped into 0..1439. */
+function minuteOfDay(deltaMinutes = 0): number {
+  const now = new Date();
+  return (((now.getHours() * 60 + now.getMinutes() + deltaMinutes) % 1440) + 1440) % 1440;
+}
+
+test.describe('Scheduled Override', () => {
+  test('inside the window the scheduled mode replaces the default behavior', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [
+          rule('blocked.test', {
+            // Default behavior is a Delay the user can wait out...
+            mode: 'DELAY',
+            delaySeconds: 2,
+            schedule: {
+              enabled: true,
+              days: null,
+              // ...but right now we are inside a Hard Block window.
+              startMinute: minuteOfDay(-30),
+              endMinute: minuteOfDay(30),
+              mode: 'HARD_BLOCK',
+              delaySeconds: 15,
+            },
+          }),
+        ],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'I changed my mind' })).toHaveCount(0);
+  });
+
+  test('outside the window the default behavior applies', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [
+          rule('blocked.test', {
+            mode: 'DELAY',
+            delaySeconds: 120,
+            schedule: {
+              enabled: true,
+              days: null,
+              // A window that starts in two hours and ends three hours from now.
+              startMinute: minuteOfDay(120),
+              endMinute: minuteOfDay(180),
+              mode: 'HARD_BLOCK',
+              delaySeconds: 15,
+            },
+          }),
+        ],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByRole('button', { name: 'I changed my mind' })).toBeVisible();
+  });
+
+  test('a disabled schedule is ignored even when now falls inside it', async ({
+    context,
+    setSettings,
+    siteUrl,
+  }) => {
+    await setSettings(
+      baseSettings({
+        rules: [
+          rule('blocked.test', {
+            mode: 'DELAY',
+            delaySeconds: 120,
+            schedule: {
+              enabled: false,
+              days: null,
+              startMinute: minuteOfDay(-30),
+              endMinute: minuteOfDay(30),
+              mode: 'HARD_BLOCK',
+              delaySeconds: 15,
+            },
+          }),
+        ],
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(siteUrl('blocked.test'));
+
+    await expect(page.getByRole('button', { name: 'I changed my mind' })).toBeVisible();
+  });
+});

--- a/extension/e2e/surfaces.spec.ts
+++ b/extension/e2e/surfaces.spec.ts
@@ -69,13 +69,23 @@ test.describe('extension surfaces', () => {
     await expect(page.getByText('Break the scroll. Take back your time.')).toBeVisible();
   });
 
-  test('no extension page logs a console error on load', async ({ context, extensionId }) => {
+  test('no extension page logs a console error or preload warning on load', async ({
+    context,
+    extensionId,
+  }) => {
     const errors: string[] = [];
+    const preloadWarnings: string[] = [];
     context.on('console', (message) => {
-      if (message.type() === 'error') errors.push(message.text());
+      const text = message.text();
+      if (message.type() === 'error') errors.push(text);
+      // Regression: Vite's modulepreload hints are useless for pages loaded off disk, and
+      // Chrome logged ~6 "cross-world extension resource mismatch" / "preloaded but not
+      // used" warnings per page. `build.modulePreload: false` in wxt.config.ts turns them
+      // off — a clean console is part of a zero-telemetry product's trust story.
+      if (message.type() === 'warning' && /preload/i.test(text)) preloadWarnings.push(text);
     });
 
-    for (const surface of ['popup.html', 'dashboard.html', 'onboarding.html']) {
+    for (const surface of ['popup.html', 'dashboard.html', 'onboarding.html', 'blocked.html']) {
       const page = await context.newPage();
       await page.goto(`chrome-extension://${extensionId}/${surface}`);
       await page.waitForTimeout(500);
@@ -83,5 +93,6 @@ test.describe('extension surfaces', () => {
     }
 
     expect(errors).toEqual([]);
+    expect(preloadWarnings).toEqual([]);
   });
 });

--- a/extension/e2e/surfaces.spec.ts
+++ b/extension/e2e/surfaces.spec.ts
@@ -1,0 +1,87 @@
+import { baseSettings, expect, rule, test } from './fixtures';
+
+/**
+ * The extension's own pages, loaded in a real browser.
+ *
+ * These are cheap but catch a whole class of failure the unit tests cannot: an entrypoint
+ * that never got wired into the manifest, or a page that throws on mount with the real
+ * chrome APIs rather than mocked ones.
+ */
+test.describe('extension surfaces', () => {
+  test('the dashboard is registered as the options page', async ({ serviceWorker }) => {
+    // Right-click the toolbar icon -> Options has to land somewhere real.
+    const manifest = await serviceWorker.evaluate(() => chrome.runtime.getManifest());
+
+    expect(manifest.options_page).toBe('dashboard.html');
+  });
+
+  test('the popup renders today\'s screen time and a way into the dashboard', async ({
+    context,
+    extensionId,
+    setSettings,
+  }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+    await expect(page.getByText('Today').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /open dashboard/i })).toBeVisible();
+  });
+
+  test('the dashboard renders stats and the Commitment Lock honesty note', async ({
+    context,
+    extensionId,
+    setSettings,
+  }) => {
+    await setSettings(baseSettings({ rules: [rule('blocked.test')] }));
+
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/dashboard.html`);
+
+    // The dashboard paints a loading state first and fills in once GET_DASHBOARD_STATE
+    // resolves, which can take a moment if the service worker was asleep — wait for the
+    // loaded UI rather than assuming an instant render.
+    //
+    // Note the role: these are <button> elements inside a role="tablist", which Chrome
+    // exposes as role="tab" (not "button"). That is the semantically correct mapping, so
+    // assert against it rather than the tag name.
+    const settingsTab = page.getByRole('tab', { name: 'Settings', exact: true });
+    await expect(settingsTab).toBeVisible({ timeout: 20_000 });
+
+    await expect(page.getByText('Blocked').first()).toBeVisible();
+    await expect(page.getByText('Walked Away').first()).toBeVisible();
+
+    // The honesty note is a product commitment (ext-02): a Chrome extension cannot stop its
+    // own removal, and we say so rather than implying an unbreakable lock.
+    await settingsTab.click();
+    await expect(page.getByText('Commitment Lock').first()).toBeVisible();
+    await expect(page.getByText(/chrome:\/\/extensions/i).first()).toBeVisible();
+  });
+
+  test('the onboarding page renders the tagline and the incognito note', async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${extensionId}/onboarding.html`);
+
+    await expect(page.getByText('Break the scroll. Take back your time.')).toBeVisible();
+  });
+
+  test('no extension page logs a console error on load', async ({ context, extensionId }) => {
+    const errors: string[] = [];
+    context.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+
+    for (const surface of ['popup.html', 'dashboard.html', 'onboarding.html']) {
+      const page = await context.newPage();
+      await page.goto(`chrome-extension://${extensionId}/${surface}`);
+      await page.waitForTimeout(500);
+      await page.close();
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -1,0 +1,66 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default tseslint.config(
+  {
+    ignores: [
+      '.output/**',
+      '.wxt/**',
+      'node_modules/**',
+      'coverage/**',
+      'playwright-report/**',
+      'test-results/**',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.webextensions },
+    },
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      // `rules-of-hooks` stays ON and is load-bearing: it caught a real bug where
+      // DelayView/BreathingView returned early before calling their hooks.
+      //
+      // These three, however, are React Compiler *optimization* advisories rather than
+      // correctness rules — they flag patterns (load-on-mount effects, hand-written
+      // useCallback deps) that are correct but that the compiler would rather own. Turned
+      // off deliberately; revisit if this codebase ever adopts the compiler.
+      'react-hooks/set-state-in-effect': 'off',
+      'react-hooks/preserve-manual-memoization': 'off',
+      'react-hooks/use-memo': 'off',
+      // Unused vars are a real signal here (a dropped prop, a dead handler), but an
+      // intentionally-ignored argument should still be expressible.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      // MV3 forbids eval outright, and the extension is zero-network by design —
+      // these rules make both promises enforceable rather than aspirational.
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'fetch',
+          message:
+            'Nudge makes zero network requests — that is a listed privacy claim. See extension/CLAUDE.md.',
+        },
+      ],
+    },
+  },
+  {
+    // Node-side tooling: configs and the Playwright suite.
+    files: ['*.config.ts', 'e2e/**/*.ts'],
+    languageOptions: { globals: { ...globals.node, ...globals.webextensions } },
+    rules: {
+      // Playwright's fixture API hands each fixture a `use()` callback, which the hooks
+      // plugin mistakes for React's `use` hook. There is no React here.
+      'react-hooks/rules-of-hooks': 'off',
+    },
+  },
+);

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,0 +1,6899 @@
+{
+  "name": "nudge-extension",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nudge-extension",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.62.0",
+        "@types/chrome": "^0.1.28",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitest/coverage-v8": "^4.1.10",
+        "@wxt-dev/module-react": "^1.2.2",
+        "jsdom": "^29.1.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.10",
+        "wxt": "^0.20.27"
+      }
+    },
+    "node_modules/@1natsu/wait-element": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@1natsu/wait-element/-/wait-element-4.2.0.tgz",
+      "integrity": "sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "many-keys-map": "^3.0.0"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@aklinker1/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
+      "integrity": "sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.8.tgz",
+      "integrity": "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@devicefarmer/adbkit-logcat": "^2.1.2",
+        "@devicefarmer/adbkit-monkey": "~1.2.1",
+        "bluebird": "~3.7",
+        "commander": "^9.1.0",
+        "debug": "~4.3.1",
+        "node-forge": "^1.3.1",
+        "split": "~1.0.1"
+      },
+      "bin": {
+        "adbkit": "bin/adbkit"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit-logcat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-logcat/-/adbkit-logcat-2.1.3.tgz",
+      "integrity": "sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit-monkey": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-monkey/-/adbkit-monkey-1.2.1.tgz",
+      "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.5.tgz",
+      "integrity": "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webext-core/fake-browser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@webext-core/fake-browser/-/fake-browser-1.5.2.tgz",
+      "integrity": "sha512-nkDQwOJ23X5Q7cEtN6LRuBtVFf1KVOFi5GoQAro0lzqdh59F5E+K350j1isbnqYbzsXRh1NJtboudIcHfZtvOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webextension-polyfill": ">=0.10.5",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@webext-core/isolated-element": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@webext-core/isolated-element/-/isolated-element-1.1.5.tgz",
+      "integrity": "sha512-4m6oP8Vzm/68YO1QmkUOZqqUcmyBtA53tji2g00/nYXE3E3IceYgeub7eIqvXDV2Z7xU6cm6qO1IMt4XFVwtvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@webext-core/match-patterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webext-core/match-patterns/-/match-patterns-1.1.0.tgz",
+      "integrity": "sha512-vebVVbcOyva4jyvljIzRJwjFi/OKMLr96LIIxiPeXfA38gE4Z3+H6Y9DwRmn7pWErJGNNHU6XOhOb5ZwicGs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@wxt-dev/browser": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.2.2.tgz",
+      "integrity": "sha512-QqLOdEE1UQxieRuMbv9rwczD+xUv45fy+i5gw1eo+/vlPtGX+/rBd6tlIfLFCU3xAN/UTH57bxqOeU2IZg7dEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@wxt-dev/module-react": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/module-react/-/module-react-1.2.2.tgz",
+      "integrity": "sha512-+lRLi1r9dAXpLySWSIWHLJ1h/nFzR20iQnx3RNrKyA6oJg4+ClOluVXozHjfPg9Okfy/umtffiOopGayASrg6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitejs/plugin-react": "^4.4.1 || ^5.0.0 || ^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      },
+      "peerDependencies": {
+        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
+        "wxt": ">=0.19.16"
+      }
+    },
+    "node_modules/@wxt-dev/storage": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/storage/-/storage-1.2.8.tgz",
+      "integrity": "sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wxt-dev/browser": "^0.1.37",
+        "async-mutex": "^0.5.0",
+        "dequal": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      }
+    },
+    "node_modules/@wxt-dev/storage/node_modules/@wxt-dev/browser": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.1.43.tgz",
+      "integrity": "sha512-RMB0zgfe7uuiTp18s9taLeKXoOCLBV418797dnEggiMWmM1JDJekiLtlvrNc6QeZg+amDBy2/KKYuQB2kh/K9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-differ": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
+      "integrity": "sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
+      "integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/filesize": {
+      "version": "11.0.22",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.22.tgz",
+      "integrity": "sha512-RlCVs9CY+oSsRnNZn95J9vDXjNjOwddKyTFjOYtA4yxYVIxBnwiVVGJX+TFhsmu3uUf81JDGyijtYL9xgawlTw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.8.0"
+      }
+    },
+    "node_modules/firefox-profile": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.7.0.tgz",
+      "integrity": "sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "~0.5.x",
+        "fs-extra": "^11.2.0",
+        "ini": "^4.1.3",
+        "minimist": "^1.2.8",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "firefox-profile": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fx-runner": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.4.0.tgz",
+      "integrity": "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "commander": "2.9.0",
+        "shell-quote": "1.7.3",
+        "spawn-sync": "1.0.15",
+        "when": "3.7.7",
+        "which": "1.2.4",
+        "winreg": "0.0.12"
+      },
+      "bin": {
+        "fx-runner": "bin/fx-runner"
+      }
+    },
+    "node_modules/fx-runner/node_modules/commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/giget": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "integrity": "sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-relative": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+      "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "integrity": "sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports/node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+      "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/many-keys-map": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-3.0.3.tgz",
+      "integrity": "sha512-1DiZmDHPXMBgMRjeUtHy1q1VYmeJscHxhIAexX9z/zjRMP80+0ETuPfssi8z+kMY4DwUgsKuHqpjxgmeA9gBNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multimatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-6.0.0.tgz",
+      "integrity": "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.5",
+        "array-differ": "^4.0.0",
+        "array-union": "^3.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.1.0.tgz",
+      "integrity": "sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-notifier/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/node-notifier/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+      "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-json": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/promise-toolbox": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+      "integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-error": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/publish-browser-extension": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-4.0.5.tgz",
+      "integrity": "sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "consola": "^3.4.2",
+        "dotenv": "^17.2.4",
+        "form-data-encoder": "^4.1.0",
+        "formdata-node": "^6.0.3",
+        "jsonwebtoken": "^9.0.3",
+        "listr2": "^10.1.0",
+        "ofetch": "^1.5.1",
+        "zod": "3.25.76 || ^4.3.6"
+      },
+      "bin": {
+        "publish-extension": "bin/publish-extension.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/publish-browser-extension/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/scule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/jonschlinkert",
+        "https://paypal.me/jonathanschlinkert",
+        "https://jonschlinkert.dev/sponsor"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=11.0"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
+      "integrity": "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
+      "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unimport": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.1.tgz",
+      "integrity": "sha512-43BV4iELfhpZ0JNSedMNdBqomAIaJwBrmTqIUYRb8ly3XVQihcRPAVIOSwb23XVCJgtjSf+f82d5Qpdsxqh8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "escape-string-regexp": "^5.0.0",
+        "estree-walker": "^3.0.3",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.2",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4",
+        "pkg-types": "^2.3.1",
+        "scule": "^1.3.0",
+        "strip-literal": "^3.1.0",
+        "tinyglobby": "^0.2.16",
+        "unplugin": "^3.0.0",
+        "unplugin-utils": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "oxc-parser": "*",
+        "rolldown": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-parser": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+      "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "configstore": "^7.0.0",
+        "is-in-ci": "^1.0.0",
+        "is-installed-globally": "^1.0.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^9.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.6.3",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-6.0.0.tgz",
+      "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^7.0.0",
+        "es-module-lexer": "^2.0.0",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "vite": "^8.0.0"
+      },
+      "bin": {
+        "vite-node": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/antfu"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-ext-run": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-ext-run/-/web-ext-run-0.2.4.tgz",
+      "integrity": "sha512-rQicL7OwuqWdQWI33JkSXKcp7cuv1mJG8u3jRQwx/8aDsmhbTHs9ZRmNYOL+LX0wX8edIEQX8jj4bB60GoXtKA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.28.2",
+        "@devicefarmer/adbkit": "3.3.8",
+        "chrome-launcher": "1.2.0",
+        "debounce": "1.2.1",
+        "es6-error": "4.1.1",
+        "firefox-profile": "4.7.0",
+        "fx-runner": "1.4.0",
+        "multimatch": "6.0.0",
+        "node-notifier": "10.0.1",
+        "parse-json": "7.1.1",
+        "pino": "9.7.0",
+        "promise-toolbox": "0.21.0",
+        "set-value": "4.1.0",
+        "source-map-support": "0.5.21",
+        "strip-bom": "5.0.0",
+        "strip-json-comments": "5.0.2",
+        "tmp": "0.2.5",
+        "update-notifier": "7.3.1",
+        "watchpack": "2.4.4",
+        "zip-dir": "2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/when": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
+      "integrity": "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+      "integrity": "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-absolute": "^0.1.7",
+        "isexe": "^1.1.1"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winreg": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+      "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
+      "dev": true,
+      "license": "BSD"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wxt": {
+      "version": "0.20.27",
+      "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.27.tgz",
+      "integrity": "sha512-dm6yixz2awM4YMqpTJnsCa8aOPiTrjiIjbWslgR5hCjgwhuft+hLlla339Dt7gIKwQloee4oOruoK++vaX0APA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@1natsu/wait-element": "^4.1.2",
+        "@aklinker1/rollup-plugin-visualizer": "5.12.0",
+        "@webext-core/fake-browser": "^1.3.4",
+        "@webext-core/isolated-element": "^1.1.3",
+        "@webext-core/match-patterns": "^1.0.3",
+        "@wxt-dev/browser": "^0.2.0",
+        "@wxt-dev/storage": "^1.0.0",
+        "async-mutex": "^0.5.0",
+        "c12": "^3.3.4",
+        "cac": "^6.7.14 || ^7.0.0",
+        "chokidar": "^5.0.0",
+        "ci-info": "^4.4.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "dotenv-expand": "^12.0.3",
+        "esbuild": "^0.27.1",
+        "filesize": "^11.0.17",
+        "get-port-please": "^3.2.0",
+        "giget": "^1.2.3 || ^2.0.0 || ^3.0.0",
+        "hookable": "^6.1.0",
+        "import-meta-resolve": "^4.2.0",
+        "is-wsl": "^3.1.1",
+        "json5": "^2.2.3",
+        "jszip": "^3.10.1",
+        "linkedom": "^0.18.12",
+        "magicast": "^0.5.2",
+        "nano-spawn": "^2.0.0",
+        "nanospinner": "^1.2.2",
+        "normalize-path": "^3.0.0",
+        "nypm": "^0.6.5",
+        "ohash": "^2.0.11",
+        "open": "^11.0.0",
+        "perfect-debounce": "^2.1.0",
+        "picomatch": "^4.0.3",
+        "prompts": "^2.4.2",
+        "publish-browser-extension": "^2.3.0 || ^3.0.2 || ^4.0.5",
+        "scule": "^1.3.0",
+        "tinyglobby": "^0.2.16",
+        "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
+        "vite-node": "^3.2.4 || ^5.0.0 || ^6.0.0",
+        "web-ext-run": "^0.2.4"
+      },
+      "bin": {
+        "wxt": "bin/wxt.mjs",
+        "wxt-publish-extension": "bin/wxt-publish-extension.mjs"
+      },
+      "engines": {
+        "bun": ">=1.2.0",
+        "node": ">=20.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zip-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-2.0.0.tgz",
+      "integrity": "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.0",
+        "jszip": "^3.2.2"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^19.2.8"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.62.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -23,8 +24,12 @@
         "@types/react-dom": "^19.2.3",
         "@vitest/coverage-v8": "^4.1.10",
         "@wxt-dev/module-react": "^1.2.2",
+        "eslint": "^10.8.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^17.7.0",
         "jsdom": "^29.1.1",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.10",
         "wxt": "^0.20.27"
       }
@@ -210,6 +215,153 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -226,6 +378,30 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,6 +428,40 @@
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -951,6 +1161,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
@@ -967,6 +1344,72 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1489,6 +1932,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1517,6 +1967,13 @@
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
       "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1563,6 +2020,347 @@
       "integrity": "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.4",
@@ -1835,6 +2633,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.18",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
@@ -1843,6 +2651,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-align": {
@@ -2055,6 +2880,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2176,6 +3014,40 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -2257,6 +3129,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2645,6 +3538,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-select": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
@@ -2763,6 +3694,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -3000,6 +3938,13 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3135,6 +4080,223 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3143,6 +4305,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -3166,6 +4338,27 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
       "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3197,6 +4390,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filesize": {
       "version": "11.0.22",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.22.tgz",
@@ -3205,6 +4411,23 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 10.8.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/firefox-profile": {
@@ -3226,6 +4449,27 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data-encoder": {
       "version": "4.1.0",
@@ -3308,6 +4552,16 @@
         "node": ">= 0.6.x"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3348,6 +4602,19 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -3381,6 +4648,19 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3410,6 +4690,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hookable": {
@@ -3544,6 +4841,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -3560,6 +4867,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -3615,6 +4932,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
@@ -3629,6 +4956,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-in-ci": {
@@ -3905,6 +5245,26 @@
         }
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
@@ -3914,6 +5274,20 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4000,6 +5374,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4037,6 +5421,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lie": {
@@ -4409,6 +5807,22 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4773,6 +6187,13 @@
         "picocolors": "^1.1.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -4855,6 +6276,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/normalize-path": {
@@ -4982,6 +6413,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -4989,6 +6438,38 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json": {
@@ -5048,6 +6529,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -5223,6 +6724,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -5750,6 +7261,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
@@ -6151,12 +7685,38 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "3.13.1",
@@ -6190,6 +7750,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
@@ -6343,6 +7927,37 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/update-notifier": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
@@ -6366,6 +7981,16 @@
       },
       "funding": {
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6772,6 +8397,16 @@
       "dev": true,
       "license": "BSD"
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
@@ -6941,6 +8576,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
@@ -7018,6 +8660,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zip-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-2.0.0.tgz",
@@ -7037,6 +8692,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -15,6 +15,9 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/chrome": "^0.1.28",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -1377,6 +1380,68 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1387,6 +1452,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1871,6 +1943,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-differ": {
@@ -2758,6 +2840,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "3.1.1",
@@ -4466,6 +4555,16 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5126,6 +5225,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5332,6 +5469,13 @@
       "peerDependencies": {
         "react": "^19.2.8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",

--- a/extension/package.json
+++ b/extension/package.json
@@ -13,13 +13,15 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "e2e": "playwright test",
-    "postinstall": "wxt prepare"
+    "postinstall": "wxt prepare",
+    "lint": "eslint ."
   },
   "dependencies": {
     "react": "^19.2.8",
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.62.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
@@ -29,8 +31,12 @@
     "@types/react-dom": "^19.2.3",
     "@vitest/coverage-v8": "^4.1.10",
     "@wxt-dev/module-react": "^1.2.2",
+    "eslint": "^10.8.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^17.7.0",
     "jsdom": "^29.1.1",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10",
     "wxt": "^0.20.27"
   }

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "nudge-extension",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Nudge for Chrome — website blocker with delay-to-open, breathing pauses, daily limits and local-only stats.",
+  "license": "GPL-3.0-only",
+  "scripts": {
+    "dev": "wxt",
+    "build": "wxt build",
+    "zip": "wxt zip",
+    "typecheck": "wxt prepare && tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "e2e": "playwright test",
+    "postinstall": "wxt prepare"
+  },
+  "dependencies": {
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.0",
+    "@types/chrome": "^0.1.28",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^4.1.10",
+    "@wxt-dev/module-react": "^1.2.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10",
+    "wxt": "^0.20.27"
+  }
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -21,6 +21,9 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/chrome": "^0.1.28",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/extension/playwright.config.ts
+++ b/extension/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  // Extension state (DNR rules, storage) is global to the browser context, so specs must
+  // not race each other.
+  fullyParallel: false,
+  workers: 1,
+  timeout: 45_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    trace: 'retain-on-failure',
+    video: 'off',
+  },
+});

--- a/extension/src/background/alarmsHub.ts
+++ b/extension/src/background/alarmsHub.ts
@@ -1,0 +1,65 @@
+/**
+ * Named alarms.
+ *
+ * Two standing alarms plus one per live temp-allow grant:
+ *  - heartbeat: backstop so a tab left open with no events still accrues time.
+ *  - midnight:  the daily reset boundary, SELF-RESCHEDULING on an absolute `when`.
+ *
+ * Why not `periodInMinutes: 1440` for midnight? A fixed 24h period drifts away from true
+ * local midnight across a DST transition. Recomputing the next local midnight inside the
+ * handler keeps it exact (ext-01 §4).
+ *
+ * Chrome's guidance is to re-verify important alarms on every worker startup, since alarms
+ * without `persistAcrossSessions` can be cleared on browser restart or extension reload.
+ */
+
+import { msUntilNextLocalMidnight } from '../core/scheduleEvaluator';
+import { refreshBadge } from './badge';
+import { domainFromAlarm, handleTempAllowExpiry, rearmTempAllows } from './tempAllow';
+import { onActivityEvent } from './tracker';
+
+export const HEARTBEAT_ALARM = 'nudge:heartbeat';
+export const MIDNIGHT_ALARM = 'nudge:midnight';
+
+/** Production floor is 30s; 1 minute keeps us clear of it while staying responsive. */
+const HEARTBEAT_PERIOD_MINUTES = 1;
+
+export async function scheduleMidnight(now: Date = new Date()): Promise<void> {
+  await chrome.alarms.create(MIDNIGHT_ALARM, {
+    when: now.getTime() + msUntilNextLocalMidnight(now),
+  });
+}
+
+/** Create any standing alarm that is missing. Safe to call repeatedly. */
+export async function ensureAlarms(now: Date = new Date()): Promise<void> {
+  if ((await chrome.alarms.get(HEARTBEAT_ALARM)) === undefined) {
+    await chrome.alarms.create(HEARTBEAT_ALARM, {
+      periodInMinutes: HEARTBEAT_PERIOD_MINUTES,
+    });
+  }
+  if ((await chrome.alarms.get(MIDNIGHT_ALARM)) === undefined) {
+    await scheduleMidnight(now);
+  }
+  await rearmTempAllows(now.getTime());
+}
+
+export async function handleAlarm(alarm: chrome.alarms.Alarm): Promise<void> {
+  if (alarm.name === HEARTBEAT_ALARM) {
+    await onActivityEvent();
+    return;
+  }
+
+  if (alarm.name === MIDNIGHT_ALARM) {
+    // Close out the interval that spanned midnight so its time lands on the correct day,
+    // then re-arm for the NEXT local midnight.
+    await onActivityEvent();
+    await scheduleMidnight(new Date());
+    await refreshBadge();
+    return;
+  }
+
+  const domain = domainFromAlarm(alarm.name);
+  if (domain !== null) {
+    await handleTempAllowExpiry(domain);
+  }
+}

--- a/extension/src/background/badge.ts
+++ b/extension/src/background/badge.ts
@@ -1,0 +1,57 @@
+/**
+ * Toolbar badge — the "Show time remaining" feature (Android parity).
+ *
+ * Hard constraint: only ~4 characters fit in a badge (ext-01 §5), hence `formatBadge`'s
+ * "12m" / "1h2" style. Colors follow Android's thresholds: green >50%, orange 25–50%,
+ * red <25% of the daily budget remaining.
+ */
+
+import { extractDomain } from '../core/domainMatcher';
+import { limitMs, remainingMs, tightestLimit } from '../core/budgets';
+import { badgeColor, formatBadge } from '../ui/format';
+import { loadSettings, todayUsageMs } from './storage';
+
+async function clearBadge(tabId?: number): Promise<void> {
+  try {
+    await chrome.action.setBadgeText(tabId === undefined ? { text: '' } : { text: '', tabId });
+  } catch {
+    // Tab vanished between query and set — nothing to clear.
+  }
+}
+
+/** Recompute the badge for the active tab. Cheap enough to call on every activity event. */
+export async function refreshBadge(): Promise<void> {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (tab?.id === undefined || tab.url === undefined) {
+      await clearBadge();
+      return;
+    }
+
+    const domain = extractDomain(tab.url);
+    if (domain === null) {
+      await clearBadge(tab.id);
+      return;
+    }
+
+    const settings = await loadSettings();
+    const rules = settings.rules.filter(
+      (rule) => rule.enabled && rule.domain === domain && rule.showTimeRemaining,
+    );
+    const limit = settings.globalEnabled ? tightestLimit(rules) : null;
+    if (limit === null) {
+      await clearBadge(tab.id);
+      return;
+    }
+
+    const usedMs = await todayUsageMs(domain, new Date());
+    const left = remainingMs(limit, usedMs) ?? 0;
+    await chrome.action.setBadgeText({ tabId: tab.id, text: formatBadge(left) });
+    await chrome.action.setBadgeBackgroundColor({
+      tabId: tab.id,
+      color: badgeColor(left, limitMs(limit)),
+    });
+  } catch {
+    // Badge is cosmetic: never let it break the tracking path.
+  }
+}

--- a/extension/src/background/dnr.ts
+++ b/extension/src/background/dnr.ts
@@ -1,0 +1,148 @@
+/**
+ * declarativeNetRequest rule compiler.
+ *
+ * Blocking model (ext-08 fixed decisions):
+ *  - DNR handles whole-site, full-page-load blocking. Content scripts handle in-SPA
+ *    navigation (DNR cannot see it).
+ *  - EVERY enabled rule compiles to a *redirect* to blocked.html — Hard Block, Delay and
+ *    Breathing all begin with the interstitial. The block page then asks the engine which
+ *    of the three to render, so the network layer stays mode-agnostic and only has to
+ *    change when the rule SET changes, not when a mode does.
+ *  - Temporary access after a completed pause is a SESSION allow-rule at a higher priority.
+ *    Session rules are wiped on browser restart, which is exactly what we want: a crash can
+ *    never leave a site permanently unlocked (ext-01 §1).
+ *
+ * The original URL is carried to the block page via `regexSubstitution` with `\0` (the
+ * entire matched text) — verified against the DNR reference. `regexSubstitution` requires
+ * `regexFilter`, and the pattern is anchored `^...$` so `\0` is the WHOLE url rather than
+ * just its prefix.
+ */
+
+import { extractDomain, normalizeToBaseDomain } from '../core/domainMatcher';
+import type { NudgeSettings } from '../core/settingsSchema';
+
+/** Redirect rules occupy 1..N; session allow rules start well above them. */
+const BLOCK_RULE_ID_BASE = 1;
+const ALLOW_RULE_ID_BASE = 10_000;
+
+const BLOCK_PRIORITY = 1;
+/** Strictly greater than BLOCK_PRIORITY so a temporary grant always wins. */
+const ALLOW_PRIORITY = 2;
+
+/** Escape a domain for embedding in a RE2 pattern. */
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Match `domain` and every subdomain of it, over http(s), for the whole URL.
+ *
+ * Anchored at both ends so the entire URL is the match — `\0` in the substitution then
+ * yields the full original URL for the block page's `target`.
+ */
+export function domainRegexFilter(domain: string): string {
+  const base = escapeForRegex(normalizeToBaseDomain(domain));
+  return `^https?://([^/:@?#]*\\.)?${base}(?::[0-9]+)?(?:[/?#].*)?$`;
+}
+
+/** The blocked.html URL, with the original URL appended verbatim as the last query param. */
+function blockedPageSubstitution(): string {
+  // `target` is deliberately LAST and unencoded: the original URL may contain '?' and '&',
+  // so the block page reads everything after the first "?target=" rather than parsing
+  // query params. (regexSubstitution cannot URL-encode.)
+  return `${chrome.runtime.getURL('blocked.html')}?target=\\0`;
+}
+
+/** Distinct base domains that currently have an enabled rule. */
+export function blockedDomains(settings: NudgeSettings): string[] {
+  if (!settings.globalEnabled) return [];
+  const domains = new Set<string>();
+  for (const rule of settings.rules) {
+    if (rule.enabled) domains.add(normalizeToBaseDomain(rule.domain));
+  }
+  return [...domains].sort();
+}
+
+/**
+ * Compile settings into the full dynamic rule set.
+ *
+ * `main_frame` only — blocking subresources would break unrelated sites that merely embed
+ * something from a blocked domain, and the product blocks *browsing*, not requests.
+ */
+export function compileRules(settings: NudgeSettings): chrome.declarativeNetRequest.Rule[] {
+  return blockedDomains(settings).map((domain, index) => ({
+    id: BLOCK_RULE_ID_BASE + index,
+    priority: BLOCK_PRIORITY,
+    action: {
+      type: 'redirect' as const,
+      redirect: { regexSubstitution: blockedPageSubstitution() },
+    },
+    condition: {
+      regexFilter: domainRegexFilter(domain),
+      resourceTypes: ['main_frame' as const],
+    },
+  }));
+}
+
+/** Replace the entire dynamic rule set with the one implied by `settings`. */
+export async function applyRules(settings: NudgeSettings): Promise<void> {
+  const existing = await chrome.declarativeNetRequest.getDynamicRules();
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    removeRuleIds: existing.map((rule) => rule.id),
+    addRules: compileRules(settings),
+  });
+}
+
+/** Stable session-rule id for a domain, derived so re-grants replace rather than stack. */
+function allowRuleId(domain: string, allDomains: string[]): number {
+  const index = allDomains.indexOf(domain);
+  return ALLOW_RULE_ID_BASE + (index >= 0 ? index : allDomains.length);
+}
+
+/**
+ * Rewrite the session allow-rules so exactly the domains in `domains` are permitted.
+ * Called on every grant and every expiry, so the rule set is always derived from state
+ * rather than incrementally patched (no drift after a service-worker restart).
+ */
+export async function applyTempAllows(domains: string[]): Promise<void> {
+  const existing = await chrome.declarativeNetRequest.getSessionRules();
+  const sorted = [...new Set(domains.map(normalizeToBaseDomain))].sort();
+  const addRules: chrome.declarativeNetRequest.Rule[] = sorted.map((domain) => ({
+    id: allowRuleId(domain, sorted),
+    priority: ALLOW_PRIORITY,
+    action: { type: 'allow' as const },
+    condition: {
+      regexFilter: domainRegexFilter(domain),
+      resourceTypes: ['main_frame' as const],
+    },
+  }));
+  await chrome.declarativeNetRequest.updateSessionRules({
+    removeRuleIds: existing.map((rule) => rule.id),
+    addRules,
+  });
+}
+
+/**
+ * Send every open tab currently on `domain` to the block page.
+ *
+ * This is the "budget flip mid-browsing" path: a page already open when the daily limit is
+ * crossed would otherwise stay readable until the next navigation, because DNR only sees
+ * requests. Fires inside the accounting step, so the flip is immediate rather than up to a
+ * heartbeat late (ext-01 §4).
+ */
+export async function redirectOpenTabs(domain: string): Promise<void> {
+  const base = normalizeToBaseDomain(domain);
+  const tabs = await chrome.tabs.query({ url: ['http://*/*', 'https://*/*'] });
+  const blockedUrl = chrome.runtime.getURL('blocked.html');
+  await Promise.all(
+    tabs.map(async (tab) => {
+      if (tab.id === undefined || tab.url === undefined) return;
+      if (extractDomain(tab.url) !== base) return;
+      try {
+        await chrome.tabs.update(tab.id, { url: `${blockedUrl}?target=${tab.url}` });
+      } catch {
+        // Tab closed or is otherwise not updatable — nothing to do.
+      }
+    }),
+  );
+}

--- a/extension/src/background/messagesRouter.ts
+++ b/extension/src/background/messagesRouter.ts
@@ -1,0 +1,356 @@
+/**
+ * The typed runtime-message router — every UI surface talks to the worker through here.
+ *
+ * Design rules:
+ *  - The engine is the single source of truth for "is this blocked and how". The block page
+ *    never decides; it asks.
+ *  - Every WEAKENING settings change is gated by the Commitment Lock (Strict Mode). The gate
+ *    lives HERE, in the worker, not in the UI — a gate a page could skip is not a gate.
+ *  - Handlers are total: an unknown message and a thrown handler both produce a defined
+ *    response rather than a hung sendMessage promise.
+ */
+
+import { evaluate } from '../core/blockEngine';
+import { remainingMs, tightestLimit } from '../core/budgets';
+import { extractDomain, normalizeUserInput } from '../core/domainMatcher';
+import * as pass from '../core/emergencyPass';
+import {
+  DEFAULT_DELAY_SUBTITLES,
+  DEFAULT_DELAY_TITLES,
+  DEFAULT_HARD_BLOCK_MESSAGES,
+  pickRandom,
+  resolvePool,
+} from '../core/messages';
+import type {
+  BlockContext,
+  DashboardState,
+  GrantResult,
+  PopupState,
+  Request,
+  SaveResult,
+  YoutubeConfig,
+} from '../core/protocol';
+import { resolveActiveRules } from '../core/ruleResolver';
+import { localDayKey } from '../core/scheduleEvaluator';
+import {
+  DEFAULT_DELAY_SECONDS,
+  migrateSettings,
+  type NudgeSettings,
+  type SiteRule,
+} from '../core/settingsSchema';
+import { allTimeTotals, lastNDayKeys, totalActiveSeconds } from '../core/stats';
+import * as strict from '../core/strictMode';
+import type { BlockMode } from '../core/types';
+import { applyRules } from './dnr';
+import {
+  loadAllUsage,
+  loadDay,
+  loadPassLedger,
+  loadSettings,
+  saveSettings,
+  savePassLedger,
+  todayUsageMs,
+} from './storage';
+import { grantTempAllow } from './tempAllow';
+import { logBlocked, logWalkedAway, onActivityEvent } from './tracker';
+
+const PENDING_CHALLENGE_KEY = 'nudge:pendingChallenge';
+
+async function loadPendingChallenge(): Promise<string | null> {
+  const stored = await chrome.storage.session.get(PENDING_CHALLENGE_KEY);
+  const value = stored[PENDING_CHALLENGE_KEY];
+  return typeof value === 'string' ? value : null;
+}
+
+async function setPendingChallenge(challenge: string | null): Promise<void> {
+  if (challenge === null) {
+    await chrome.storage.session.remove(PENDING_CHALLENGE_KEY);
+  } else {
+    await chrome.storage.session.set({ [PENDING_CHALLENGE_KEY]: challenge });
+  }
+}
+
+async function buildBlockContext(target: string, now: Date): Promise<BlockContext> {
+  const settings = await loadSettings();
+  const domain = extractDomain(target) ?? '';
+  const usedMs = domain === '' ? 0 : await todayUsageMs(domain, now);
+
+  const decision = settings.globalEnabled
+    ? evaluate(resolveActiveRules(settings.rules, domain, now), usedMs, now)
+    : { type: 'ALLOW' as const };
+
+  const ledger = pass.parse(await loadPassLedger());
+  const passAvailable = pass.canUseGlobal(ledger, now.getTime(), pass.LOCKOUT_MS);
+
+  return {
+    target,
+    domain,
+    decision,
+    delayTitle: pickRandom(
+      resolvePool(settings.messages.delayTitles, DEFAULT_DELAY_TITLES),
+    ),
+    delaySubtitle: pickRandom(
+      resolvePool(settings.messages.delaySubtitles, DEFAULT_DELAY_SUBTITLES),
+    ),
+    hardBlockMessage: pickRandom(
+      resolvePool(settings.messages.hardBlockMessages, DEFAULT_HARD_BLOCK_MESSAGES),
+    ),
+    passEnabled: settings.emergencyPass.enabled,
+    passAvailable,
+    passNextAvailableMs: pass.nextAvailableGlobalMs(
+      ledger,
+      now.getTime(),
+      pass.LOCKOUT_MS,
+    ),
+    strictModeEnabled: settings.strictMode.enabled,
+    tempAllowMinutes: settings.tempAllowMinutes,
+  };
+}
+
+/**
+ * Grant temporary access after a completed pause.
+ *
+ * Guarded: a pause can only buy access to something that was actually a DELAY or BREATHING
+ * block. A HARD_BLOCK (including a budget-exhausted one) can never be completed away, so a
+ * stray or replayed COMPLETE_PAUSE cannot unlock it.
+ */
+async function completePause(target: string, now: Date): Promise<GrantResult> {
+  const context = await buildBlockContext(target, now);
+  if (context.domain === '') return { ok: false, until: 0, reason: 'unknown-site' };
+
+  if (context.decision.type === 'ALLOW') {
+    return { ok: true, until: now.getTime() };
+  }
+  if (context.decision.mode === 'HARD_BLOCK') {
+    return { ok: false, until: 0, reason: 'hard-block' };
+  }
+
+  const until = await grantTempAllow(
+    context.domain,
+    context.tempAllowMinutes,
+    now.getTime(),
+  );
+  return { ok: true, until };
+}
+
+/** The Escape Hatch: one 2-minute window per rolling 24h, globally. */
+async function useEmergencyPass(target: string, now: Date): Promise<GrantResult> {
+  const settings = await loadSettings();
+  if (!settings.emergencyPass.enabled) {
+    return { ok: false, until: 0, reason: 'disabled' };
+  }
+  // A commitment lock must not have a one-tap bypass.
+  if (settings.strictMode.enabled) {
+    return { ok: false, until: 0, reason: 'strict-mode' };
+  }
+
+  const domain = extractDomain(target);
+  if (domain === null) return { ok: false, until: 0, reason: 'unknown-site' };
+
+  const ledger = pass.parse(await loadPassLedger());
+  if (!pass.canUseGlobal(ledger, now.getTime(), pass.LOCKOUT_MS)) {
+    return { ok: false, until: 0, reason: 'locked-out' };
+  }
+
+  await savePassLedger(pass.serialize(pass.recordGlobal(now.getTime())));
+  const until = await grantTempAllow(
+    domain,
+    pass.PASS_DURATION_MS / 60_000,
+    now.getTime(),
+  );
+  return { ok: true, until };
+}
+
+async function buildPopupState(now: Date): Promise<PopupState> {
+  const settings = await loadSettings();
+  const day = await loadDay(localDayKey(now));
+
+  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  const currentDomain = tab?.url === undefined ? null : extractDomain(tab.url);
+
+  const rules =
+    currentDomain === null
+      ? []
+      : settings.rules.filter((rule) => rule.domain === currentDomain);
+  const limit = tightestLimit(rules.filter((rule) => rule.enabled));
+  const usedMs = currentDomain === null ? 0 : (day[currentDomain]?.activeSec ?? 0) * 1000;
+
+  return {
+    globalEnabled: settings.globalEnabled,
+    todayTotalSeconds: totalActiveSeconds(day),
+    currentDomain,
+    currentRule: rules[0] ?? null,
+    currentRemainingMs: remainingMs(limit, usedMs),
+    currentUsageSeconds: Math.floor(usedMs / 1000),
+  };
+}
+
+async function buildDashboardState(now: Date): Promise<DashboardState> {
+  const usage = await loadAllUsage();
+  const totals = allTimeTotals(usage);
+  return {
+    settings: await loadSettings(),
+    recentDays: lastNDayKeys(now, 7),
+    usage,
+    allTimeBlocked: totals.blocked,
+    allTimeWalkedAway: totals.walkedAway,
+  };
+}
+
+/**
+ * Persist settings, gating any WEAKENING change behind the Commitment Lock.
+ *
+ * Strengthening is never gated. The challenge is held in storage.session and reused across
+ * retries so the user can keep typing the code they are looking at; it is cleared the moment
+ * a save succeeds or the pending change is abandoned.
+ */
+async function handleSave(
+  next: NudgeSettings,
+  challengeResponse: string | undefined,
+  now: Date,
+): Promise<SaveResult> {
+  const current = await loadSettings();
+  const normalized = migrateSettings(next);
+
+  if (current.strictMode.enabled && strict.isWeakening(current, normalized)) {
+    const pending = (await loadPendingChallenge()) ?? strict.generate(
+      current.strictMode.challengeLength,
+    );
+    await setPendingChallenge(pending);
+
+    if (challengeResponse === undefined) {
+      return { ok: false, challenge: pending, reason: 'challenge-required' };
+    }
+    if (!strict.verify(challengeResponse, pending)) {
+      return { ok: false, challenge: pending, reason: 'challenge-incorrect' };
+    }
+  }
+
+  await setPendingChallenge(null);
+  await saveSettings(normalized);
+  await applyRules(normalized);
+  await onActivityEvent(now.getTime());
+  return { ok: true };
+}
+
+async function addSite(
+  domain: string,
+  mode: BlockMode,
+  delaySeconds: number,
+  now: Date,
+): Promise<{ ok: boolean; reason?: string }> {
+  const normalizedDomain = normalizeUserInput(domain);
+  if (normalizedDomain === null) return { ok: false, reason: 'invalid-domain' };
+
+  const settings = await loadSettings();
+  if (settings.rules.some((rule) => rule.domain === normalizedDomain)) {
+    return { ok: false, reason: 'already-blocked' };
+  }
+
+  const rule: SiteRule = {
+    id: `rule-${normalizedDomain}-${now.getTime()}`,
+    domain: normalizedDomain,
+    mode,
+    delaySeconds: delaySeconds > 0 ? delaySeconds : DEFAULT_DELAY_SECONDS,
+    dailyLimitMinutes: null,
+    enabled: true,
+    createdAt: now.getTime(),
+    showTimeRemaining: false,
+    schedule: null,
+  };
+
+  // Adding a rule STRENGTHENS protection, so it is never gated by Strict Mode.
+  const updated = migrateSettings({ ...settings, rules: [...settings.rules, rule] });
+  await saveSettings(updated);
+  await applyRules(updated);
+  return { ok: true };
+}
+
+async function buildYoutubeConfig(now: Date): Promise<YoutubeConfig> {
+  const settings = await loadSettings();
+  if (!settings.globalEnabled) {
+    return {
+      enabled: false,
+      hideShortsShelf: false,
+      shortsMode: 'ALLOW',
+      shortsDelaySeconds: settings.youtube.shortsDelaySeconds,
+    };
+  }
+
+  let shortsMode: BlockMode | 'ALLOW';
+  if (settings.youtube.shortsMode === 'INHERIT') {
+    // Defer to whatever the site rule for youtube.com decides right now.
+    const usedMs = await todayUsageMs('youtube.com', now);
+    const decision = evaluate(
+      resolveActiveRules(settings.rules, 'youtube.com', now),
+      usedMs,
+      now,
+    );
+    shortsMode = decision.type === 'ALLOW' ? 'ALLOW' : decision.mode;
+  } else {
+    shortsMode = settings.youtube.shortsMode;
+  }
+
+  return {
+    enabled: true,
+    hideShortsShelf: settings.youtube.hideShortsShelf,
+    shortsMode,
+    shortsDelaySeconds: settings.youtube.shortsDelaySeconds,
+  };
+}
+
+/** Dispatch one request. Throwing here would hang the caller, so it never throws. */
+export async function handleRequest(request: Request, now: Date = new Date()): Promise<unknown> {
+  switch (request.type) {
+    case 'GET_BLOCK_CONTEXT': {
+      const context = await buildBlockContext(request.target, now);
+      // The interstitial rendering IS the block event (Android's "Blocked" counter).
+      if (context.decision.type === 'BLOCK' && context.domain !== '') {
+        await logBlocked(context.domain, now);
+      }
+      return context;
+    }
+    case 'COMPLETE_PAUSE':
+      return completePause(request.target, now);
+    case 'WALKED_AWAY': {
+      const domain = extractDomain(request.target);
+      if (domain !== null) await logWalkedAway(domain, now);
+      return { ok: true };
+    }
+    case 'USE_EMERGENCY_PASS':
+      return useEmergencyPass(request.target, now);
+    case 'GET_POPUP_STATE':
+      return buildPopupState(now);
+    case 'GET_DASHBOARD_STATE':
+      return buildDashboardState(now);
+    case 'ADD_SITE':
+      return addSite(request.domain, request.mode, request.delaySeconds, now);
+    case 'SAVE_SETTINGS':
+      return handleSave(request.settings, request.challengeResponse, now);
+    case 'GET_SETTINGS':
+      return loadSettings();
+    case 'GET_YOUTUBE_CONFIG':
+      return buildYoutubeConfig(now);
+    default:
+      return { ok: false, reason: 'unknown-request' };
+  }
+}
+
+/**
+ * Wire the router to chrome.runtime.
+ *
+ * Returns `true` synchronously so Chrome keeps the message channel open for the async
+ * response — omitting this is the classic MV3 "port closed before a response was received"
+ * bug. A rejected handler still sends a response so the caller never hangs.
+ */
+export function registerMessageRouter(): void {
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    handleRequest(message as Request)
+      .then(sendResponse)
+      .catch((error: unknown) => {
+        console.error('[nudge] message handler failed', error);
+        sendResponse({ ok: false, reason: 'handler-error' });
+      });
+    return true;
+  });
+}

--- a/extension/src/background/messagesRouter.ts
+++ b/extension/src/background/messagesRouter.ts
@@ -134,7 +134,7 @@ async function completePause(target: string, now: Date): Promise<GrantResult> {
 }
 
 /** The Escape Hatch: one 2-minute window per rolling 24h, globally. */
-async function useEmergencyPass(target: string, now: Date): Promise<GrantResult> {
+async function redeemEmergencyPass(target: string, now: Date): Promise<GrantResult> {
   const settings = await loadSettings();
   if (!settings.emergencyPass.enabled) {
     return { ok: false, until: 0, reason: 'disabled' };
@@ -318,7 +318,7 @@ export async function handleRequest(request: Request, now: Date = new Date()): P
       return { ok: true };
     }
     case 'USE_EMERGENCY_PASS':
-      return useEmergencyPass(request.target, now);
+      return redeemEmergencyPass(request.target, now);
     case 'GET_POPUP_STATE':
       return buildPopupState(now);
     case 'GET_DASHBOARD_STATE':

--- a/extension/src/background/storage.ts
+++ b/extension/src/background/storage.ts
@@ -1,0 +1,141 @@
+/**
+ * Persistence adapter. The ONLY module that talks to chrome.storage.
+ *
+ * Three tiers, deliberately separated (ext-08 Data):
+ *  - settings  -> storage.sync   (~100KB, free cross-device sync via the user's Chrome
+ *                                 account; falls back to local when sync is unavailable)
+ *  - usage     -> storage.local  (+ unlimitedStorage). NEVER syncs, never leaves the device.
+ *  - ephemeral -> storage.session (in-memory, dies with the browser — which is a feature
+ *                                 for temp-allow grants: a crash can't leave a site unlocked)
+ */
+
+import { migrateSettings, type NudgeSettings } from '../core/settingsSchema';
+import { localDayKey } from '../core/scheduleEvaluator';
+import { emptyDayUsage } from '../core/stats';
+import type { DayUsage, UsageByDay } from '../core/protocol';
+
+const SETTINGS_KEY = 'nudge:settings';
+const USAGE_PREFIX = 'usage:';
+const PASS_LEDGER_KEY = 'nudge:passLedger';
+const TRACKER_STATE_KEY = 'nudge:tracker';
+const TEMP_ALLOW_KEY = 'nudge:tempAllow';
+
+/** Settings live in sync; a sync failure (quota, sync disabled) degrades to local. */
+export async function loadSettings(): Promise<NudgeSettings> {
+  try {
+    const synced = await chrome.storage.sync.get(SETTINGS_KEY);
+    if (synced[SETTINGS_KEY] !== undefined) return migrateSettings(synced[SETTINGS_KEY]);
+  } catch {
+    // fall through to local
+  }
+  const local = await chrome.storage.local.get(SETTINGS_KEY);
+  return migrateSettings(local[SETTINGS_KEY]);
+}
+
+export async function saveSettings(settings: NudgeSettings): Promise<void> {
+  const normalized = migrateSettings(settings);
+  // Always mirror to local so a later sync outage still reads current settings.
+  await chrome.storage.local.set({ [SETTINGS_KEY]: normalized });
+  try {
+    await chrome.storage.sync.set({ [SETTINGS_KEY]: normalized });
+  } catch {
+    // Sync unavailable or over quota — local mirror above is authoritative.
+  }
+}
+
+function usageKey(dayKey: string): string {
+  return `${USAGE_PREFIX}${dayKey}`;
+}
+
+export async function loadDay(dayKey: string): Promise<Record<string, DayUsage>> {
+  const stored = await chrome.storage.local.get(usageKey(dayKey));
+  const day = stored[usageKey(dayKey)];
+  return day && typeof day === 'object' ? (day as Record<string, DayUsage>) : {};
+}
+
+export async function saveDay(
+  dayKey: string,
+  day: Record<string, DayUsage>,
+): Promise<void> {
+  await chrome.storage.local.set({ [usageKey(dayKey)]: day });
+}
+
+/**
+ * Read-modify-write one domain's rollup for one day.
+ *
+ * Every accounting step is a complete atomic read-modify-write rather than an increment
+ * against a value cached in a service-worker global — the worker can be torn down between
+ * any two events, so nothing may be held in memory across them (ext-01 §2).
+ */
+export async function updateDomainUsage(
+  dayKey: string,
+  domain: string,
+  mutate: (usage: DayUsage) => DayUsage,
+): Promise<DayUsage> {
+  const day = await loadDay(dayKey);
+  const next = mutate(day[domain] ?? emptyDayUsage());
+  day[domain] = next;
+  await saveDay(dayKey, day);
+  return next;
+}
+
+/** Active seconds spent on `domain` today. */
+export async function todayUsageMs(domain: string, now: Date): Promise<number> {
+  const day = await loadDay(localDayKey(now));
+  return (day[domain]?.activeSec ?? 0) * 1000;
+}
+
+/** Load every stored day, newest keys included. Used by the dashboard. */
+export async function loadAllUsage(): Promise<UsageByDay> {
+  const all = await chrome.storage.local.get(null);
+  const usage: UsageByDay = {};
+  for (const [key, value] of Object.entries(all)) {
+    if (key.startsWith(USAGE_PREFIX) && value && typeof value === 'object') {
+      usage[key.slice(USAGE_PREFIX.length)] = value as Record<string, DayUsage>;
+    }
+  }
+  return usage;
+}
+
+/** The emergency-pass ledger. Device-local: the lockout is per device, like Android's. */
+export async function loadPassLedger(): Promise<string> {
+  const stored = await chrome.storage.local.get(PASS_LEDGER_KEY);
+  const raw = stored[PASS_LEDGER_KEY];
+  return typeof raw === 'string' ? raw : '';
+}
+
+export async function savePassLedger(raw: string): Promise<void> {
+  await chrome.storage.local.set({ [PASS_LEDGER_KEY]: raw });
+}
+
+/** What the tracker was counting when it last woke. Ephemeral by design. */
+export interface TrackerState {
+  domain: string | null;
+  since: number;
+}
+
+export async function loadTrackerState(): Promise<TrackerState> {
+  const stored = await chrome.storage.session.get(TRACKER_STATE_KEY);
+  const state = stored[TRACKER_STATE_KEY];
+  if (state && typeof state === 'object' && typeof (state as TrackerState).since === 'number') {
+    return state as TrackerState;
+  }
+  return { domain: null, since: Date.now() };
+}
+
+export async function saveTrackerState(state: TrackerState): Promise<void> {
+  await chrome.storage.session.set({ [TRACKER_STATE_KEY]: state });
+}
+
+/** domain -> epoch ms the temporary grant expires. */
+export type TempAllowMap = Record<string, number>;
+
+export async function loadTempAllow(): Promise<TempAllowMap> {
+  const stored = await chrome.storage.session.get(TEMP_ALLOW_KEY);
+  const map = stored[TEMP_ALLOW_KEY];
+  return map && typeof map === 'object' ? (map as TempAllowMap) : {};
+}
+
+export async function saveTempAllow(map: TempAllowMap): Promise<void> {
+  await chrome.storage.session.set({ [TEMP_ALLOW_KEY]: map });
+}

--- a/extension/src/background/tempAllow.ts
+++ b/extension/src/background/tempAllow.ts
@@ -1,0 +1,116 @@
+/**
+ * Temporary access grants — the browser analog of Android's "the app opens" after a
+ * completed Delay/Breathing pause.
+ *
+ * Per-ORIGIN for N minutes, not per-tab (ext-08 fixed decision: DNR matches URLs, not tab
+ * ids, so per-tab exemption would need a fragile service-worker layer on top; per-origin is
+ * also what competitors ship).
+ *
+ * State lives in storage.session and the DNR allow-rules are SESSION rules, so both halves
+ * die together on browser restart — there is no way to end up with a grant recorded but not
+ * enforced, or enforced but not recorded.
+ */
+
+import { normalizeToBaseDomain } from '../core/domainMatcher';
+import { applyTempAllows } from './dnr';
+import { loadTempAllow, saveTempAllow, type TempAllowMap } from './storage';
+
+export const TEMP_ALLOW_ALARM_PREFIX = 'nudge:tempallow:';
+
+export function tempAllowAlarmName(domain: string): string {
+  return `${TEMP_ALLOW_ALARM_PREFIX}${normalizeToBaseDomain(domain)}`;
+}
+
+export function domainFromAlarm(alarmName: string): string | null {
+  return alarmName.startsWith(TEMP_ALLOW_ALARM_PREFIX)
+    ? alarmName.slice(TEMP_ALLOW_ALARM_PREFIX.length)
+    : null;
+}
+
+/** Drop expired entries. Pure so it can be unit tested without chrome. */
+export function pruneExpired(map: TempAllowMap, now: number): TempAllowMap {
+  const next: TempAllowMap = {};
+  for (const [domain, until] of Object.entries(map)) {
+    if (until > now) next[domain] = until;
+  }
+  return next;
+}
+
+/**
+ * Re-derive the DNR session allow-rules from the stored grant map, dropping anything that
+ * has expired. Every mutation funnels through here so the rules are always a pure function
+ * of state — a service-worker restart mid-grant can never leave the two out of step.
+ */
+async function syncFromMap(map: TempAllowMap, now: number): Promise<TempAllowMap> {
+  const live = pruneExpired(map, now);
+  await saveTempAllow(live);
+  await applyTempAllows(Object.keys(live));
+  return live;
+}
+
+/** Grant `domain` access for `minutes`, and schedule its expiry. */
+export async function grantTempAllow(
+  domain: string,
+  minutes: number,
+  now: number = Date.now(),
+): Promise<number> {
+  const base = normalizeToBaseDomain(domain);
+  const until = now + Math.max(1, minutes) * 60_000;
+  const map = await loadTempAllow();
+  map[base] = until;
+  await syncFromMap(map, now);
+  // Absolute `when` rather than delayInMinutes: alarms below 1 minute are unreliable in
+  // production builds, and an absolute time survives a worker restart intact.
+  await chrome.alarms.create(tempAllowAlarmName(base), { when: until });
+  return until;
+}
+
+/** Revoke a grant immediately (used when a daily budget is exhausted mid-grant). */
+export async function revokeTempAllow(
+  domain: string,
+  now: number = Date.now(),
+): Promise<void> {
+  const base = normalizeToBaseDomain(domain);
+  const map = await loadTempAllow();
+  delete map[base];
+  await syncFromMap(map, now);
+  await chrome.alarms.clear(tempAllowAlarmName(base));
+}
+
+/**
+ * Handle an expiry alarm. The allow-rule is removed so the NEXT navigation re-blocks; the
+ * page currently open is deliberately left alone (no yanking a page out from under the
+ * user mid-read — ext-08 flow 2).
+ */
+export async function handleTempAllowExpiry(
+  domain: string,
+  now: number = Date.now(),
+): Promise<void> {
+  const map = await loadTempAllow();
+  delete map[normalizeToBaseDomain(domain)];
+  await syncFromMap(map, now);
+}
+
+export async function isTempAllowed(
+  domain: string,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const map = await loadTempAllow();
+  const until = map[normalizeToBaseDomain(domain)];
+  return until !== undefined && until > now;
+}
+
+/**
+ * Re-derive rules and re-arm alarms on every service-worker startup.
+ *
+ * Chrome's own guidance: alarms are not guaranteed to survive a restart, so important ones
+ * must be re-verified when the worker starts (ext-01 §4).
+ */
+export async function rearmTempAllows(now: number = Date.now()): Promise<void> {
+  const live = await syncFromMap(await loadTempAllow(), now);
+  await Promise.all(
+    Object.entries(live).map(([domain, until]) =>
+      chrome.alarms.create(tempAllowAlarmName(domain), { when: until }),
+    ),
+  );
+}

--- a/extension/src/background/tracker.ts
+++ b/extension/src/background/tracker.ts
@@ -1,0 +1,134 @@
+/**
+ * Usage tracking — event-driven timestamp accounting.
+ *
+ * THE MV3 RULE (ext-01 §2): never accumulate elapsed time in a service-worker global. The
+ * worker is torn down after ~30s idle, so anything held in memory between two events is
+ * lost. Instead every relevant event does one atomic step:
+ *
+ *    read `since` from storage.session -> add (now - since) to today's rollup -> write
+ *    the new `since`.
+ *
+ * Each step stands alone, so arbitrary teardown between events costs nothing. A heartbeat
+ * alarm is the backstop for a tab that simply sits open with no events firing.
+ *
+ * Time is counted only when Chrome has OS focus AND the machine is not idle/locked —
+ * `windows.onFocusChanged` and `chrome.idle` are what make "screen time" mean attention
+ * rather than "a window was open".
+ */
+
+import { extractDomain } from '../core/domainMatcher';
+import { localDayKey } from '../core/scheduleEvaluator';
+import { addActiveSeconds, recordBlocked, recordWalkedAway } from '../core/stats';
+import { crossesLimit, tightestLimit } from '../core/budgets';
+import { loadSettings } from './storage';
+import {
+  loadTrackerState,
+  saveTrackerState,
+  todayUsageMs,
+  updateDomainUsage,
+} from './storage';
+import { redirectOpenTabs } from './dnr';
+import { revokeTempAllow } from './tempAllow';
+import { refreshBadge } from './badge';
+
+/** Idle threshold handed to chrome.idle (seconds). */
+export const IDLE_DETECTION_SECONDS = 60;
+
+/**
+ * Upper bound on the time a single accounting step may attribute.
+ *
+ * The heartbeat fires every minute, so a legitimate gap is ~60s. A much larger gap means
+ * the machine slept, the clock jumped, or the worker was starved — attributing it would
+ * silently inflate "screen time" (and could trip a daily limit the user never used). Cap
+ * generously at 3 heartbeats and drop the excess.
+ */
+export const MAX_ATTRIBUTABLE_MS = 3 * 60_000;
+
+/** The domain that should be accruing time right now, or null if nothing should. */
+export async function currentTrackedDomain(): Promise<string | null> {
+  try {
+    const idleState = await chrome.idle.queryState(IDLE_DETECTION_SECONDS);
+    if (idleState !== 'active') return null;
+
+    const lastFocused = await chrome.windows.getLastFocused();
+    if (lastFocused.focused === false) return null;
+
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (tab?.url === undefined) return null;
+    return extractDomain(tab.url);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Close out the currently-tracked interval and start a new one on `nextDomain`.
+ * Safe to call from any event handler; idempotent when nothing changed.
+ */
+export async function accountAndSwitch(
+  nextDomain: string | null,
+  now: number = Date.now(),
+): Promise<void> {
+  const state = await loadTrackerState();
+  await saveTrackerState({ domain: nextDomain, since: now });
+
+  const elapsed = now - state.since;
+  if (state.domain === null || elapsed <= 0) return;
+
+  const attributable = Math.min(elapsed, MAX_ATTRIBUTABLE_MS);
+  const seconds = Math.floor(attributable / 1000);
+  if (seconds <= 0) return;
+
+  const at = new Date(now);
+  const previousMs = await todayUsageMs(state.domain, at);
+  await updateDomainUsage(localDayKey(at), state.domain, (usage) =>
+    addActiveSeconds(usage, seconds, at.getHours()),
+  );
+  await enforceBudget(state.domain, previousMs, previousMs + seconds * 1000, at);
+}
+
+/**
+ * Flip a site to blocked the instant its daily limit is crossed.
+ *
+ * Runs inside the same accounting step that crossed the threshold (not on a separate poll),
+ * so the block is immediate rather than up to a heartbeat late — ext-01 §4. `crossesLimit`
+ * is true only on the transition, so open tabs are redirected exactly once.
+ */
+async function enforceBudget(
+  domain: string,
+  previousMs: number,
+  nextMs: number,
+  now: Date,
+): Promise<void> {
+  const settings = await loadSettings();
+  if (!settings.globalEnabled) return;
+
+  const rules = settings.rules.filter((rule) => rule.enabled && rule.domain === domain);
+  if (rules.length === 0) return;
+
+  const limit = tightestLimit(rules);
+  if (limit === null) return;
+
+  if (crossesLimit(limit, previousMs, nextMs)) {
+    // An exhausted budget outranks an in-flight temporary grant (Android forces HARD_BLOCK).
+    await revokeTempAllow(domain, now.getTime());
+    await redirectOpenTabs(domain);
+  }
+}
+
+/** Re-evaluate what should be tracked right now. The single entry point for all events. */
+export async function onActivityEvent(now: number = Date.now()): Promise<void> {
+  const next = await currentTrackedDomain();
+  await accountAndSwitch(next, now);
+  await refreshBadge();
+}
+
+/** Record that a block was shown (dashboard "Blocked" counter). */
+export async function logBlocked(domain: string, now: Date = new Date()): Promise<void> {
+  await updateDomainUsage(localDayKey(now), domain, recordBlocked);
+}
+
+/** Record a "I changed my mind" bail (dashboard "Walked Away" counter). */
+export async function logWalkedAway(domain: string, now: Date = new Date()): Promise<void> {
+  await updateDomainUsage(localDayKey(now), domain, recordWalkedAway);
+}

--- a/extension/src/content/selectors.ts
+++ b/extension/src/content/selectors.ts
@@ -1,0 +1,310 @@
+/**
+ * EVERY YouTube DOM selector Nudge uses. Nothing is hardcoded in youtube.ts.
+ *
+ * Source of the taxonomy: ops/routes/nudge/research/ext-03-youtube-techniques.md §1 and §6
+ * (read from `Vulpelo/hide-youtube-shorts`, `malekwael229/FocusTube`,
+ * `tobiasdalhof/sanersocialmedia` — real shipped extensions, not invention).
+ *
+ * Three rules this file exists to enforce (ext-03 §6):
+ *
+ *  1. MULTI-SELECTOR CHAINS, tried in order. YouTube renames wrappers periodically; a
+ *     chain survives one rename, a single selector does not.
+ *  2. THE GENERIC `[href^="/shorts/"]` MEMBER IS A **FALLBACK**. It survives almost any
+ *     wrapper rename but only hides the anchor, not the card around it — degraded, not
+ *     correct. Whenever it is the only thing that matched we emit a loud console.warn:
+ *     silent degradation is how a blocker quietly stops blocking. It lives in its own
+ *     terminal surface (`SHORTS_FALLBACK_SURFACE`) rather than at the end of every chain,
+ *     because a chain-tail fallback fires on any page that simply lacks that surface —
+ *     and a warning that cries wolf on a healthy page is a warning nobody reads.
+ *  3. ATTRIBUTE-ANCHORED over class-anchored. `ytd-*` tag names and `[is-shorts]` /
+ *     `[href^=]` attributes are comparatively stable; build-hashed classes are not.
+ *
+ * PURE + ZERO NETWORK. Every selector is bundled at build time. We never fetch a remote
+ * selector list — even though CWS policy would permit remote *data*, "zero network
+ * requests" is a listed trust claim for this extension (ext-07 non-negotiables).
+ *
+ * Fixture tests live in tests/content/selectors.test.ts so that upstream YouTube churn
+ * fails CI rather than users (ext-03 §6 pattern 4).
+ */
+
+/** YouTube surfaces that get their own selector map — one breaking doesn't break the rest. */
+export type YoutubePageType =
+  | 'home'
+  | 'subscriptions'
+  | 'search'
+  | 'channel'
+  | 'watch'
+  | 'shorts'
+  | 'other';
+
+/** One rung of a chain. */
+export interface SelectorRule {
+  selector: string;
+  /**
+   * A generic catch-all kept only so a wrapper rename degrades instead of failing shut.
+   * Matching ONLY on a fallback is a signal that YouTube's DOM moved — it warns.
+   */
+  fallback?: boolean;
+  /** Why this rung exists, for the next person reading a broken selector. */
+  note?: string;
+}
+
+/** A named Shorts surface plus the ordered selector chain that finds it. */
+export interface ShortsSurface {
+  /** Stable id — used in warnings and tests, safe to grep. */
+  id: string;
+  description: string;
+  chain: SelectorRule[];
+}
+
+/** The class we toggle to hide things. Also defined in youtube.css. */
+export const HIDDEN_CLASS = 'nudge-hidden';
+
+/** The generic catch-all (ext-03 §1). Always the LAST rung, and always `fallback`. */
+export const SHORTS_HREF_FALLBACK: SelectorRule = {
+  selector: '[href^="/shorts/"]',
+  fallback: true,
+  note: 'Generic catch-all (ext-03 §1). Survives wrapper renames but only hides the anchor.',
+};
+
+/**
+ * The terminal surface, tried after every specific surface on the page.
+ *
+ * It hides anything that links to a Short and that no specific selector already covered —
+ * which is exactly the "YouTube renamed its wrappers" state, and exactly when the loud
+ * warning is warranted. `applyShortsHiding` owns that "already covered" test, which is
+ * why the warn sink is injectable: the caller decides whether a fallback match is news.
+ */
+export const SHORTS_FALLBACK_SURFACE: ShortsSurface = {
+  id: 'shorts-fallback',
+  description: 'Generic catch-all for Shorts links no specific selector covered',
+  chain: [SHORTS_HREF_FALLBACK],
+};
+
+/** Shelves: a horizontal row of Shorts embedded in a feed. */
+const SHELF_SURFACE: ShortsSurface = {
+  id: 'shorts-shelf',
+  description: 'Horizontal Shorts shelf embedded in a feed',
+  chain: [
+    {
+      selector: 'ytd-rich-section-renderer:has(>div>ytd-rich-shelf-renderer)',
+      note: 'Home/subscriptions shelf wrapper (Vulpelo).',
+    },
+    {
+      selector: 'ytd-rich-shelf-renderer[is-shorts]',
+      note: 'Attribute-anchored shelf (FocusTube, sanersocialmedia).',
+    },
+    { selector: 'ytd-reel-shelf-renderer', note: 'Shelf variant used on search results.' },
+    { selector: 'grid-shelf-view-model', note: 'Newer extendable shelf view-model.' },
+  ],
+};
+
+/** Grid groups: the block that wraps a Shorts row in the rich grid feed. */
+const GRID_GROUP_SURFACE: ShortsSurface = {
+  id: 'shorts-grid-group',
+  description: 'Rich-grid group containing Shorts',
+  chain: [
+    {
+      selector: 'ytd-rich-grid-group:has(a[href^="/shorts/"])',
+      note: 'Shorts container in the home/subscriptions feed (Vulpelo).',
+    },
+    { selector: 'ytd-rich-grid-group[is-shorts]' },
+  ],
+};
+
+/** Individual Shorts cards scattered through a feed / sidebar / search results. */
+function cardSurface(cardSelectors: string[]): ShortsSurface {
+  return {
+    id: 'shorts-cards',
+    description: 'Individual Shorts video cards',
+    chain: cardSelectors.map((tag) => ({
+      selector: `${tag}:has(a[href^="/shorts/"])`,
+      note: `${tag} card whose thumbnail links to a Short.`,
+    })),
+  };
+}
+
+/** The Shorts entry in the left navigation (full guide + collapsed mini guide). */
+const NAV_SURFACE: ShortsSurface = {
+  id: 'shorts-nav',
+  description: 'Shorts entry in the left navigation rail',
+  chain: [
+    {
+      selector: "ytd-mini-guide-entry-renderer>a[href='/shorts/']",
+      note: 'Collapsed mini-guide Shorts tab (Vulpelo).',
+    },
+    {
+      selector: 'ytd-guide-entry-renderer:has(>a[href="/shorts/"])',
+      note: 'Expanded guide Shorts tab.',
+    },
+    { selector: 'a[title="Shorts"]', note: 'Title-anchored nav link (FocusTube).' },
+  ],
+};
+
+/**
+ * Per-page-type selector maps (ext-03 §6 pattern 5). A page type that breaks upstream
+ * only takes its own surfaces down with it.
+ *
+ * These are the SPECIFIC surfaces only — `SHORTS_FALLBACK_SURFACE` is applied after them,
+ * on every page type.
+ *
+ * The `/shorts/*` player page has no hiding surfaces of its own beyond the nav — it is
+ * *gated* by the interstitial overlay in youtube.ts instead, because there is nothing
+ * left to browse once you hide the player.
+ */
+export const SHORTS_SURFACES: Record<YoutubePageType, ShortsSurface[]> = {
+  home: [
+    SHELF_SURFACE,
+    GRID_GROUP_SURFACE,
+    cardSurface(['ytd-rich-item-renderer']),
+    NAV_SURFACE,
+  ],
+  subscriptions: [
+    SHELF_SURFACE,
+    GRID_GROUP_SURFACE,
+    cardSurface(['ytd-rich-item-renderer', 'ytd-grid-video-renderer']),
+    NAV_SURFACE,
+  ],
+  search: [
+    SHELF_SURFACE,
+    cardSurface(['ytd-video-renderer', 'ytd-rich-item-renderer']),
+    NAV_SURFACE,
+  ],
+  channel: [
+    SHELF_SURFACE,
+    GRID_GROUP_SURFACE,
+    cardSurface(['ytd-rich-item-renderer', 'ytd-grid-video-renderer']),
+    NAV_SURFACE,
+  ],
+  watch: [
+    SHELF_SURFACE,
+    cardSurface(['ytd-compact-video-renderer', 'ytd-rich-item-renderer']),
+    NAV_SURFACE,
+  ],
+  shorts: [NAV_SURFACE],
+  other: [NAV_SURFACE],
+};
+
+/** Where the Shorts player mounts — the overlay anchors here, falling back to <body>. */
+export const SHORTS_PLAYER_CONTAINERS: SelectorRule[] = [
+  { selector: 'ytd-shorts', note: 'The Shorts player host element.' },
+  { selector: '#shorts-player' },
+  { selector: 'ytd-reel-video-renderer' },
+  { selector: 'body', fallback: true, note: 'Always present; overlay still covers the viewport.' },
+];
+
+/** Elements Nudge itself injects, so we never hide our own overlay. */
+export const NUDGE_OVERLAY_ID = 'nudge-shorts-gate';
+
+export interface QueryResult {
+  /** Everything the first matching rung matched. Empty when nothing in the chain matched. */
+  elements: Element[];
+  /** The selector string that matched, or null when the whole chain missed. */
+  matchedSelector: string | null;
+  /** True when the ONLY rung that matched was flagged `fallback`. */
+  usedFallback: boolean;
+}
+
+/** Injectable so tests can assert the warning fired without polluting test output. */
+export type WarnFn = (message: string) => void;
+
+const warnedSelectors = new Set<string>();
+
+/**
+ * Default warning sink: one loud console.warn per selector per page load.
+ *
+ * Deduped because the MutationObserver re-runs the chains constantly — an undeduped
+ * warning would be a console flood, and a flooded console is an ignored console.
+ */
+export const defaultWarn: WarnFn = (message) => {
+  if (warnedSelectors.has(message)) return;
+  warnedSelectors.add(message);
+  console.warn(message);
+};
+
+/** Test/reset seam for the dedupe set. */
+export function resetFallbackWarnings(): void {
+  warnedSelectors.clear();
+}
+
+/** The exact warning text, so tests assert on one definition rather than a copy. */
+export function fallbackWarningMessage(surfaceId: string, selector: string): string {
+  return (
+    `[nudge] YouTube DOM changed: the "${surfaceId}" surface only matched the fallback ` +
+    `selector \`${selector}\`. Shorts hiding is running in degraded mode (the link is ` +
+    `hidden, its card is not). Please report this at ` +
+    `https://github.com/astraedus/nudge/issues so the selector chain can be updated.`
+  );
+}
+
+/**
+ * Run one selector chain against `root`, first rung that matches wins.
+ *
+ * Chains are ordered specific -> generic, so "first match wins" means "most precise
+ * available selector". When the winner is a `fallback` rung we warn loudly instead of
+ * silently degrading (ext-03 §6 pattern 2).
+ */
+export function queryWithFallback(
+  root: ParentNode,
+  chain: readonly SelectorRule[],
+  options: { surfaceId?: string; warn?: WarnFn } = {},
+): QueryResult {
+  const { surfaceId = 'unknown', warn = defaultWarn } = options;
+
+  for (const rule of chain) {
+    let matches: Element[];
+    try {
+      matches = Array.from(root.querySelectorAll(rule.selector));
+    } catch {
+      // A selector the engine cannot parse (e.g. `:has()` on an ancient browser) must
+      // never abort the chain — skip the rung and keep going.
+      continue;
+    }
+    if (matches.length === 0) continue;
+
+    if (rule.fallback) {
+      warn(fallbackWarningMessage(surfaceId, rule.selector));
+    }
+    return {
+      elements: matches,
+      matchedSelector: rule.selector,
+      usedFallback: rule.fallback === true,
+    };
+  }
+
+  return { elements: [], matchedSelector: null, usedFallback: false };
+}
+
+/**
+ * `/shorts`, `/shorts/`, `/shorts/<id>` — "shorts" must be a WHOLE first path segment.
+ * `/shortsomething` and `/watch` are not Shorts no matter what else the URL says.
+ */
+const SHORTS_PATH = /^\/shorts(\/|$)/;
+const CHANNEL_PATH = /^\/(channel|c|user)\//;
+
+/**
+ * Classify a YouTube URL by *pathname only*.
+ *
+ * Pathname-only is the point: a video merely titled "shorts", or a search for the word,
+ * puts "shorts" in the query string or the page title — never in the first path segment.
+ * Matching those would gate an ordinary watch page.
+ */
+export function pageTypeFor(url: string): YoutubePageType {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'other';
+  }
+  if (!/(^|\.)youtube\.com$/.test(parsed.hostname)) return 'other';
+
+  const path = parsed.pathname.replace(/\/+$/, '') || '/';
+
+  if (SHORTS_PATH.test(parsed.pathname)) return 'shorts';
+  if (path === '/watch') return 'watch';
+  if (path === '/results') return 'search';
+  if (path === '/feed/subscriptions') return 'subscriptions';
+  if (path === '/') return 'home';
+  if (CHANNEL_PATH.test(parsed.pathname) || parsed.pathname.startsWith('/@')) return 'channel';
+  return 'other';
+}

--- a/extension/src/content/youtube.css
+++ b/extension/src/content/youtube.css
@@ -1,0 +1,172 @@
+/*
+ * Static CSS for the YouTube content script.
+ *
+ * WHY STATIC, AND WHY THE MANIFEST: the entrypoint imports this file with
+ * `cssInjectionMode: 'manifest'`, so WXT emits it into the content script's `css` array.
+ * Chrome guarantees manifest CSS is injected "before any DOM is constructed", regardless
+ * of `run_at` — that is the ONLY FOUC-safe mechanism available (ext-03 §4/§6). Injecting
+ * the same rules from JS at document_idle would let a Shorts shelf paint first and then
+ * vanish, which is exactly the flash LeechBlockNG gets criticised for.
+ *
+ * REMOTE CSS IS IMPOSSIBLE HERE, BY POLICY AND BY PLATFORM: manifest `content_scripts.css`
+ * cannot point at a remote URL, and Chrome Web Store policy bans remote code outright.
+ * Nudge additionally makes ZERO network requests of any kind — this file ships in the
+ * bundle, forever, and nothing about it is fetched at runtime.
+ *
+ * Palette: Nudge teal. Light primary #1B6B5A, dark primary #8BD6C1 (ext-07 Brand).
+ * Iconography: none. No emoji-as-icon anywhere.
+ */
+
+/* The one hiding mechanism. A class toggle, never node removal — hiding is reversible
+ * the instant the user flips the setting off, and YouTube's virtual DOM keeps ownership
+ * of its own elements. `!important` because YouTube sets inline display on feed items. */
+.nudge-hidden {
+  display: none !important;
+}
+
+/* ------------------------------------------------------------------ overlay */
+
+#nudge-shorts-gate.nudge-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483647; /* above YouTube's own full-screen layers */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(9, 20, 18, 0.92);
+  backdrop-filter: blur(6px);
+  font-family:
+    'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  color: #fbfdf9;
+  -webkit-font-smoothing: antialiased;
+}
+
+.nudge-overlay__card {
+  box-sizing: border-box;
+  width: min(420px, 100%);
+  padding: 32px 28px;
+  border-radius: 28px;
+  background: #12201d;
+  border: 1px solid rgba(139, 214, 193, 0.24);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+  text-align: center;
+}
+
+.nudge-overlay__title {
+  margin: 0 0 8px;
+  font-size: 26px;
+  line-height: 1.2;
+  font-weight: 700;
+  color: #8bd6c1;
+}
+
+.nudge-overlay__subtitle {
+  margin: 0 0 24px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: rgba(251, 253, 249, 0.76);
+}
+
+/* Delay: the countdown. Big, calm, and the only thing moving. */
+.nudge-overlay__count {
+  margin: 0 auto 24px;
+  width: 132px;
+  height: 132px;
+  border-radius: 50%;
+  border: 4px solid rgba(139, 214, 193, 0.28);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 46px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #8bd6c1;
+  background: rgba(27, 107, 90, 0.22);
+}
+
+/* Breathing: a 4s-in / 4s-out cycle. The class is toggled from JS so the phase label and
+ * the circle can never drift apart the way two independent animations would. */
+.nudge-overlay__breath {
+  margin: 0 auto 16px;
+  width: 132px;
+  height: 132px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(139, 214, 193, 0.34), rgba(27, 107, 90, 0.2));
+  border: 2px solid rgba(139, 214, 193, 0.4);
+  transform: scale(0.68);
+  transition: transform 4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.nudge-overlay__breath--in {
+  transform: scale(1);
+}
+
+.nudge-overlay__phase {
+  margin-bottom: 16px;
+  font-size: 15px;
+  letter-spacing: 0.04em;
+  color: rgba(251, 253, 249, 0.8);
+}
+
+.nudge-overlay__progress {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(139, 214, 193, 0.18);
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.nudge-overlay__bar {
+  height: 100%;
+  width: 0;
+  border-radius: 999px;
+  background: #8bd6c1;
+  transition: width 200ms linear;
+}
+
+.nudge-overlay__remaining {
+  margin-bottom: 24px;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: rgba(251, 253, 249, 0.6);
+}
+
+/* "I changed my mind" — Android parity wording, and the primary action here on purpose. */
+.nudge-overlay__bail {
+  display: block;
+  width: 100%;
+  padding: 14px 24px;
+  border: none;
+  border-radius: 999px;
+  background: #1b6b5a;
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.nudge-overlay__bail:hover {
+  opacity: 0.88;
+}
+
+.nudge-overlay__bail:focus-visible {
+  outline: 2px solid #8bd6c1;
+  outline-offset: 3px;
+}
+
+/* Rule transparency footer — Android parity: always say which rule is acting. */
+.nudge-overlay__footer {
+  margin: 16px 0 0;
+  font-size: 12px;
+  color: rgba(251, 253, 249, 0.45);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nudge-overlay__breath,
+  .nudge-overlay__bar {
+    transition: none;
+  }
+}

--- a/extension/src/content/youtube.ts
+++ b/extension/src/content/youtube.ts
@@ -1,0 +1,463 @@
+/**
+ * The YouTube content script's logic. Importable and unit-testable WITHOUT a browser:
+ * every DOM-touching export takes its root/config as an argument, and only
+ * `initYoutubeContentScript()` reaches for `chrome.*` or global listeners.
+ *
+ * Why a content script exists at all: declarativeNetRequest cannot see YouTube's
+ * client-side navigation. Swiping from one Short to the next never fires a network
+ * request DNR can match, so a rule-only blocker just... stops blocking (ext-03 §2,
+ * confirmed by LeechBlockNG#17). The SPA detection below is that gap, closed.
+ *
+ * Two jobs:
+ *  1. HIDE Shorts surfaces (`hideShortsShelf`) by toggling a CSS class — never by
+ *     removing nodes, so flipping the setting off restores the page instantly and we
+ *     never fight YouTube's virtual DOM over ownership of an element we deleted.
+ *  2. GATE the `/shorts/*` player (`shortsMode` != 'ALLOW') with an in-page interstitial
+ *     overlay. We do NOT navigate away: a redirect races YouTube's router, and the whole
+ *     product thesis is friction-with-a-choice, not a wall.
+ *
+ * `shortsMode` arrives already resolved by the service worker (the 'INHERIT' case is
+ * decided there by running the block engine against the youtube.com site rule) — this
+ * module must never re-implement inheritance.
+ */
+
+import type { YoutubeConfig } from '../core/protocol';
+import { MODE_LABELS } from '../core/types';
+import { send } from '../ui/rpc';
+import {
+  HIDDEN_CLASS,
+  NUDGE_OVERLAY_ID,
+  SHORTS_FALLBACK_SURFACE,
+  SHORTS_PLAYER_CONTAINERS,
+  SHORTS_SURFACES,
+  defaultWarn,
+  pageTypeFor,
+  queryWithFallback,
+  type WarnFn,
+  type YoutubePageType,
+} from './selectors';
+
+/** Debounce for DOM re-checks. Long enough to batch YouTube's mutation storms. */
+export const DOM_DEBOUNCE_MS = 250;
+/** Safety-net poll for the case where every event AND the observer miss (ext-03 §2). */
+export const SAFETY_NET_MS = 1000;
+/** Breathing cycle: 4s in, 4s out (Android parity). */
+export const BREATH_IN_MS = 4000;
+export const BREATH_OUT_MS = 4000;
+
+/** Exact Android wording. Do not "improve" this string. */
+export const BAIL_LABEL = 'I changed my mind';
+/** Where the bail button sends the user. */
+export const BAIL_URL = 'https://www.youtube.com/';
+
+/**
+ * `chrome` is absent in unit tests and in any non-extension context. Reading it through
+ * `globalThis` keeps a missing global a soft `undefined` instead of a ReferenceError.
+ */
+const chromeApi: typeof chrome | undefined = (globalThis as { chrome?: typeof chrome })
+  .chrome;
+
+/** The URL of whatever document `root` belongs to. */
+function documentUrl(root: Document | Element): string {
+  const doc = root.ownerDocument ?? (root as Document);
+  return doc.location?.href ?? '';
+}
+
+export interface HidingResult {
+  /** Elements newly given the hidden class this pass. */
+  hidden: number;
+  /** Elements whose hidden class was removed this pass. */
+  revealed: number;
+  /** Surfaces that only matched via their generic fallback selector. */
+  degradedSurfaces: string[];
+}
+
+/**
+ * Add/remove the hidden class across every Shorts surface for this page type.
+ *
+ * Reversible by construction: when hiding is off (or Nudge is globally off) we sweep
+ * `.nudge-hidden` and clear it, so a toggle flip restores the page without a reload.
+ */
+export function applyShortsHiding(
+  root: Document | Element,
+  config: Pick<YoutubeConfig, 'enabled' | 'hideShortsShelf'>,
+  options: { pageType?: YoutubePageType; url?: string; warn?: WarnFn } = {},
+): HidingResult {
+  const { warn = defaultWarn } = options;
+  const result: HidingResult = { hidden: 0, revealed: 0, degradedSurfaces: [] };
+
+  if (!config.enabled || !config.hideShortsShelf) {
+    for (const element of Array.from(root.querySelectorAll(`.${HIDDEN_CLASS}`))) {
+      element.classList.remove(HIDDEN_CLASS);
+      result.revealed += 1;
+    }
+    return result;
+  }
+
+  const pageType = options.pageType ?? pageTypeFor(options.url ?? documentUrl(root));
+  const covered: Element[] = [];
+
+  function hide(elements: readonly Element[]): number {
+    let count = 0;
+    for (const element of elements) {
+      // Never hide our own overlay, whatever a selector claims.
+      if (element.id === NUDGE_OVERLAY_ID || element.closest(`#${NUDGE_OVERLAY_ID}`)) continue;
+      covered.push(element);
+      if (element.classList.contains(HIDDEN_CLASS)) continue;
+      element.classList.add(HIDDEN_CLASS);
+      count += 1;
+    }
+    return count;
+  }
+
+  for (const surface of SHORTS_SURFACES[pageType]) {
+    const { elements, usedFallback } = queryWithFallback(root, surface.chain, {
+      surfaceId: surface.id,
+      warn,
+    });
+    if (usedFallback) result.degradedSurfaces.push(surface.id);
+    result.hidden += hide(elements);
+  }
+
+  // The catch-all, last. It matches every anchor pointing at a Short — including ones the
+  // specific surfaces already swallowed — so we only treat the leftovers as evidence, and
+  // only warn if there ARE leftovers. That is the difference between "YouTube renamed a
+  // wrapper" (real news) and "this page has no Shorts shelf" (Tuesday).
+  let deferredWarning: string | null = null;
+  const catchAll = queryWithFallback(root, SHORTS_FALLBACK_SURFACE.chain, {
+    surfaceId: SHORTS_FALLBACK_SURFACE.id,
+    warn: (message) => {
+      deferredWarning = message;
+    },
+  });
+  const uncovered = catchAll.elements.filter(
+    (element) => !covered.some((seen) => seen === element || seen.contains(element)),
+  );
+  if (uncovered.length > 0) {
+    result.hidden += hide(uncovered);
+    result.degradedSurfaces.push(SHORTS_FALLBACK_SURFACE.id);
+    if (deferredWarning !== null) warn(deferredWarning);
+  }
+
+  return result;
+}
+
+/** True when this URL is a Shorts surface AND the resolved mode is not 'ALLOW'. */
+export function shouldGateShorts(
+  url: string,
+  config: Pick<YoutubeConfig, 'enabled' | 'shortsMode'>,
+): boolean {
+  if (!config.enabled) return false;
+  if (config.shortsMode === 'ALLOW') return false;
+  return pageTypeFor(url) === 'shorts';
+}
+
+/* ------------------------------------------------------------------ overlay */
+
+interface OverlayHandle {
+  element: HTMLElement;
+  /** Clears every timer this overlay owns. */
+  dispose: () => void;
+}
+
+/** Copy for the interstitial, mode by mode. Android microcopy parity. */
+function gateCopy(mode: Exclude<YoutubeConfig['shortsMode'], 'ALLOW'>): {
+  title: string;
+  subtitle: string;
+} {
+  switch (mode) {
+    case 'HARD_BLOCK':
+      return {
+        title: 'Shorts is blocked',
+        subtitle: 'You asked Nudge to keep you out of here. Still true?',
+      };
+    case 'BREATHING':
+      return { title: 'Take a breath', subtitle: 'Follow the circle. Shorts will wait.' };
+    case 'DELAY':
+    default:
+      return { title: 'Hold on a second', subtitle: 'Still want to watch Shorts?' };
+  }
+}
+
+/**
+ * Build the interstitial. Markup is deliberately tiny and self-contained: styles live in
+ * youtube.css (injected via the manifest, so it is on the page before YouTube paints).
+ *
+ * `onComplete` fires when a Delay/Breathing pause elapses. HARD_BLOCK never calls it —
+ * its only exit is the bail button.
+ */
+export function createShortsOverlay(
+  doc: Document,
+  config: Pick<YoutubeConfig, 'shortsMode' | 'shortsDelaySeconds'>,
+  handlers: { onComplete: () => void; onBail: () => void },
+): OverlayHandle {
+  const mode = config.shortsMode === 'ALLOW' ? 'HARD_BLOCK' : config.shortsMode;
+  const copy = gateCopy(mode);
+  const timers: number[] = [];
+
+  const overlay = doc.createElement('div');
+  overlay.id = NUDGE_OVERLAY_ID;
+  overlay.className = 'nudge-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-label', `Nudge — ${MODE_LABELS[mode]}`);
+
+  const card = doc.createElement('div');
+  card.className = 'nudge-overlay__card';
+
+  const title = doc.createElement('h1');
+  title.className = 'nudge-overlay__title';
+  title.textContent = copy.title;
+
+  const subtitle = doc.createElement('p');
+  subtitle.className = 'nudge-overlay__subtitle';
+  subtitle.textContent = copy.subtitle;
+
+  card.append(title, subtitle);
+
+  if (mode === 'DELAY') {
+    const seconds = Math.max(1, Math.round(config.shortsDelaySeconds));
+    const counter = doc.createElement('div');
+    counter.className = 'nudge-overlay__count';
+    counter.textContent = String(seconds);
+    card.append(counter);
+
+    let remaining = seconds;
+    const tick = doc.defaultView?.setInterval(() => {
+      remaining -= 1;
+      counter.textContent = String(Math.max(0, remaining));
+      if (remaining <= 0) {
+        clearAll();
+        handlers.onComplete();
+      }
+    }, 1000);
+    if (tick !== undefined) timers.push(tick);
+  } else if (mode === 'BREATHING') {
+    const circle = doc.createElement('div');
+    circle.className = 'nudge-overlay__breath';
+    const phase = doc.createElement('div');
+    phase.className = 'nudge-overlay__phase';
+    phase.textContent = 'Breathe in';
+    const remainingLabel = doc.createElement('div');
+    remainingLabel.className = 'nudge-overlay__remaining';
+
+    const totalMs = Math.max(1, Math.round(config.shortsDelaySeconds)) * 1000;
+    const startedAt = Date.now();
+    remainingLabel.textContent = `${Math.ceil(totalMs / 1000)}s remaining`;
+
+    const progress = doc.createElement('div');
+    progress.className = 'nudge-overlay__progress';
+    const bar = doc.createElement('div');
+    bar.className = 'nudge-overlay__bar';
+    progress.append(bar);
+
+    card.append(circle, phase, progress, remainingLabel);
+
+    const cycle = BREATH_IN_MS + BREATH_OUT_MS;
+    const tick = doc.defaultView?.setInterval(() => {
+      const elapsed = Date.now() - startedAt;
+      const left = Math.max(0, totalMs - elapsed);
+      remainingLabel.textContent = `${Math.ceil(left / 1000)}s remaining`;
+      bar.style.width = `${Math.min(100, (elapsed / totalMs) * 100)}%`;
+      const inhaling = elapsed % cycle < BREATH_IN_MS;
+      phase.textContent = inhaling ? 'Breathe in' : 'Breathe out';
+      circle.classList.toggle('nudge-overlay__breath--in', inhaling);
+      if (left <= 0) {
+        clearAll();
+        handlers.onComplete();
+      }
+    }, 200);
+    if (tick !== undefined) timers.push(tick);
+  }
+
+  const bail = doc.createElement('button');
+  bail.type = 'button';
+  bail.className = 'nudge-overlay__bail';
+  bail.textContent = BAIL_LABEL;
+  bail.addEventListener('click', () => {
+    clearAll();
+    handlers.onBail();
+  });
+  card.append(bail);
+
+  const footer = doc.createElement('p');
+  footer.className = 'nudge-overlay__footer';
+  footer.textContent = `Rule: YouTube Shorts · ${MODE_LABELS[mode]}`;
+  card.append(footer);
+
+  overlay.append(card);
+
+  function clearAll(): void {
+    for (const id of timers.splice(0)) doc.defaultView?.clearInterval(id);
+  }
+
+  return {
+    element: overlay,
+    dispose: () => {
+      clearAll();
+      overlay.remove();
+    },
+  };
+}
+
+/** Anchor the overlay over the player (falls back to <body>, which still covers the view). */
+function overlayHost(doc: Document): Element {
+  const { elements } = queryWithFallback(doc, SHORTS_PLAYER_CONTAINERS, {
+    surfaceId: 'shorts-player',
+    // The `body` rung is a legitimate anchor, not DOM churn — don't cry wolf.
+    warn: () => {},
+  });
+  return elements[0] ?? doc.body;
+}
+
+/** Pause any playing media so the interstitial isn't just a lid over a running video. */
+function pauseMedia(doc: Document): void {
+  for (const video of Array.from(doc.querySelectorAll('video'))) {
+    try {
+      (video as HTMLVideoElement).pause();
+    } catch {
+      // jsdom and some embeds throw on pause(); the overlay still stands.
+    }
+  }
+}
+
+/* --------------------------------------------------------------- controller */
+
+export interface YoutubeController {
+  /** Force a re-check (also what the SPA listeners call). */
+  refresh: () => void;
+  /** Re-read config from the service worker, then refresh. */
+  reload: () => Promise<void>;
+  /** Detach every listener, timer and overlay. */
+  stop: () => void;
+}
+
+const IDLE_CONFIG: YoutubeConfig = {
+  enabled: false,
+  hideShortsShelf: false,
+  shortsMode: 'ALLOW',
+  shortsDelaySeconds: 15,
+};
+
+/**
+ * Wire everything up on a real page.
+ *
+ * 3-layer SPA navigation detection (ext-03 §2 — two independent OSS blockers converged
+ * on exactly this, and one-layer designs are the documented failure):
+ *   1. `yt-navigate-finish` on document — YouTube's own post-route-change event (primary)
+ *   2. `popstate` — back/forward, which YouTube does not always announce (secondary)
+ *   3. debounced MutationObserver + a slow interval — the safety net for lazy-loaded
+ *      feed cards and for the day YouTube renames its event.
+ *
+ * The observer callback does nothing but schedule: heavy work inside a mutation callback
+ * on YouTube is a guaranteed jank complaint (ext-03 §4).
+ */
+export function initYoutubeContentScript(
+  doc: Document = document,
+  fetchConfig: () => Promise<YoutubeConfig> = () => send({ type: 'GET_YOUTUBE_CONFIG' }),
+): YoutubeController {
+  const view = doc.defaultView;
+  let config: YoutubeConfig = IDLE_CONFIG;
+  let overlay: OverlayHandle | null = null;
+  /** Set once a pause is completed; cleared as soon as we leave the Shorts surface. */
+  let gateSatisfied = false;
+  let lastUrl = doc.location?.href ?? '';
+  let debounceTimer: number | undefined;
+  let stopped = false;
+
+  function currentHref(): string {
+    return doc.location?.href ?? '';
+  }
+
+  function teardownOverlay(): void {
+    overlay?.dispose();
+    overlay = null;
+  }
+
+  function refresh(): void {
+    if (stopped) return;
+
+    const url = currentHref();
+    if (url !== lastUrl) {
+      lastUrl = url;
+      // Leaving Shorts resets the grant — coming back should cost you the pause again.
+      if (pageTypeFor(url) !== 'shorts') gateSatisfied = false;
+    }
+
+    applyShortsHiding(doc, config, { url });
+
+    if (!shouldGateShorts(url, config) || gateSatisfied) {
+      teardownOverlay();
+      return;
+    }
+    if (overlay?.element.isConnected) return;
+
+    teardownOverlay();
+    pauseMedia(doc);
+    overlay = createShortsOverlay(doc, config, {
+      onComplete: () => {
+        gateSatisfied = true;
+        teardownOverlay();
+      },
+      onBail: () => {
+        teardownOverlay();
+        doc.location.assign(BAIL_URL);
+      },
+    });
+    overlayHost(doc).append(overlay.element);
+  }
+
+  function scheduleRefresh(): void {
+    if (stopped || !view) return;
+    if (debounceTimer !== undefined) view.clearTimeout(debounceTimer);
+    debounceTimer = view.setTimeout(() => {
+      debounceTimer = undefined;
+      refresh();
+    }, DOM_DEBOUNCE_MS);
+  }
+
+  async function reload(): Promise<void> {
+    try {
+      config = await fetchConfig();
+    } catch {
+      // The service worker can be asleep or mid-reload. Stay in the last known state
+      // rather than failing open on a transient messaging error.
+      return;
+    }
+    refresh();
+  }
+
+  const onNavigate = (): void => scheduleRefresh();
+  doc.addEventListener('yt-navigate-finish', onNavigate);
+  view?.addEventListener('popstate', onNavigate);
+
+  const observer = view ? new view.MutationObserver(() => scheduleRefresh()) : null;
+  observer?.observe(doc.documentElement, { childList: true, subtree: true });
+
+  const safetyNet = view?.setInterval(() => {
+    if (currentHref() !== lastUrl) refresh();
+    else scheduleRefresh();
+  }, SAFETY_NET_MS);
+
+  const onStorageChanged = (): void => {
+    void reload();
+  };
+  chromeApi?.storage?.onChanged?.addListener(onStorageChanged);
+
+  void reload();
+
+  return {
+    refresh,
+    reload,
+    stop: () => {
+      stopped = true;
+      doc.removeEventListener('yt-navigate-finish', onNavigate);
+      view?.removeEventListener('popstate', onNavigate);
+      observer?.disconnect();
+      if (safetyNet !== undefined) view?.clearInterval(safetyNet);
+      if (debounceTimer !== undefined) view?.clearTimeout(debounceTimer);
+      chromeApi?.storage?.onChanged?.removeListener(onStorageChanged);
+      teardownOverlay();
+    },
+  };
+}

--- a/extension/src/core/blockEngine.ts
+++ b/extension/src/core/blockEngine.ts
@@ -1,0 +1,102 @@
+/**
+ * The block decision engine. PURE.
+ *
+ * Direct port of Android's `domain/engine/BlockEngine.kt`, preserving its priority order
+ * exactly:
+ *
+ *   unconditional HARD_BLOCK  >  daily budget exceeded (forces HARD_BLOCK)
+ *                             >  DELAY  >  BREATHING  >  Allow
+ *
+ * "Unconditional" means a HARD_BLOCK rule carrying no daily limit — it can never be
+ * satisfied by waiting, so it outranks everything. A budget-exceeded rule is escalated to
+ * HARD_BLOCK and its name suffixed "(limit reached)" (naming parity with Android).
+ */
+
+import { isScheduleActiveAt } from './scheduleEvaluator';
+import { ALLOW, block, type ActiveRule, type BlockDecision } from './types';
+
+/** Suffix appended to a rule's name when the block is caused by an exhausted budget. */
+export const LIMIT_REACHED_SUFFIX = ' (limit reached)';
+
+export function evaluate(
+  activeRules: readonly ActiveRule[],
+  dailyUsageMs: number,
+  now: Date = new Date(),
+): BlockDecision {
+  const applicable = activeRules.filter(
+    (rule) =>
+      rule.enabled &&
+      isScheduleActiveAt(
+        {
+          days: rule.scheduleDays,
+          startMinute: rule.scheduleStartMinute,
+          endMinute: rule.scheduleEndMinute,
+        },
+        now,
+      ),
+  );
+
+  if (applicable.length === 0) return ALLOW;
+
+  // The tightest budget among applicable rules drives the remaining-time readout.
+  const limits = applicable
+    .map((r) => r.dailyLimitMinutes)
+    .filter((l): l is number => l !== null);
+  const minDailyLimit = limits.length > 0 ? Math.min(...limits) : null;
+  const dailyTimeRemainingMs =
+    minDailyLimit !== null
+      ? Math.max(0, minDailyLimit * 60_000 - dailyUsageMs)
+      : null;
+
+  const unconditionalHardBlock = applicable.find(
+    (r) => r.mode === 'HARD_BLOCK' && r.dailyLimitMinutes === null,
+  );
+  if (unconditionalHardBlock) {
+    return block({
+      mode: 'HARD_BLOCK',
+      ruleName: unconditionalHardBlock.ruleName,
+      dailyTimeRemainingMs,
+      dailyLimitMinutes: minDailyLimit,
+    });
+  }
+
+  const budgetExceeded = applicable.find(
+    (r) => r.dailyLimitMinutes !== null && dailyUsageMs >= r.dailyLimitMinutes * 60_000,
+  );
+  if (budgetExceeded) {
+    return block({
+      mode: 'HARD_BLOCK',
+      ruleName:
+        budgetExceeded.ruleName === null
+          ? null
+          : `${budgetExceeded.ruleName}${LIMIT_REACHED_SUFFIX}`,
+      dailyTimeRemainingMs,
+      dailyLimitMinutes: minDailyLimit,
+      limitReached: true,
+    });
+  }
+
+  const delayRule = applicable.find((r) => r.mode === 'DELAY');
+  if (delayRule) {
+    return block({
+      mode: 'DELAY',
+      delaySeconds: delayRule.delaySeconds,
+      ruleName: delayRule.ruleName,
+      dailyTimeRemainingMs,
+      dailyLimitMinutes: minDailyLimit,
+    });
+  }
+
+  const breathingRule = applicable.find((r) => r.mode === 'BREATHING');
+  if (breathingRule) {
+    return block({
+      mode: 'BREATHING',
+      delaySeconds: breathingRule.delaySeconds,
+      ruleName: breathingRule.ruleName,
+      dailyTimeRemainingMs,
+      dailyLimitMinutes: minDailyLimit,
+    });
+  }
+
+  return ALLOW;
+}

--- a/extension/src/core/blockEngine.ts
+++ b/extension/src/core/blockEngine.ts
@@ -10,6 +10,12 @@
  * "Unconditional" means a HARD_BLOCK rule carrying no daily limit — it can never be
  * satisfied by waiting, so it outranks everything. A budget-exceeded rule is escalated to
  * HARD_BLOCK and its name suffixed "(limit reached)" (naming parity with Android).
+ *
+ * INVARIANT: if ANY rule applies, the verdict is a BLOCK. ALLOW is reserved for "no rule
+ * applies here". The browser makes this stricter than it is on Android: DNR has already
+ * redirected the navigation by the time the engine runs, so an ALLOW while a rule still
+ * applies bounces the user back to the site and straight into the redirect again — an
+ * infinite loop, not a no-op. Any new mode or qualifier MUST get its own branch below.
  */
 
 import { isScheduleActiveAt } from './scheduleEvaluator';
@@ -76,6 +82,23 @@ export function evaluate(
     });
   }
 
+  // A Hard Block rule that ALSO carries a daily limit, while still under that limit.
+  //
+  // A daily limit is meaningless on a Hard Block — the site is barred outright, so there is
+  // no browsing time to budget. Without this branch such a rule matched nothing above (it is
+  // not "unconditional", not over budget, and not DELAY/BREATHING) and fell through to
+  // ALLOW, while DNR kept redirecting the domain: block page -> ALLOW -> back to the site ->
+  // redirect, an infinite loop that also hammered the service worker.
+  const hardBlockWithLimit = applicable.find((r) => r.mode === 'HARD_BLOCK');
+  if (hardBlockWithLimit) {
+    return block({
+      mode: 'HARD_BLOCK',
+      ruleName: hardBlockWithLimit.ruleName,
+      dailyTimeRemainingMs,
+      dailyLimitMinutes: minDailyLimit,
+    });
+  }
+
   const delayRule = applicable.find((r) => r.mode === 'DELAY');
   if (delayRule) {
     return block({
@@ -98,5 +121,11 @@ export function evaluate(
     });
   }
 
+  // UNREACHABLE for a non-empty `applicable` list, and that is a load-bearing invariant:
+  // DNR redirects the domain regardless of mode, so an ALLOW returned while a rule still
+  // applies produces an infinite block-page <-> site redirect loop rather than a harmless
+  // "no block". Every BlockMode now has a branch above, so the only way here is
+  // `applicable.length === 0`. tests/core/blockEngine.test.ts drives the full
+  // mode x limit x usage matrix to keep it that way.
   return ALLOW;
 }

--- a/extension/src/core/budgets.ts
+++ b/extension/src/core/budgets.ts
@@ -1,0 +1,91 @@
+/**
+ * Daily-limit ("budget") math. PURE — zero chrome.* imports, no I/O.
+ *
+ * `SiteRule.dailyLimitMinutes` is `null` when a rule has no daily cap configured. Every
+ * function here treats `null` as "no limit" and propagates that meaning to its return
+ * value rather than special-casing it per call site.
+ *
+ * Boundary convention: "over budget" is `usedMs >= limitMs`, matching blockEngine.ts's
+ * budget-exceeded check (`dailyUsageMs >= r.dailyLimitMinutes * 60_000`) — exactly-at-the-
+ * limit already counts as over, it does not require usage to exceed the limit.
+ */
+
+import type { SiteRule } from './settingsSchema';
+
+const MS_PER_MINUTE = 60_000;
+
+/** Convert a daily limit in minutes to milliseconds. */
+export function limitMs(limitMinutes: number): number {
+  return limitMinutes * MS_PER_MINUTE;
+}
+
+/**
+ * Remaining budget in ms for a rule with the given limit and today's usage so far.
+ * `null` when no limit is set (unlimited budget). Floored at 0 — never negative, even once
+ * usage has overshot the limit.
+ */
+export function remainingMs(limitMinutes: number | null, usedMs: number): number | null {
+  if (limitMinutes === null) return null;
+  return Math.max(0, limitMs(limitMinutes) - usedMs);
+}
+
+/**
+ * True once usage has reached or passed the limit. Uses `>=` deliberately — exactly at the
+ * limit already counts as over, matching blockEngine.ts's `budgetExceeded` check. `false`
+ * when no limit is configured (an unlimited budget can never be "over").
+ */
+export function isOverBudget(limitMinutes: number | null, usedMs: number): boolean {
+  if (limitMinutes === null) return false;
+  return usedMs >= limitMs(limitMinutes);
+}
+
+/**
+ * Fraction of the daily budget remaining, 0..1 (clamped both ends — usage past the limit
+ * still reads 0, never negative; unused budget reads 1, never above it). `null` when no
+ * limit is set.
+ */
+export function remainingFraction(limitMinutes: number | null, usedMs: number): number | null {
+  if (limitMinutes === null) return null;
+  const total = limitMs(limitMinutes);
+  if (total <= 0) return 0;
+  const used = Math.min(Math.max(0, usedMs), total);
+  return (total - used) / total;
+}
+
+/**
+ * The tightest (minimum) non-null `dailyLimitMinutes` across a set of rules — the cap that
+ * actually governs remaining-time readouts when several rules apply at once. `null` when
+ * none of the rules set a limit.
+ */
+export function tightestLimit(rules: readonly SiteRule[]): number | null {
+  let min: number | null = null;
+  for (const rule of rules) {
+    if (rule.dailyLimitMinutes === null) continue;
+    if (min === null || rule.dailyLimitMinutes < min) {
+      min = rule.dailyLimitMinutes;
+    }
+  }
+  return min;
+}
+
+/**
+ * True only on the accounting tick that pushes usage from under-limit to at-or-over-limit.
+ * This is what the background service uses to fire the mid-browsing "flip to blocked"
+ * transition exactly once, instead of on every periodic accounting tick after the limit is
+ * already exhausted.
+ *
+ * - `false` when `limitMinutes` is `null` (no limit, nothing to cross).
+ * - `false` when usage was already at/over the limit before this tick (no new transition).
+ * - `false` when usage is still under the limit after this tick (no transition yet).
+ * - `true` only when `previousUsedMs` was under the limit and `nextUsedMs` is at/over it.
+ */
+export function crossesLimit(
+  limitMinutes: number | null,
+  previousUsedMs: number,
+  nextUsedMs: number,
+): boolean {
+  if (limitMinutes === null) return false;
+  const wasOver = isOverBudget(limitMinutes, previousUsedMs);
+  const isOver = isOverBudget(limitMinutes, nextUsedMs);
+  return !wasOver && isOver;
+}

--- a/extension/src/core/domainMatcher.ts
+++ b/extension/src/core/domainMatcher.ts
@@ -1,0 +1,120 @@
+/**
+ * Domain extraction + matching. PURE.
+ *
+ * Direct port of Android's `domain/WebDomainMatcher.kt` (same normalization rules and
+ * the same known-subdomain set) so a rule for "youtube.com" behaves identically on both
+ * platforms. Extended only where the browser sees things Android's URL-bar reader never
+ * did: extension/internal schemes.
+ */
+
+/** Schemes that can never be a blockable site. */
+const INTERNAL_SCHEMES = new Set([
+  'chrome',
+  'chrome-extension',
+  'chrome-search',
+  'chrome-untrusted',
+  'about',
+  'edge',
+  'moz-extension',
+  'file',
+  'data',
+  'blob',
+  'javascript',
+  'view-source',
+  'devtools',
+]);
+
+/**
+ * Subdomains stripped when reducing a host to its base domain, so a rule on
+ * "youtube.com" also covers "www.youtube.com" and "m.youtube.com" (Android parity).
+ */
+const KNOWN_SUBDOMAINS = new Set(['www', 'm', 'mobile', 'l', 'lm']);
+
+/**
+ * Reduce a host to its base domain by stripping a single known subdomain prefix.
+ * "www.instagram.com" -> "instagram.com"; "m.youtube.com" -> "youtube.com";
+ * "instagram.com" -> "instagram.com"; "foo.bar.example.com" -> unchanged.
+ */
+export function normalizeToBaseDomain(host: string): string {
+  const lower = host.trim().toLowerCase();
+  const parts = lower.split('.');
+  if (parts.length <= 2) return lower;
+  if (KNOWN_SUBDOMAINS.has(parts[0]!)) {
+    return parts.slice(1).join('.');
+  }
+  return lower;
+}
+
+/**
+ * Extract the base domain from a URL or bare domain string.
+ *
+ * Returns null for blank input, internal/extension schemes, and anything without a dot
+ * (a bare hostname like "localhost" is not a blockable site).
+ */
+export function extractDomain(url: string): string | null {
+  const trimmed = url.trim();
+  if (trimmed === '') return null;
+
+  const schemeSep = trimmed.indexOf('://');
+  if (schemeSep > 0) {
+    const scheme = trimmed.slice(0, schemeSep).toLowerCase();
+    if (INTERNAL_SCHEMES.has(scheme)) return null;
+  } else {
+    // Scheme-relative forms without "://" (e.g. "about:blank", "javascript:void(0)").
+    const colon = trimmed.indexOf(':');
+    if (colon > 0 && INTERNAL_SCHEMES.has(trimmed.slice(0, colon).toLowerCase())) {
+      return null;
+    }
+  }
+
+  const withoutProtocol = schemeSep > 0 ? trimmed.slice(schemeSep + 3) : trimmed;
+
+  // Strip userinfo ("user:pass@host") before splitting on path separators.
+  const afterUserinfo = withoutProtocol.includes('@')
+    ? withoutProtocol.slice(withoutProtocol.indexOf('@') + 1)
+    : withoutProtocol;
+
+  const hostPart = afterUserinfo.split('/')[0]!.split('?')[0]!.split('#')[0]!;
+  const host = hostPart.split(':')[0]!.toLowerCase();
+
+  if (host === '' || !host.includes('.')) return null;
+  // Reject anything with characters a hostname can't contain — guards against a
+  // malformed string being treated as a site.
+  if (!/^[a-z0-9.-]+$/.test(host)) return null;
+
+  return normalizeToBaseDomain(host);
+}
+
+/**
+ * True when `url` belongs to `ruleDomain` — exact base-domain match after normalizing
+ * both sides, so "https://www.youtube.com/feed" matches a rule on "youtube.com".
+ */
+export function matchesDomain(url: string, ruleDomain: string): boolean {
+  const extracted = extractDomain(url);
+  if (extracted === null) return false;
+  const normalizedRule = normalizeToBaseDomain(ruleDomain);
+  if (normalizedRule === '') return false;
+  return extracted === normalizedRule;
+}
+
+/**
+ * The DNR `urlFilter` for a rule domain. `||domain.com^` is the standard
+ * "this domain and all its subdomains" anchored pattern, so www./m./any subdomain
+ * are covered by ONE rule (matching `normalizeToBaseDomain`'s intent).
+ */
+export function dnrUrlFilter(ruleDomain: string): string {
+  return `||${normalizeToBaseDomain(ruleDomain)}^`;
+}
+
+/**
+ * Normalize whatever the user typed in "add a site" into a storable rule domain.
+ * Accepts "youtube.com", "https://www.youtube.com/feed", "m.youtube.com".
+ * Returns null when the input can't be read as a site.
+ */
+export function normalizeUserInput(input: string): string | null {
+  const direct = extractDomain(input);
+  if (direct !== null) return direct;
+  // A user may type a bare host with a path but no scheme and no dot survives —
+  // nothing more to recover, treat as invalid.
+  return null;
+}

--- a/extension/src/core/emergencyPass.ts
+++ b/extension/src/core/emergencyPass.ts
@@ -1,0 +1,112 @@
+/**
+ * The "2-minute daily pass" emergency escape hatch — ONE global free window per rolling 24h
+ * across the whole extension. PURE. Direct port of Android's `domain/emergency/EmergencyPass.kt`.
+ *
+ * Global (not per-site) semantics: using the pass on ANY blocked site opens a free window for
+ * that site AND locks the pass out for every site for `LOCKOUT_MS`. The active free window itself
+ * stays scoped to the site it was granted on (owned by the background service that calls this
+ * module); this file only decides eligibility (the shared lockout).
+ *
+ * Ledger shape: `Record<string, number>` — site/domain key -> epoch-millis last-used. A plain
+ * Record (not a Map) keeps this directly JSON-serializable for chrome.storage without a
+ * translation layer, matching the persisted-string ledger the Android original used
+ * (`key=epochMillis;…`) — [globalLastUsed] takes the MAX timestamp across ALL entries, so a
+ * pre-existing per-site ledger is interpreted as "last used = the most recent of any site." A
+ * fresh global use collapses the ledger to a single [GLOBAL_KEY] entry. The extension's analog of
+ * Android's "package" is a domain, but the ledger format and global semantics are unchanged.
+ *
+ * `parse` is deliberately lenient — any malformed entry is skipped and blank/garbage input yields
+ * an empty object, never an exception (persisted settings must never crash the block-decision path).
+ *
+ * No chrome.* imports — fully unit-testable under plain Node/vitest.
+ */
+
+/** Free window granted per use (2 minutes). */
+export const PASS_DURATION_MS = 120_000;
+
+/** Rolling global lockout after a use before the pass can be used again (24h). */
+export const LOCKOUT_MS = 86_400_000;
+
+/**
+ * Reserved ledger key holding the single global last-used timestamp after a fresh use. Not a
+ * real domain (domains never contain `*`), so it can never collide with a migrated per-site entry.
+ */
+export const GLOBAL_KEY = '*';
+
+const ENTRY_SEPARATOR = ';';
+const KEY_VALUE_SEPARATOR = '=';
+
+/** Matches an optionally-signed integer string — the numeric grammar `parse` accepts as a value. */
+const INTEGER_PATTERN = /^-?\d+$/;
+
+/** Deserialize the ledger. Malformed entries are ignored; blank input -> empty object. Never throws. */
+export function parse(raw: string): Record<string, number> {
+  const result: Record<string, number> = {};
+  if (raw.trim() === '') return result;
+
+  for (const entry of raw.split(ENTRY_SEPARATOR)) {
+    if (entry.trim() === '') continue;
+    const idx = entry.indexOf(KEY_VALUE_SEPARATOR);
+    // Require a non-empty key before '=' and a value after it.
+    if (idx <= 0 || idx === entry.length - 1) continue;
+    const key = entry.slice(0, idx);
+    const valueRaw = entry.slice(idx + 1);
+    if (!INTEGER_PATTERN.test(valueRaw)) continue;
+    const millis = Number(valueRaw);
+    if (!Number.isFinite(millis) || millis < 0) continue;
+    result[key] = millis;
+  }
+  return result;
+}
+
+/** Inverse of `parse`. Round-trips (blank keys are dropped defensively). */
+export function serialize(usage: Record<string, number>): string {
+  return Object.entries(usage)
+    .filter(([key]) => key.trim() !== '')
+    .map(([key, value]) => `${key}${KEY_VALUE_SEPARATOR}${value}`)
+    .join(ENTRY_SEPARATOR);
+}
+
+/**
+ * The global last-used timestamp: the MAX across ALL ledger entries. This makes the lockout
+ * global (any site's use counts) and migrates a legacy per-site ledger transparently. Null if the
+ * pass has never been used.
+ */
+export function globalLastUsed(usage: Record<string, number>): number | null {
+  const values = Object.values(usage);
+  if (values.length === 0) return null;
+  return Math.max(...values);
+}
+
+/**
+ * True once `cooldownMs` has elapsed since the pass was last used on ANY site (or it never was).
+ * Boundary is inclusive: exactly at `last + cooldownMs` this returns true.
+ */
+export function canUseGlobal(
+  usage: Record<string, number>,
+  now: number,
+  cooldownMs: number,
+): boolean {
+  const last = globalLastUsed(usage);
+  if (last === null) return true;
+  return now - last >= cooldownMs;
+}
+
+/** Remaining global lockout in ms (0 if available now). For the "Next pass in Xh" UI hint. */
+export function nextAvailableGlobalMs(
+  usage: Record<string, number>,
+  now: number,
+  cooldownMs: number,
+): number {
+  const last = globalLastUsed(usage);
+  if (last === null) return 0;
+  return Math.max(0, last + cooldownMs - now);
+}
+
+/**
+ * A fresh ledger recording a global use at `now`. Collapses to the single [GLOBAL_KEY] entry —
+ * previous per-site entries are dropped because the global timestamp already dominates them.
+ */
+export function recordGlobal(now: number): Record<string, number> {
+  return { [GLOBAL_KEY]: now };
+}

--- a/extension/src/core/messages.ts
+++ b/extension/src/core/messages.ts
@@ -1,0 +1,66 @@
+/**
+ * Rotating message pools shown on the block overlays. PURE. Port of Android's
+ * `ui/overlay/NudgeMessages.kt` (defaults + `resolvePool`).
+ *
+ * Ported VERBATIM except three strings swap the word "app" for "site" where it would read wrong
+ * in a browser context — each swap is called out against the Android original in a comment below.
+ *
+ * No chrome.* imports — fully unit-testable under plain Node/vitest.
+ */
+
+export const DEFAULT_DELAY_TITLES: string[] = [
+  'Take a moment to think...',
+  'Pause and reflect',
+  'Is this intentional?',
+  'Before you scroll...',
+  'A moment of awareness',
+];
+
+export const DEFAULT_DELAY_SUBTITLES: string[] = [
+  // Android: "Do you really need to open this app right now?"
+  'Do you really need to open this site right now?',
+  'What were you about to do instead?',
+  'Will this bring you closer to your goals?',
+  'You chose to add friction here for a reason.',
+  'This is your future self thanking you.',
+];
+
+export const DEFAULT_HARD_BLOCK_MESSAGES: string[] = [
+  // Android: "You've blocked access to this app"
+  "You've blocked access to this site",
+  // Android: "This app is off-limits right now"
+  'This site is off-limits right now',
+  'Your future self will thank you',
+  'Time to do something else',
+  'You set this boundary for a reason',
+];
+
+/**
+ * Resolves the pool of messages to display, given the user's custom text and the built-in
+ * `defaults`. Port of `NudgeMessages.resolvePool`.
+ *
+ * `customRaw` is one message per line — either a raw multiline string (as the Settings textarea
+ * produces) or an already-split array of lines (as persisted `NudgeSettings.messages` stores it).
+ * Lines are trimmed and blanks dropped. If the result is empty, falls back to `defaults`.
+ */
+export function resolvePool(customRaw: string | string[], defaults: string[]): string[] {
+  const lines = Array.isArray(customRaw) ? customRaw : customRaw.split('\n');
+  const cleaned = lines.map((line) => line.trim()).filter((line) => line.length > 0);
+  return cleaned.length > 0 ? cleaned : defaults;
+}
+
+/**
+ * Picks a random element from `pool`. `rng` is injectable for deterministic tests; defaults to
+ * `Math.random()` — this is display-only randomness (which message rotates in), never a
+ * commitment device, so `Math.random()` is an appropriate default here (unlike `strictMode.ts`'s
+ * `generate`, which never uses it).
+ */
+export function pickRandom<T>(pool: readonly T[], rng: () => number = Math.random): T {
+  if (pool.length === 0) {
+    throw new RangeError('pickRandom: pool must not be empty');
+  }
+  const index = Math.floor(rng() * pool.length);
+  const safeIndex = Math.min(pool.length - 1, Math.max(0, index));
+  // Safe: safeIndex is clamped into [0, pool.length) above, and pool.length > 0 was just checked.
+  return pool[safeIndex] as T;
+}

--- a/extension/src/core/protocol.ts
+++ b/extension/src/core/protocol.ts
@@ -1,0 +1,116 @@
+/**
+ * The typed runtime-message contract between the service worker and every UI surface
+ * (block page, popup, dashboard, onboarding) plus the YouTube content script. PURE.
+ *
+ * Every message is a discriminated union member keyed on `type`, and every request type
+ * maps to exactly one response type via `ResponseFor`, so a handler that returns the wrong
+ * shape is a compile error rather than a runtime surprise.
+ */
+
+import type { BlockDecision, BlockMode } from './types';
+import type { NudgeSettings, SiteRule } from './settingsSchema';
+
+/** Everything the block page needs to render, fetched in one round trip. */
+export interface BlockContext {
+  target: string;
+  domain: string;
+  decision: BlockDecision;
+  /** Message pools already resolved (custom overrides applied, defaults otherwise). */
+  delayTitle: string;
+  delaySubtitle: string;
+  hardBlockMessage: string;
+  /** "Escape Hatch" state. */
+  passEnabled: boolean;
+  passAvailable: boolean;
+  /** Remaining global lockout in ms; 0 when available. */
+  passNextAvailableMs: number;
+  strictModeEnabled: boolean;
+  tempAllowMinutes: number;
+}
+
+export interface PopupState {
+  globalEnabled: boolean;
+  /** Total tracked active seconds across all sites today. */
+  todayTotalSeconds: number;
+  /** The active tab's site, when it is a trackable http(s) page. */
+  currentDomain: string | null;
+  /** The rule covering the current domain, if any. */
+  currentRule: SiteRule | null;
+  /** Remaining daily budget in ms for the current domain; null when no limit is set. */
+  currentRemainingMs: number | null;
+  /** Active seconds spent on the current domain today. */
+  currentUsageSeconds: number;
+}
+
+/** A per-domain daily rollup. Stored in storage.local, never transmitted anywhere. */
+export interface DayUsage {
+  activeSec: number;
+  blocked: number;
+  walkedAway: number;
+  /** 24 buckets of active seconds, indexed by local hour. */
+  hourly: number[];
+}
+
+/** `yyyy-mm-dd` -> domain -> rollup. */
+export type UsageByDay = Record<string, Record<string, DayUsage>>;
+
+export interface DashboardState {
+  settings: NudgeSettings;
+  /** The last 7 local days including today, oldest first. */
+  recentDays: string[];
+  usage: UsageByDay;
+  allTimeBlocked: number;
+  allTimeWalkedAway: number;
+}
+
+export type Request =
+  | { type: 'GET_BLOCK_CONTEXT'; target: string }
+  | { type: 'COMPLETE_PAUSE'; target: string }
+  | { type: 'WALKED_AWAY'; target: string }
+  | { type: 'USE_EMERGENCY_PASS'; target: string }
+  | { type: 'GET_POPUP_STATE' }
+  | { type: 'GET_DASHBOARD_STATE' }
+  | { type: 'ADD_SITE'; domain: string; mode: BlockMode; delaySeconds: number }
+  | { type: 'SAVE_SETTINGS'; settings: NudgeSettings; challengeResponse?: string }
+  | { type: 'GET_SETTINGS' }
+  | { type: 'GET_YOUTUBE_CONFIG' };
+
+/** Granting temporary access, or refusing to. */
+export interface GrantResult {
+  ok: boolean;
+  /** Epoch ms the grant expires; 0 when refused. */
+  until: number;
+  /** Present when `ok` is false. */
+  reason?: string;
+}
+
+/** A save that Strict Mode intercepted: the UI must solve `challenge` and retry. */
+export interface SaveResult {
+  ok: boolean;
+  /** Set when a Strict Mode challenge is required (or was answered incorrectly). */
+  challenge?: string;
+  reason?: string;
+}
+
+export interface YoutubeConfig {
+  enabled: boolean;
+  hideShortsShelf: boolean;
+  /** The resolved mode for /shorts/*, already accounting for INHERIT. */
+  shortsMode: BlockMode | 'ALLOW';
+  shortsDelaySeconds: number;
+}
+
+export interface ResponseMap {
+  GET_BLOCK_CONTEXT: BlockContext;
+  COMPLETE_PAUSE: GrantResult;
+  WALKED_AWAY: { ok: true };
+  USE_EMERGENCY_PASS: GrantResult;
+  GET_POPUP_STATE: PopupState;
+  GET_DASHBOARD_STATE: DashboardState;
+  ADD_SITE: { ok: boolean; reason?: string };
+  SAVE_SETTINGS: SaveResult;
+  GET_SETTINGS: NudgeSettings;
+  GET_YOUTUBE_CONFIG: YoutubeConfig;
+}
+
+export type ResponseFor<T extends Request['type']> = ResponseMap[T];

--- a/extension/src/core/ruleResolver.ts
+++ b/extension/src/core/ruleResolver.ts
@@ -1,0 +1,61 @@
+/**
+ * Bridges stored settings (`SiteRule`) to engine input (`ActiveRule`). PURE.
+ *
+ * This is where the "Scheduled Override" semantics live: inside an active schedule window
+ * the scheduled mode+delay REPLACE the rule's default behavior; outside it, the rule's
+ * "Default Behavior" applies. The daily limit is a property of the site, so it applies in
+ * both cases.
+ *
+ * Because the schedule is resolved here, the `ActiveRule` handed to the engine carries no
+ * schedule of its own — the engine's own schedule filter then trivially passes. (The engine
+ * keeps that filter so it remains a faithful port of the Kotlin original, which is fed
+ * pre-mirrored scheduled rows.)
+ */
+
+import { isScheduleActiveAt } from './scheduleEvaluator';
+import type { SiteRule } from './settingsSchema';
+import type { ActiveRule } from './types';
+
+/** All enabled rules whose domain matches `domain` (already normalized). */
+export function rulesForDomain(
+  rules: readonly SiteRule[],
+  domain: string,
+): SiteRule[] {
+  return rules.filter((rule) => rule.enabled && rule.domain === domain);
+}
+
+/** Resolve one stored rule into the rule in effect at `now`. */
+export function resolveRule(rule: SiteRule, now: Date): ActiveRule {
+  const schedule = rule.schedule;
+  const scheduleActive =
+    schedule !== null &&
+    schedule.enabled &&
+    isScheduleActiveAt(
+      {
+        days: schedule.days,
+        startMinute: schedule.startMinute,
+        endMinute: schedule.endMinute,
+      },
+      now,
+    );
+
+  return {
+    mode: scheduleActive ? schedule.mode : rule.mode,
+    delaySeconds: scheduleActive ? schedule.delaySeconds : rule.delaySeconds,
+    dailyLimitMinutes: rule.dailyLimitMinutes,
+    enabled: true,
+    scheduleDays: null,
+    scheduleStartMinute: null,
+    scheduleEndMinute: null,
+    ruleName: rule.domain,
+  };
+}
+
+/** Resolve every rule matching `domain` into engine input. */
+export function resolveActiveRules(
+  rules: readonly SiteRule[],
+  domain: string,
+  now: Date,
+): ActiveRule[] {
+  return rulesForDomain(rules, domain).map((rule) => resolveRule(rule, now));
+}

--- a/extension/src/core/scheduleEvaluator.ts
+++ b/extension/src/core/scheduleEvaluator.ts
@@ -1,0 +1,82 @@
+/**
+ * Schedule evaluation. PURE.
+ *
+ * Direct port of Android's `domain/engine/ScheduleEvaluator.kt`, including its exact
+ * boundary semantics — the ported Kotlin tests are mirrored in tests/core/scheduleEvaluator.test.ts.
+ *
+ * Day numbering: ISO 8601, 1=Monday .. 7=Sunday.
+ * Time: minutes from local midnight, 0..1439.
+ * Overnight spans (end < start, e.g. 23:00–06:00) are supported.
+ */
+
+export interface ScheduleWindow {
+  /** ISO day numbers. null or empty = every day. */
+  days: number[] | null;
+  /** Minutes from local midnight. Both null = all day (on the chosen days). */
+  startMinute: number | null;
+  endMinute: number | null;
+}
+
+/** Convert a JS `Date.getDay()` (0=Sun..6=Sat) to ISO (1=Mon..7=Sun). */
+export function isoDayOfWeek(date: Date): number {
+  const day = date.getDay();
+  return day === 0 ? 7 : day;
+}
+
+/** Minutes elapsed since local midnight for `date`. */
+export function minutesSinceMidnight(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+
+/**
+ * True when the schedule window covers `now` (local time).
+ *
+ * With no schedule fields set at all the window is "always" — that is what makes an
+ * unscheduled rule permanently active.
+ */
+export function isScheduleActiveAt(window: ScheduleWindow, now: Date): boolean {
+  const { days, startMinute, endMinute } = window;
+
+  // Nothing configured -> always active.
+  if ((days === null || days.length === 0) && startMinute === null && endMinute === null) {
+    return true;
+  }
+
+  if (days !== null && days.length > 0 && !days.includes(isoDayOfWeek(now))) {
+    return false;
+  }
+
+  if (startMinute !== null && endMinute !== null) {
+    const current = minutesSinceMidnight(now);
+    if (startMinute <= endMinute) {
+      // Normal range, end EXCLUSIVE: 09:00–17:00 is active at 09:00, not at 17:00.
+      // (start === end therefore yields an empty window — never active — matching Android.)
+      return current >= startMinute && current < endMinute;
+    }
+    // Overnight range: 23:00–06:00.
+    return current >= startMinute || current < endMinute;
+  }
+
+  // Only days set -> active all day on those days.
+  return true;
+}
+
+/**
+ * Milliseconds from `now` until the next local midnight.
+ *
+ * Computed by constructing the next calendar day at 00:00 LOCAL rather than adding a
+ * fixed 24h, so a DST transition shortens/lengthens the interval correctly instead of
+ * drifting the daily reset off midnight (ext-01 §4).
+ */
+export function msUntilNextLocalMidnight(now: Date): number {
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 0);
+  return next.getTime() - now.getTime();
+}
+
+/** Local calendar day key, `yyyy-mm-dd`. The key usage rollups are stored under. */
+export function localDayKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/extension/src/core/settingsSchema.ts
+++ b/extension/src/core/settingsSchema.ts
@@ -136,6 +136,16 @@ function coerceMode(value: unknown, fallback: BlockMode): BlockMode {
   return VALID_MODES.includes(value as BlockMode) ? (value as BlockMode) : fallback;
 }
 
+/**
+ * The YouTube feature rule carries one extra state beyond the three block modes:
+ * 'INHERIT', meaning "defer to the site rule for youtube.com". It needs its own
+ * coercion because 'INHERIT' is not a `BlockMode` and so cannot be a `coerceMode` fallback.
+ */
+function coerceShortsMode(value: unknown): 'INHERIT' | BlockMode {
+  if (value === 'INHERIT') return 'INHERIT';
+  return VALID_MODES.includes(value as BlockMode) ? (value as BlockMode) : 'INHERIT';
+}
+
 function coerceStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((v): v is string => typeof v === 'string');
@@ -228,8 +238,7 @@ export function migrateSettings(raw: unknown): NudgeSettings {
     },
     emergencyPass: { enabled: pass.enabled !== false },
     youtube: {
-      shortsMode:
-        yt.shortsMode === 'INHERIT' ? 'INHERIT' : coerceMode(yt.shortsMode, 'INHERIT'),
+      shortsMode: coerceShortsMode(yt.shortsMode),
       hideShortsShelf: yt.hideShortsShelf === true,
       shortsDelaySeconds: clamp(
         typeof yt.shortsDelaySeconds === 'number'

--- a/extension/src/core/settingsSchema.ts
+++ b/extension/src/core/settingsSchema.ts
@@ -1,0 +1,256 @@
+/**
+ * The persisted settings shape (chrome.storage.sync) + defaults + migrations.
+ *
+ * PURE — no chrome.* imports. The storage adapter lives in src/background/storage.ts.
+ *
+ * Shapes are designed to become the `extension` JSONB namespace if optional account
+ * sync ever ships (ext-06), hence `schemaVersion` from day one.
+ * Usage/stats data NEVER lives here — it is storage.local only and never leaves the device.
+ */
+
+import type { BlockMode } from './types';
+
+export const SCHEMA_VERSION = 1;
+
+/** Delay presets, seconds (Android parity). Custom range 1–300. */
+export const DELAY_PRESETS = [5, 15, 30, 60] as const;
+export const DELAY_MIN_SECONDS = 1;
+export const DELAY_MAX_SECONDS = 300;
+export const DEFAULT_DELAY_SECONDS = 15;
+
+/** Daily Time Limit presets, minutes (Android parity). Custom range 1–480. */
+export const DAILY_LIMIT_PRESETS = [15, 30, 60, 120] as const;
+export const DAILY_LIMIT_MIN_MINUTES = 1;
+export const DAILY_LIMIT_MAX_MINUTES = 480;
+
+/**
+ * Temporary access granted after completing a Delay/Breathing pause — the browser
+ * analog of Android's "the app opens". Per-origin, not per-tab (ext-08 fixed decision).
+ */
+export const TEMP_ALLOW_MIN_MINUTES = 1;
+export const TEMP_ALLOW_MAX_MINUTES = 60;
+export const DEFAULT_TEMP_ALLOW_MINUTES = 10;
+
+/** Strict Mode challenge difficulty presets (raw characters to type). */
+export const CHALLENGE_LENGTH_EASY = 12;
+export const CHALLENGE_LENGTH_MEDIUM = 24;
+export const CHALLENGE_LENGTH_HARD = 48;
+
+/** A per-site rule. One row per site; the schedule override is nested, not a mirrored row. */
+export interface SiteRule {
+  id: string;
+  /** Normalized base domain, e.g. "youtube.com". Matches www./m./mobile. automatically. */
+  domain: string;
+  mode: BlockMode;
+  delaySeconds: number;
+  dailyLimitMinutes: number | null;
+  enabled: boolean;
+  createdAt: number;
+  /** Show remaining budget as badge text on the toolbar icon. */
+  showTimeRemaining: boolean;
+  /** "Scheduled Override" — an independent mode+delay inside the window. */
+  schedule: ScheduleOverride | null;
+}
+
+/**
+ * Scheduled Override. Inside the window the scheduled mode/delay REPLACES the rule's
+ * default behavior; outside it the default applies.
+ *
+ * Overnight spans (end < start, e.g. 23:00–06:00) are supported — see scheduleEvaluator.
+ */
+export interface ScheduleOverride {
+  enabled: boolean;
+  /** ISO day numbers 1=Mon..7=Sun. null/empty = all days. */
+  days: number[] | null;
+  /** Minutes from local midnight, 0..1439. Both null = all day on the chosen days. */
+  startMinute: number | null;
+  endMinute: number | null;
+  mode: BlockMode;
+  delaySeconds: number;
+}
+
+/** Rotating message pools. Empty array = use the bundled Android defaults. */
+export interface MessageSettings {
+  delayTitles: string[];
+  delaySubtitles: string[];
+  hardBlockMessages: string[];
+}
+
+export interface StrictModeSettings {
+  enabled: boolean;
+  /** 12 (Easy) / 24 (Medium, default) / 48 (Hard). */
+  challengeLength: number;
+}
+
+export interface EmergencyPassSettings {
+  /** "Escape Hatch" — the daily 2-minute pass. Hidden entirely under Strict Mode. */
+  enabled: boolean;
+}
+
+/** YouTube feature rule — the Android "Feature Rules" analog. */
+export interface YoutubeSettings {
+  /** 'INHERIT' defers to the site rule for youtube.com (if any). */
+  shortsMode: 'INHERIT' | BlockMode;
+  /** Hide the Shorts shelf/tab/cards across YouTube surfaces. */
+  hideShortsShelf: boolean;
+  shortsDelaySeconds: number;
+}
+
+export interface NudgeSettings {
+  schemaVersion: number;
+  /** Master toggle. Off = Nudge behaves as if uninstalled (Android v1.9.2 semantics). */
+  globalEnabled: boolean;
+  onboardingComplete: boolean;
+  rules: SiteRule[];
+  messages: MessageSettings;
+  strictMode: StrictModeSettings;
+  emergencyPass: EmergencyPassSettings;
+  youtube: YoutubeSettings;
+  tempAllowMinutes: number;
+}
+
+export const DEFAULT_SETTINGS: NudgeSettings = {
+  schemaVersion: SCHEMA_VERSION,
+  globalEnabled: true,
+  onboardingComplete: false,
+  rules: [],
+  messages: { delayTitles: [], delaySubtitles: [], hardBlockMessages: [] },
+  strictMode: { enabled: false, challengeLength: CHALLENGE_LENGTH_MEDIUM },
+  emergencyPass: { enabled: true },
+  youtube: {
+    shortsMode: 'INHERIT',
+    hideShortsShelf: false,
+    shortsDelaySeconds: DEFAULT_DELAY_SECONDS,
+  },
+  tempAllowMinutes: DEFAULT_TEMP_ALLOW_MINUTES,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+const VALID_MODES: readonly BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+function coerceMode(value: unknown, fallback: BlockMode): BlockMode {
+  return VALID_MODES.includes(value as BlockMode) ? (value as BlockMode) : fallback;
+}
+
+function coerceStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+function coerceSchedule(value: unknown): ScheduleOverride | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Partial<ScheduleOverride>;
+  const days = Array.isArray(raw.days)
+    ? raw.days.filter((d): d is number => Number.isInteger(d) && d >= 1 && d <= 7)
+    : null;
+  return {
+    enabled: raw.enabled !== false,
+    days: days && days.length > 0 ? days : null,
+    startMinute:
+      typeof raw.startMinute === 'number' ? clamp(raw.startMinute, 0, 1439) : null,
+    endMinute: typeof raw.endMinute === 'number' ? clamp(raw.endMinute, 0, 1439) : null,
+    mode: coerceMode(raw.mode, 'HARD_BLOCK'),
+    delaySeconds: clamp(
+      typeof raw.delaySeconds === 'number' ? raw.delaySeconds : DEFAULT_DELAY_SECONDS,
+      DELAY_MIN_SECONDS,
+      DELAY_MAX_SECONDS,
+    ),
+  };
+}
+
+function coerceRule(value: unknown): SiteRule | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Partial<SiteRule>;
+  if (typeof raw.domain !== 'string' || raw.domain.trim() === '') return null;
+  return {
+    id: typeof raw.id === 'string' && raw.id ? raw.id : `rule-${raw.domain}`,
+    domain: raw.domain.trim().toLowerCase(),
+    mode: coerceMode(raw.mode, 'HARD_BLOCK'),
+    delaySeconds: clamp(
+      typeof raw.delaySeconds === 'number' ? raw.delaySeconds : DEFAULT_DELAY_SECONDS,
+      DELAY_MIN_SECONDS,
+      DELAY_MAX_SECONDS,
+    ),
+    dailyLimitMinutes:
+      typeof raw.dailyLimitMinutes === 'number'
+        ? clamp(raw.dailyLimitMinutes, DAILY_LIMIT_MIN_MINUTES, DAILY_LIMIT_MAX_MINUTES)
+        : null,
+    enabled: raw.enabled !== false,
+    createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : 0,
+    showTimeRemaining: raw.showTimeRemaining === true,
+    schedule: coerceSchedule(raw.schedule),
+  };
+}
+
+/**
+ * Normalize arbitrary persisted data into a valid `NudgeSettings`.
+ *
+ * Deliberately total and lenient: settings come from storage that may have been written
+ * by an older version, hand-edited via import, or corrupted. Anything unrecognized falls
+ * back to a default rather than throwing — a settings read must never break the block path.
+ *
+ * Failing toward the DEFAULTS is also the safe direction: defaults enforce (globalEnabled
+ * true), so corruption can never silently disable protection.
+ */
+export function migrateSettings(raw: unknown): NudgeSettings {
+  if (!raw || typeof raw !== 'object') return structuredCloneSettings(DEFAULT_SETTINGS);
+  const input = raw as Partial<NudgeSettings>;
+
+  const rules = Array.isArray(input.rules)
+    ? input.rules.map(coerceRule).filter((r): r is SiteRule => r !== null)
+    : [];
+
+  const messages = (input.messages ?? {}) as Partial<MessageSettings>;
+  const strict = (input.strictMode ?? {}) as Partial<StrictModeSettings>;
+  const pass = (input.emergencyPass ?? {}) as Partial<EmergencyPassSettings>;
+  const yt = (input.youtube ?? {}) as Partial<YoutubeSettings>;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    globalEnabled: input.globalEnabled !== false,
+    onboardingComplete: input.onboardingComplete === true,
+    rules,
+    messages: {
+      delayTitles: coerceStringArray(messages.delayTitles),
+      delaySubtitles: coerceStringArray(messages.delaySubtitles),
+      hardBlockMessages: coerceStringArray(messages.hardBlockMessages),
+    },
+    strictMode: {
+      enabled: strict.enabled === true,
+      challengeLength:
+        typeof strict.challengeLength === 'number'
+          ? clamp(strict.challengeLength, 1, 256)
+          : CHALLENGE_LENGTH_MEDIUM,
+    },
+    emergencyPass: { enabled: pass.enabled !== false },
+    youtube: {
+      shortsMode:
+        yt.shortsMode === 'INHERIT' ? 'INHERIT' : coerceMode(yt.shortsMode, 'INHERIT'),
+      hideShortsShelf: yt.hideShortsShelf === true,
+      shortsDelaySeconds: clamp(
+        typeof yt.shortsDelaySeconds === 'number'
+          ? yt.shortsDelaySeconds
+          : DEFAULT_DELAY_SECONDS,
+        DELAY_MIN_SECONDS,
+        DELAY_MAX_SECONDS,
+      ),
+    },
+    tempAllowMinutes: clamp(
+      typeof input.tempAllowMinutes === 'number'
+        ? input.tempAllowMinutes
+        : DEFAULT_TEMP_ALLOW_MINUTES,
+      TEMP_ALLOW_MIN_MINUTES,
+      TEMP_ALLOW_MAX_MINUTES,
+    ),
+  };
+}
+
+function structuredCloneSettings(settings: NudgeSettings): NudgeSettings {
+  return JSON.parse(JSON.stringify(settings)) as NudgeSettings;
+}
+
+export { structuredCloneSettings };

--- a/extension/src/core/stats.ts
+++ b/extension/src/core/stats.ts
@@ -1,0 +1,223 @@
+/**
+ * Daily usage rollups and dashboard aggregations. PURE — zero chrome.* imports, no I/O.
+ *
+ * `DayUsage` / `UsageByDay` are defined in ./protocol (the storage.local shape) and reused
+ * verbatim here, not redefined. All mutation-shaped operations (`addActiveSeconds`,
+ * `recordBlocked`, `recordWalkedAway`) are pure — they return a NEW `DayUsage` and never
+ * touch the object passed in, so the background service worker can safely keep the old
+ * reference around (e.g. for a diff) after calling them.
+ */
+
+import { localDayKey } from './scheduleEvaluator';
+import type { DayUsage, UsageByDay } from './protocol';
+
+const HOURS_PER_DAY = 24;
+
+function cloneHourly(hourly: readonly number[]): number[] {
+  return [...hourly];
+}
+
+/** A fresh, all-zero rollup for a domain that hasn't been seen yet today. */
+export function emptyDayUsage(): DayUsage {
+  return { activeSec: 0, blocked: 0, walkedAway: 0, hourly: new Array<number>(HOURS_PER_DAY).fill(0) };
+}
+
+/**
+ * Add active seconds to a rollup, both to the running total and to the given local hour's
+ * bucket. Pure — returns a new `DayUsage`, never mutates `usage`.
+ *
+ * Guards (both make the call a no-op, returning an unchanged copy, so `activeSec` and
+ * `sum(hourly)` never drift apart from each other):
+ * - negative or non-finite `seconds` is ignored.
+ * - `hour` must be an integer 0..23; anything else is ignored.
+ */
+export function addActiveSeconds(usage: DayUsage, seconds: number, hour: number): DayUsage {
+  const validHour = Number.isInteger(hour) && hour >= 0 && hour <= 23;
+  if (!Number.isFinite(seconds) || seconds < 0 || !validHour) {
+    return { ...usage, hourly: cloneHourly(usage.hourly) };
+  }
+  const hourly = cloneHourly(usage.hourly);
+  hourly[hour] = (hourly[hour] ?? 0) + seconds;
+  return { ...usage, activeSec: usage.activeSec + seconds, hourly };
+}
+
+/** Increment the blocked count. Pure — returns a new `DayUsage`. */
+export function recordBlocked(usage: DayUsage): DayUsage {
+  return { ...usage, blocked: usage.blocked + 1, hourly: cloneHourly(usage.hourly) };
+}
+
+/** Increment the walked-away count. Pure — returns a new `DayUsage`. */
+export function recordWalkedAway(usage: DayUsage): DayUsage {
+  return { ...usage, walkedAway: usage.walkedAway + 1, hourly: cloneHourly(usage.hourly) };
+}
+
+/** Sum of active seconds across every domain rolled up for one day. */
+export function totalActiveSeconds(day: Record<string, DayUsage>): number {
+  let total = 0;
+  for (const usage of Object.values(day)) {
+    total += usage.activeSec;
+  }
+  return total;
+}
+
+export interface TopSite {
+  domain: string;
+  activeSec: number;
+  /** This domain's share of the day's total active seconds, 0..1. 0 when the day total is 0. */
+  fraction: number;
+}
+
+/**
+ * Domains for one day, ranked by active seconds descending. Ties break alphabetically by
+ * domain for a stable, deterministic order. Safe when the day's total is 0 (every fraction
+ * reads 0 rather than dividing by zero).
+ */
+export function topSites(day: Record<string, DayUsage>, limit?: number): TopSite[] {
+  const total = totalActiveSeconds(day);
+  const entries: TopSite[] = Object.entries(day).map(([domain, usage]) => ({
+    domain,
+    activeSec: usage.activeSec,
+    fraction: total > 0 ? usage.activeSec / total : 0,
+  }));
+  entries.sort((a, b) => {
+    if (b.activeSec !== a.activeSec) return b.activeSec - a.activeSec;
+    if (a.domain < b.domain) return -1;
+    if (a.domain > b.domain) return 1;
+    return 0;
+  });
+  return typeof limit === 'number' ? entries.slice(0, limit) : entries;
+}
+
+/**
+ * The last `n` local calendar day keys ending with today (today last, oldest first).
+ * Steps by calendar day via the `Date(y, m, d - i)` constructor — never by subtracting a
+ * fixed 86_400_000ms — so the result is correct across a DST transition (a "day" some
+ * dates is 23h or 25h of wall-clock time, but it is still exactly one calendar day).
+ */
+export function lastNDayKeys(now: Date, n: number): string[] {
+  const keys: string[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const day = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+    keys.push(localDayKey(day));
+  }
+  return keys;
+}
+
+export interface WeeklySeriesPoint {
+  day: string;
+  activeSec: number;
+  blocked: number;
+  walkedAway: number;
+}
+
+/**
+ * Per-day totals (summed across all domains) for the given day keys, zero-filled for any
+ * day absent from `usage`. Order follows `dayKeys` as given (pass `lastNDayKeys` output for
+ * the standard oldest-first, ending-today series).
+ */
+export function weeklySeries(usage: UsageByDay, dayKeys: readonly string[]): WeeklySeriesPoint[] {
+  return dayKeys.map((day) => {
+    const domains = usage[day];
+    if (!domains) return { day, activeSec: 0, blocked: 0, walkedAway: 0 };
+    let activeSec = 0;
+    let blocked = 0;
+    let walkedAway = 0;
+    for (const usageForDomain of Object.values(domains)) {
+      activeSec += usageForDomain.activeSec;
+      blocked += usageForDomain.blocked;
+      walkedAway += usageForDomain.walkedAway;
+    }
+    return { day, activeSec, blocked, walkedAway };
+  });
+}
+
+/** 24 hourly active-second buckets for one day, summed across every domain. */
+export function hourlyHeatmap(usage: UsageByDay, dayKey: string): number[] {
+  const hourly = new Array<number>(HOURS_PER_DAY).fill(0);
+  const domains = usage[dayKey];
+  if (!domains) return hourly;
+  for (const usageForDomain of Object.values(domains)) {
+    for (let h = 0; h < HOURS_PER_DAY; h++) {
+      hourly[h] = (hourly[h] ?? 0) + (usageForDomain.hourly[h] ?? 0);
+    }
+  }
+  return hourly;
+}
+
+/**
+ * Consecutive-day "streak" — direct port of Android's
+ * `ui/screens/stats/StatsCalculator.kt#calculateStreak`. Kotlin source (quoted, with
+ * `DAY_MS` = 24h and `referenceDayStartMs` defaulting to the start of today):
+ *
+ * ```kotlin
+ * fun calculateStreak(weekEvents: List<UsageEvent>, referenceDayStartMs: Long = todayStart): Int {
+ *     var streak = 0
+ *     for (i in 0..6) {
+ *         val dayStart = referenceDayStartMs - i * DAY_MS
+ *         val dayEnd = dayStart + DAY_MS
+ *         val dayEvents = weekEvents.filter { it.timestamp in dayStart until dayEnd }
+ *         val hadWalkedAway = dayEvents.any { it.userChangedMind }
+ *         val hadBlocked = dayEvents.any { it.wasBlocked }
+ *         if (hadWalkedAway || hadBlocked) {
+ *             streak++
+ *         } else if (i == 0 && dayEvents.isEmpty()) {
+ *             continue
+ *         } else {
+ *             break
+ *         }
+ *     }
+ *     return streak
+ * }
+ * ```
+ *
+ * Rule implemented (exactly, not the loosened "any zero-event day is skipped" summary):
+ * walk backwards from today (i=0) to 6 days ago. A day with >=1 blocked-or-walked-away
+ * event increments the streak and the walk continues. Day i=0 (TODAY ONLY) gets a free
+ * pass — skipped, not counted, not breaking — but only when it has ZERO events of ANY kind
+ * (the "haven't used the phone yet today" case). Every other day (i=1..6, and i=0 when it
+ * has SOME activity but no block/walk-away) that lacks a blocked-or-walked-away event
+ * BREAKS the walk immediately, whether or not it has other recorded activity. Concretely: a
+ * zero-event gap day earlier in the week still breaks the streak — only today is exempt.
+ *
+ * Port note: Android's `dayEvents.isEmpty()` means zero `UsageEvent` rows of ANY kind that
+ * day (active-time tracking rows included, not just blocked/walked-away ones). The
+ * extension has no per-event log, only aggregated `DayUsage` rollups per domain, so "day
+ * has zero events" is reconstructed as "every domain rollup for that day is entirely zero"
+ * (`activeSec === 0 && blocked === 0 && walkedAway === 0`) — true both when the day key is
+ * absent from `usage` and when it is present but carries no recorded activity.
+ */
+export function calculateStreak(usage: UsageByDay, now: Date): number {
+  let streak = 0;
+  for (let i = 0; i <= 6; i++) {
+    const day = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+    const key = localDayKey(day);
+    const domainsRecord = usage[key];
+    const domains = domainsRecord ? Object.values(domainsRecord) : [];
+
+    const hadBlocked = domains.some((d) => d.blocked > 0);
+    const hadWalkedAway = domains.some((d) => d.walkedAway > 0);
+    const dayIsEmpty = domains.every((d) => d.activeSec === 0 && d.blocked === 0 && d.walkedAway === 0);
+
+    if (hadBlocked || hadWalkedAway) {
+      streak++;
+    } else if (i === 0 && dayIsEmpty) {
+      continue;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+/** All-time totals across every day and domain ever recorded. */
+export function allTimeTotals(usage: UsageByDay): { blocked: number; walkedAway: number } {
+  let blocked = 0;
+  let walkedAway = 0;
+  for (const domains of Object.values(usage)) {
+    for (const usageForDomain of Object.values(domains)) {
+      blocked += usageForDomain.blocked;
+      walkedAway += usageForDomain.walkedAway;
+    }
+  }
+  return { blocked, walkedAway };
+}

--- a/extension/src/core/strictMode.ts
+++ b/extension/src/core/strictMode.ts
@@ -1,0 +1,253 @@
+/**
+ * Strict Mode "commitment lock" challenge. PURE.
+ *
+ * Direct port of Android's `domain/lock/StrictModeChallenge.kt`. Strict Mode makes weakening
+ * protection (turning off the global toggle, disabling/deleting a rule, softening a config, or
+ * turning Strict Mode itself off) require typing a random unlock string by hand. The friction is
+ * deliberate: it gives the conscious self a moment to reconsider before undoing a block.
+ * Strengthening protection is never gated.
+ *
+ * `isWeakening` is the extension-settings analog of Android's separate `RuleWeakening.kt` —
+ * folded in here (rather than a 4th file) because both objects exist to decide what the Strict
+ * Mode challenge gates, and the extension's single `NudgeSettings` blob (vs. Android's
+ * per-BlockRule entity + separate global prefs) makes one combined comparison the natural shape.
+ *
+ * No chrome.* imports — fully unit-testable under plain Node/vitest.
+ */
+
+import type { NudgeSettings, SiteRule } from './settingsSchema';
+import type { BlockMode } from './types';
+
+/**
+ * Unambiguous charset: excludes visually-confusable glyphs (0/O, 1/l/I) so a user copying the
+ * string by eye never mis-reads it. Both letter cases are included so the challenge is genuinely
+ * case-sensitive. Identical to the Android charset (parity matters — same commitment device).
+ */
+export const CHARSET = 'abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+/** Characters per display group (e.g. "k7Qm2-vX9pL"). */
+const GROUP_SIZE = 5;
+
+/** Default / suggested difficulty presets (number of raw characters to type). */
+export const LENGTH_EASY = 12;
+export const LENGTH_MEDIUM = 24;
+export const LENGTH_HARD = 48;
+export const DEFAULT_LENGTH = LENGTH_MEDIUM;
+
+/**
+ * Produces `count` uniformly random integers in `[0, maxExclusive)`. Injectable so tests can
+ * supply a deterministic sequence instead of real randomness.
+ */
+export type RandomInts = (count: number, maxExclusive: number) => number[];
+
+const UINT32_RANGE = 0x1_0000_0000; // 2^32
+
+function drawUint32(): number {
+  const buf = new Uint32Array(1);
+  crypto.getRandomValues(buf);
+  const value = buf[0];
+  if (value === undefined) {
+    // Unreachable — a length-1 Uint32Array always has index 0 after getRandomValues fills it.
+    // Guarding this way (rather than a non-null assertion) keeps noUncheckedIndexedAccess honest.
+    throw new Error('crypto.getRandomValues did not fill the buffer');
+  }
+  return value;
+}
+
+/**
+ * Crypto-backed uniform integers in `[0, maxExclusive)` via rejection sampling.
+ *
+ * This is a commitment device — its unlock string MUST come from a real CSPRNG, never
+ * `Math.random()` (which is not cryptographically secure and is a documented house standard to
+ * avoid in security-relevant contexts, unlike the Kotlin original which used `kotlin.random.Random`
+ * on a platform where that concern doesn't apply the same way).
+ *
+ * Naively computing `drawUint32() % maxExclusive` is BIASED whenever `maxExclusive` doesn't evenly
+ * divide 2^32 — which is every value except powers of two, and our 57-char CHARSET is no
+ * exception. The low remainder classes (`0 .. (2^32 % maxExclusive) - 1`) would get one extra
+ * draw each out of every 2^32 draws, subtly skewing which characters appear more often. Rejecting
+ * any draw at or above `rejectionThreshold` (the largest multiple of `maxExclusive` that fits in a
+ * uint32) discards exactly the draws that would cause that skew — every accepted draw then falls
+ * into one of `maxExclusive` equally-sized buckets, so `draw % maxExclusive` is exactly uniform.
+ */
+function defaultRandomInts(count: number, maxExclusive: number): number[] {
+  if (maxExclusive <= 0) throw new RangeError('maxExclusive must be positive');
+  const rejectionThreshold = UINT32_RANGE - (UINT32_RANGE % maxExclusive);
+  const results: number[] = [];
+  while (results.length < count) {
+    const draw = drawUint32();
+    if (draw < rejectionThreshold) {
+      results.push(draw % maxExclusive);
+    }
+  }
+  return results;
+}
+
+/**
+ * Generates a fresh random challenge string of `length` raw characters drawn from `CHARSET`.
+ * Returns the RAW string (no dashes); use `forDisplay` to render it grouped.
+ *
+ * @param randomInts injectable for deterministic tests; defaults to a `crypto.getRandomValues`-
+ *   backed, rejection-sampled generator (see `defaultRandomInts`). NEVER defaults to
+ *   `Math.random()` — this string is a commitment device, not display-only randomness.
+ */
+export function generate(
+  length: number = DEFAULT_LENGTH,
+  randomInts: RandomInts = defaultRandomInts,
+): string {
+  const safeLength = Math.max(1, Math.trunc(length));
+  const indices = randomInts(safeLength, CHARSET.length);
+  let result = '';
+  for (const index of indices) {
+    result += CHARSET.charAt(index);
+  }
+  return result;
+}
+
+/**
+ * Renders a raw challenge string grouped into dash-separated chunks for readability, e.g.
+ * "k7Qm2vX9pLtR4wZ" -> "k7Qm2-vX9pL-tR4wZ". Display-only; never stored or compared.
+ */
+export function forDisplay(raw: string): string {
+  const groups: string[] = [];
+  for (let i = 0; i < raw.length; i += GROUP_SIZE) {
+    groups.push(raw.slice(i, i + GROUP_SIZE));
+  }
+  return groups.join('-');
+}
+
+/**
+ * Strips display dashes and surrounding whitespace, returning the raw comparable content.
+ * Internal whitespace is NOT stripped — it would make a typo (an accidental space mid-string)
+ * silently pass, which weakens the commitment device.
+ *
+ * Public so the UI can derive the live progress counter from the SAME rule `verify` compares
+ * against (single source of truth: the dashes the user may type are ignored identically in the
+ * counter and the match).
+ */
+export function normalize(value: string): string {
+  return value.trim().replace(/-/g, '');
+}
+
+/**
+ * Count of raw, dash-stripped characters in `value` — the unit the unlock counter shows and the
+ * unit `verify` compares. Typing the code WITH or WITHOUT dashes yields the same count.
+ */
+export function rawLength(value: string): number {
+  return normalize(value).length;
+}
+
+/**
+ * Case-SENSITIVE exact match of `input` against `target`.
+ *
+ * Both sides are normalized first: surrounding whitespace trimmed and display dashes removed, so
+ * the user may type the string with or without the dashes shown on screen. Everything else (case,
+ * every character) must match exactly.
+ */
+export function verify(input: string, target: string): boolean {
+  const normalizedTarget = normalize(target);
+  if (normalizedTarget.length === 0) return false;
+  return normalize(input) === normalizedTarget;
+}
+
+// ── isWeakening — extension-settings analog of Android's RuleWeakening.kt ──
+
+/**
+ * Block-mode strength ordering (higher = stronger protection), mirroring
+ * RuleWeakening.kt's `modeStrength`. Anything unrecognized sorts below the known modes.
+ */
+function modeStrength(mode: string | null | undefined): number {
+  switch (mode) {
+    case 'HARD_BLOCK':
+      return 3;
+    case 'DELAY':
+      return 2;
+    case 'BREATHING':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Same ordering as `modeStrength`, plus YouTube's 'INHERIT' as the weakest rung of all. */
+function youtubeModeStrength(mode: 'INHERIT' | BlockMode): number {
+  return mode === 'INHERIT' ? 0 : modeStrength(mode);
+}
+
+/**
+ * A daily limit is weakened when an existing cap is removed (null) or raised. Adding a cap where
+ * none existed, or lowering an existing cap, is strengthening. Mirrors
+ * RuleWeakening.kt's `isDailyLimitWeakened`.
+ */
+function isDailyLimitWeakened(oldLimit: number | null, newLimit: number | null): boolean {
+  if (oldLimit === null) return false; // no cap before -> any new cap (or still none) is not weaker
+  if (newLimit === null) return true; // had a cap, now removed -> weaker
+  return newLimit > oldLimit; // cap raised -> weaker
+}
+
+/** Per-rule weakening check — the SiteRule analog of RuleWeakening.kt's `isWeakening(old, new)`. */
+function isRuleWeakened(oldRule: SiteRule, newRule: SiteRule): boolean {
+  // Disabling an active rule.
+  if (oldRule.enabled && !newRule.enabled) return true;
+  // Softening the block mode.
+  if (modeStrength(newRule.mode) < modeStrength(oldRule.mode)) return true;
+  // Shortening the delay = less friction before the site opens.
+  if (newRule.delaySeconds < oldRule.delaySeconds) return true;
+  // Daily limit: removing it, or raising it, grants more usage.
+  if (isDailyLimitWeakened(oldRule.dailyLimitMinutes, newRule.dailyLimitMinutes)) return true;
+  return false;
+}
+
+/**
+ * Returns true if `newSettings` is weaker protection than `oldSettings` in ANY dimension, each
+ * dimension evaluated independently — softening one axis is weakening even if another is
+ * strengthened at the same time (the user must justify the part that reduces protection).
+ * Unchanged on every dimension -> false.
+ *
+ * Weakening dimensions (each documented at its check below):
+ *  - globalEnabled true -> false
+ *  - strictMode.enabled true -> false
+ *  - a rule removed (matched by `id`)
+ *  - a rule disabled, mode softened, delay shortened, or daily limit raised/removed
+ *  - emergencyPass.enabled false -> true (adding an escape hatch IS weakening)
+ *  - tempAllowMinutes increased
+ *  - youtube.shortsMode softened (HARD_BLOCK > DELAY > BREATHING > INHERIT)
+ *
+ * Adding a brand-new rule (present in `new`, absent in `old`) is strengthening, never weakening.
+ */
+export function isWeakening(oldSettings: NudgeSettings, newSettings: NudgeSettings): boolean {
+  // Axis: the master toggle. Off suppresses all enforcement — the ultimate weakening.
+  if (oldSettings.globalEnabled && !newSettings.globalEnabled) return true;
+
+  // Axis: turning Strict Mode itself off removes the commitment lock that gates every other
+  // weakening action — so turning it off must itself be gated while it's still on.
+  if (oldSettings.strictMode.enabled && !newSettings.strictMode.enabled) return true;
+
+  // Axis: per-site rules, matched by id. A rule present in `old` but missing from `new` was
+  // deleted — weakening. Rules present in both are compared field-by-field via isRuleWeakened.
+  // A rule present only in `new` is a brand-new rule -> strengthening, not checked here.
+  const newRulesById = new Map(newSettings.rules.map((r) => [r.id, r] as const));
+  for (const oldRule of oldSettings.rules) {
+    const newRule = newRulesById.get(oldRule.id);
+    if (!newRule) return true; // rule removed
+    if (isRuleWeakened(oldRule, newRule)) return true;
+  }
+
+  // Axis: the emergency pass is an escape hatch — turning it ON (false -> true) is weakening
+  // even though "enabled" reads as a positive word. Turning it off is strengthening.
+  if (!oldSettings.emergencyPass.enabled && newSettings.emergencyPass.enabled) return true;
+
+  // Axis: a longer temporary-allow window grants more free access per Delay/Breathing pass.
+  if (newSettings.tempAllowMinutes > oldSettings.tempAllowMinutes) return true;
+
+  // Axis: YouTube Shorts mode softened, including softening all the way to 'INHERIT' (deferring
+  // to the site rule, or to nothing if there is none, is the weakest possible stance).
+  if (
+    youtubeModeStrength(newSettings.youtube.shortsMode) <
+    youtubeModeStrength(oldSettings.youtube.shortsMode)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/extension/src/core/types.ts
+++ b/extension/src/core/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Engine-level types. PURE — no chrome.* imports anywhere in src/core/.
+ *
+ * Ported from the Android domain layer (domain/model/{BlockMode,ActiveRule,BlockDecision}.kt),
+ * which is likewise pure (zero Android imports) and unit-tested on the JVM.
+ */
+
+/** Block modes. Labels shown to the user are "Hard Block" / "Delay" / "Breathing". */
+export type BlockMode = 'HARD_BLOCK' | 'DELAY' | 'BREATHING';
+
+/** User-facing label for a mode — Android naming parity. */
+export const MODE_LABELS: Record<BlockMode, string> = {
+  HARD_BLOCK: 'Hard Block',
+  DELAY: 'Delay',
+  BREATHING: 'Breathing',
+};
+
+/**
+ * A rule resolved for "right now" — schedule already applied — and handed to the
+ * BlockEngine. Mirrors Android's `ActiveRule`.
+ */
+export interface ActiveRule {
+  mode: BlockMode;
+  delaySeconds: number;
+  dailyLimitMinutes: number | null;
+  enabled: boolean;
+  /** ISO day numbers, 1=Mon .. 7=Sun. null/empty = every day. */
+  scheduleDays: number[] | null;
+  /** Minutes from local midnight, 0..1439. */
+  scheduleStartMinute: number | null;
+  scheduleEndMinute: number | null;
+  ruleName: string | null;
+}
+
+export type BlockDecision =
+  | { type: 'ALLOW' }
+  | {
+      type: 'BLOCK';
+      mode: BlockMode;
+      delaySeconds: number;
+      ruleName: string | null;
+      dailyTimeRemainingMs: number | null;
+      dailyLimitMinutes: number | null;
+      /** True when this block was forced by an exhausted daily limit. */
+      limitReached: boolean;
+    };
+
+export const ALLOW: BlockDecision = { type: 'ALLOW' };
+
+/** Convenience constructor keeping BLOCK decisions total (every field explicit). */
+export function block(params: {
+  mode: BlockMode;
+  delaySeconds?: number;
+  ruleName?: string | null;
+  dailyTimeRemainingMs?: number | null;
+  dailyLimitMinutes?: number | null;
+  limitReached?: boolean;
+}): BlockDecision {
+  return {
+    type: 'BLOCK',
+    mode: params.mode,
+    delaySeconds: params.delaySeconds ?? 0,
+    ruleName: params.ruleName ?? null,
+    dailyTimeRemainingMs: params.dailyTimeRemainingMs ?? null,
+    dailyLimitMinutes: params.dailyLimitMinutes ?? null,
+    limitReached: params.limitReached ?? false,
+  };
+}

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -1,3 +1,63 @@
+import { ensureAlarms, handleAlarm } from '../background/alarmsHub';
+import { applyRules } from '../background/dnr';
+import { registerMessageRouter } from '../background/messagesRouter';
+import { loadSettings } from '../background/storage';
+import { IDLE_DETECTION_SECONDS, onActivityEvent } from '../background/tracker';
+
+/**
+ * Service-worker entrypoint.
+ *
+ * Every listener is registered SYNCHRONOUSLY at the top level. An MV3 worker is torn down
+ * after ~30s idle and re-spawned by an incoming event; a listener registered inside an
+ * async callback would not exist yet when that event arrives, so the event is missed.
+ *
+ * `bootstrap()` therefore runs on every worker wake (not just on install) and re-derives
+ * all durable state — DNR rules, standing alarms, live temp-allow grants — because none of
+ * it can be assumed to have survived.
+ */
 export default defineBackground(() => {
-  console.log('[nudge] service worker booted');
+  registerMessageRouter();
+
+  async function bootstrap(): Promise<void> {
+    try {
+      await chrome.idle.setDetectionInterval(IDLE_DETECTION_SECONDS);
+      await applyRules(await loadSettings());
+      await ensureAlarms();
+      await onActivityEvent();
+    } catch (error) {
+      console.error('[nudge] bootstrap failed', error);
+    }
+  }
+
+  chrome.runtime.onInstalled.addListener((details) => {
+    void bootstrap();
+    if (details.reason === 'install') {
+      void chrome.tabs.create({ url: chrome.runtime.getURL('onboarding.html') });
+    }
+  });
+
+  chrome.runtime.onStartup.addListener(() => void bootstrap());
+
+  // --- Usage accounting. Each of these is "something about attention changed" ---
+  chrome.tabs.onActivated.addListener(() => void onActivityEvent());
+  chrome.tabs.onUpdated.addListener((_tabId, changeInfo) => {
+    // Only a committed URL change matters; ignore title/favicon churn.
+    if (changeInfo.url !== undefined) void onActivityEvent();
+  });
+  // Fires with WINDOW_ID_NONE when Chrome itself loses OS focus, which is what stops us
+  // counting time while the user is in another application.
+  chrome.windows.onFocusChanged.addListener(() => void onActivityEvent());
+  chrome.idle.onStateChanged.addListener(() => void onActivityEvent());
+
+  chrome.alarms.onAlarm.addListener((alarm) => void handleAlarm(alarm));
+
+  // Settings can change from any surface (and from another synced device) — recompile.
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'session') return;
+    if (Object.keys(changes).some((key) => key === 'nudge:settings')) {
+      void loadSettings().then(applyRules);
+    }
+  });
+
+  void bootstrap();
 });

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -1,0 +1,3 @@
+export default defineBackground(() => {
+  console.log('[nudge] service worker booted');
+});

--- a/extension/src/entrypoints/blocked/BlockPage.tsx
+++ b/extension/src/entrypoints/blocked/BlockPage.tsx
@@ -68,8 +68,12 @@ export function useCountdownMs(totalMs: number): number {
  * Fires COMPLETE_PAUSE exactly once when the countdown reaches zero, then navigates to
  * `target` on success. Exposes `status`/`retry` so the view can show a retry affordance
  * instead of hanging if the service worker is asleep/restarting.
+ *
+ * `enabled` exists so callers can invoke this UNCONDITIONALLY (React requires stable hook
+ * order) without arming it. That matters: a disarmed view has a zero-length countdown, and
+ * "remaining === 0" would otherwise complete the pause instantly and grant real access.
  */
-export function useCompleteOnZero(remainingMs: number, target: string) {
+export function useCompleteOnZero(remainingMs: number, target: string, enabled = true) {
   const [status, setStatus] = useState<'idle' | 'pending' | 'error'>('idle');
   const firedRef = useRef(false);
 
@@ -87,11 +91,11 @@ export function useCompleteOnZero(remainingMs: number, target: string) {
   }, [target]);
 
   useEffect(() => {
-    if (remainingMs === 0 && !firedRef.current) {
+    if (enabled && remainingMs === 0 && !firedRef.current) {
       firedRef.current = true;
       attempt();
     }
-  }, [remainingMs, attempt]);
+  }, [enabled, remainingMs, attempt]);
 
   return { status, retry: attempt };
 }

--- a/extension/src/entrypoints/blocked/BlockPage.tsx
+++ b/extension/src/entrypoints/blocked/BlockPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * The block-page orchestrator. Reached via a DNR redirect to `blocked.html?target=<encoded url>`.
+ * Fetches a `BlockContext` from the service worker and renders the right interstitial —
+ * never flashing the wrong mode, never navigating anywhere unsafe.
+ *
+ * PRD: ops/routes/nudge/research/ext-07-prd.md MVP items 1, 7, 8, 9.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { BlockContext } from '../../core/protocol';
+import { Button, NudgeMark, RuleFooter } from '../../ui/components';
+import { send } from '../../ui/rpc';
+import { BreathingView } from './BreathingView';
+import { DelayView } from './DelayView';
+import { HardBlockView } from './HardBlockView';
+
+/**
+ * Open-redirect / XSS guard. Every navigation this feature performs — Delay/Breathing
+ * completion, the Escape Hatch grant, and the raw `target` query param itself — MUST be
+ * gated through this before it is ever assigned to `window.location`. `javascript:`,
+ * `data:`, and `chrome-extension:` (or any other non-http(s) scheme) are rejected.
+ */
+export function isNavigableTarget(raw: string | null | undefined): raw is string {
+  if (!raw) return false;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+/** Where "I changed my mind" sends the user. Falls back to about:blank outside an extension context. */
+export function resolveDashboardUrl(): string {
+  try {
+    return chrome.runtime.getURL('dashboard.html');
+  } catch {
+    return 'about:blank';
+  }
+}
+
+const TICK_MS = 100;
+
+/** Ticks down from `totalMs` to 0 in fixed 100ms steps. Clamps at 0 and self-clears its interval. */
+export function useCountdownMs(totalMs: number): number {
+  const clamped = Math.max(0, totalMs);
+  const [remainingMs, setRemainingMs] = useState(clamped);
+
+  useEffect(() => {
+    setRemainingMs(clamped);
+    if (clamped <= 0) return;
+    const id = setInterval(() => {
+      setRemainingMs((prev) => {
+        const next = Math.max(0, prev - TICK_MS);
+        if (next === 0) clearInterval(id);
+        return next;
+      });
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [clamped]);
+
+  return remainingMs;
+}
+
+/**
+ * Fires COMPLETE_PAUSE exactly once when the countdown reaches zero, then navigates to
+ * `target` on success. Exposes `status`/`retry` so the view can show a retry affordance
+ * instead of hanging if the service worker is asleep/restarting.
+ */
+export function useCompleteOnZero(remainingMs: number, target: string) {
+  const [status, setStatus] = useState<'idle' | 'pending' | 'error'>('idle');
+  const firedRef = useRef(false);
+
+  const attempt = useCallback(() => {
+    setStatus('pending');
+    send({ type: 'COMPLETE_PAUSE', target })
+      .then((result) => {
+        if (result.ok && isNavigableTarget(target)) {
+          window.location.replace(target);
+          return;
+        }
+        setStatus('error');
+      })
+      .catch(() => setStatus('error'));
+  }, [target]);
+
+  useEffect(() => {
+    if (remainingMs === 0 && !firedRef.current) {
+      firedRef.current = true;
+      attempt();
+    }
+  }, [remainingMs, attempt]);
+
+  return { status, retry: attempt };
+}
+
+type LoadState =
+  | { status: 'invalid' }
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'ready'; context: BlockContext; target: string };
+
+/** The marker the DNR redirect appends the original URL after. Must stay last in the URL. */
+const TARGET_PARAM = '?target=';
+
+/**
+ * Read the blocked URL out of our own address bar.
+ *
+ * Deliberately NOT `URLSearchParams`: the DNR rule appends the original URL verbatim via
+ * `regexSubstitution` (which cannot percent-encode), so the target routinely contains its
+ * own `?` and `&` — e.g. `youtube.com/watch?v=abc&t=30`. Parsing it as query parameters
+ * would silently truncate at the first `&` and turn `+` into a space. `target` is always
+ * the LAST thing in the URL, so everything after the first marker is the target.
+ *
+ * Read from `href`, not `search`, so a target carrying its own `#fragment` survives too.
+ * The target is never percent-decoded here: both producers (the DNR rule and
+ * `redirectOpenTabs`) append it verbatim, so decoding would corrupt any URL that legitimately
+ * contains a `%XX` sequence.
+ */
+function readTargetParam(): string | null {
+  try {
+    const { href } = window.location;
+    const markerAt = href.indexOf(TARGET_PARAM);
+    if (markerAt === -1) return null;
+    const raw = href.slice(markerAt + TARGET_PARAM.length);
+    return raw === '' ? null : raw;
+  } catch {
+    return null;
+  }
+}
+
+function PageShell({ ruleName, children }: { ruleName: string | null; children: ReactNode }) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 24px',
+        gap: 32,
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+        <NudgeMark size={36} />
+        <p
+          style={{
+            margin: 0,
+            fontSize: 13,
+            fontWeight: 500,
+            color: 'var(--nudge-on-surface-variant)',
+            letterSpacing: 0.2,
+          }}
+        >
+          Break the scroll. Take back your time.
+        </p>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          maxWidth: 440,
+          width: '100%',
+        }}
+      >
+        {children}
+      </div>
+      <RuleFooter ruleName={ruleName} />
+    </div>
+  );
+}
+
+export function BlockPage() {
+  const rawTarget = useMemo(readTargetParam, []);
+  const targetIsSafe = isNavigableTarget(rawTarget);
+  const [state, setState] = useState<LoadState>(
+    targetIsSafe ? { status: 'loading' } : { status: 'invalid' },
+  );
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (!targetIsSafe) return;
+    let cancelled = false;
+    setState({ status: 'loading' });
+    send({ type: 'GET_BLOCK_CONTEXT', target: rawTarget })
+      .then((context) => {
+        if (!cancelled) setState({ status: 'ready', context, target: rawTarget });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+    // rawTarget/targetIsSafe are stable for the page's lifetime; `attempt` is the retry trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attempt]);
+
+  // ALLOW is unexpected on the block page (nothing to block) — send the user on rather
+  // than trap them behind a dead interstitial.
+  useEffect(() => {
+    if (
+      state.status === 'ready' &&
+      state.context.decision.type === 'ALLOW' &&
+      isNavigableTarget(state.target)
+    ) {
+      window.location.replace(state.target);
+    }
+  }, [state]);
+
+  if (state.status === 'invalid') {
+    return (
+      <PageShell ruleName={null}>
+        <p style={{ margin: 0, fontSize: 16, color: 'var(--nudge-on-surface-variant)' }}>
+          Nothing to show here — the page you came from didn&apos;t tell Nudge where you were
+          headed.
+        </p>
+      </PageShell>
+    );
+  }
+
+  if (state.status === 'loading') {
+    return (
+      <PageShell ruleName={null}>
+        <p style={{ margin: 0, fontSize: 15, color: 'var(--nudge-on-surface-variant)' }}>
+          Loading…
+        </p>
+      </PageShell>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <PageShell ruleName={null}>
+        <p
+          style={{
+            margin: '0 0 16px',
+            fontSize: 15,
+            color: 'var(--nudge-on-surface-variant)',
+          }}
+        >
+          Nudge couldn&apos;t load this page. It may still be waking up.
+        </p>
+        <Button variant="secondary" onClick={() => setAttempt((n) => n + 1)}>
+          Retry
+        </Button>
+      </PageShell>
+    );
+  }
+
+  const { context, target } = state;
+
+  if (context.decision.type !== 'BLOCK') {
+    // ALLOW — the redirect effect above handles it; render a neutral state meanwhile.
+    return (
+      <PageShell ruleName={null}>
+        <p style={{ margin: 0, fontSize: 15, color: 'var(--nudge-on-surface-variant)' }}>
+          Redirecting…
+        </p>
+      </PageShell>
+    );
+  }
+
+  const ruleName = context.decision.ruleName;
+
+  return (
+    <PageShell ruleName={ruleName}>
+      {context.decision.mode === 'HARD_BLOCK' && <HardBlockView context={context} target={target} />}
+      {context.decision.mode === 'DELAY' && <DelayView context={context} target={target} />}
+      {context.decision.mode === 'BREATHING' && <BreathingView context={context} target={target} />}
+    </PageShell>
+  );
+}

--- a/extension/src/entrypoints/blocked/BreathingView.tsx
+++ b/extension/src/entrypoints/blocked/BreathingView.tsx
@@ -17,11 +17,15 @@ const MAX_SCALE = 1.0;
 
 export function BreathingView({ context, target }: { context: BlockContext; target: string }) {
   const decision = context.decision;
-  if (decision.type !== 'BLOCK') return null;
-
-  const totalMs = Math.max(0, decision.delaySeconds * 1000);
+  // Hooks run unconditionally so their order is stable across renders; the view bails out
+  // AFTER them. `isBlocked` disarms the completion hook so a non-block render — which has a
+  // zero-length countdown — cannot instantly "complete" a pause and grant access.
+  const isBlocked = decision.type === 'BLOCK';
+  const totalMs = isBlocked ? Math.max(0, decision.delaySeconds * 1000) : 0;
   const remainingMs = useCountdownMs(totalMs);
-  const { status, retry } = useCompleteOnZero(remainingMs, target);
+  const { status, retry } = useCompleteOnZero(remainingMs, target, isBlocked);
+
+  if (!isBlocked) return null;
 
   const elapsedMs = totalMs - remainingMs;
   const cyclePos = elapsedMs % (HALF_CYCLE_MS * 2);

--- a/extension/src/entrypoints/blocked/BreathingView.tsx
+++ b/extension/src/entrypoints/blocked/BreathingView.tsx
@@ -1,0 +1,106 @@
+/**
+ * Breathing — a circle scaling 0.6x-1.0x on a fixed 4000ms inhale / 4000ms exhale cycle
+ * (8s per cycle — exact Android timing), alternating "Breathe in..." / "Breathe out...",
+ * repeating until `decision.delaySeconds` elapses. Linear progress bar + "Ns remaining".
+ * Same completion behaviour as Delay.
+ */
+
+import type { BlockContext } from '../../core/protocol';
+import { Button } from '../../ui/components';
+import { send } from '../../ui/rpc';
+import { resolveDashboardUrl, useCompleteOnZero, useCountdownMs } from './BlockPage';
+import { EscapeHatch } from './EscapeHatch';
+
+const HALF_CYCLE_MS = 4000; // fixed 4s inhale / 4s exhale — exact Android timing
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 1.0;
+
+export function BreathingView({ context, target }: { context: BlockContext; target: string }) {
+  const decision = context.decision;
+  if (decision.type !== 'BLOCK') return null;
+
+  const totalMs = Math.max(0, decision.delaySeconds * 1000);
+  const remainingMs = useCountdownMs(totalMs);
+  const { status, retry } = useCompleteOnZero(remainingMs, target);
+
+  const elapsedMs = totalMs - remainingMs;
+  const cyclePos = elapsedMs % (HALF_CYCLE_MS * 2);
+  const isInhale = cyclePos < HALF_CYCLE_MS;
+  const withinHalf = isInhale ? cyclePos : cyclePos - HALF_CYCLE_MS;
+  const halfFraction = withinHalf / HALF_CYCLE_MS;
+  const scale = isInhale
+    ? MIN_SCALE + (MAX_SCALE - MIN_SCALE) * halfFraction
+    : MAX_SCALE - (MAX_SCALE - MIN_SCALE) * halfFraction;
+
+  const secondsLeft = Math.ceil(remainingMs / 1000);
+  const progressPct = totalMs > 0 ? Math.min(100, (elapsedMs / totalMs) * 100) : 100;
+
+  const handleWalkAway = async () => {
+    try {
+      await send({ type: 'WALKED_AWAY', target });
+    } catch {
+      // Best-effort stat log — still leave even if the service worker missed it.
+    }
+    window.location.replace(resolveDashboardUrl());
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 20, width: '100%' }}>
+      <div
+        aria-hidden="true"
+        style={{
+          width: 120,
+          height: 120,
+          borderRadius: '50%',
+          background: 'var(--nudge-primary-container)',
+          border: '2px solid var(--nudge-primary)',
+          transform: `scale(${scale})`,
+          transition: 'transform 100ms linear',
+        }}
+      />
+      <p style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>
+        {isInhale ? 'Breathe in...' : 'Breathe out...'}
+      </p>
+
+      <div
+        style={{
+          width: '100%',
+          maxWidth: 260,
+          height: 6,
+          borderRadius: 999,
+          background: 'var(--nudge-surface-variant)',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            width: `${progressPct}%`,
+            height: '100%',
+            background: 'var(--nudge-primary)',
+            transition: 'width 100ms linear',
+          }}
+        />
+      </div>
+      <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+        {secondsLeft}s remaining
+      </p>
+
+      {status === 'error' && (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-danger)' }}>
+            Couldn&apos;t reach Nudge.
+          </p>
+          <Button variant="secondary" onClick={retry}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      <Button variant="muted" onClick={handleWalkAway}>
+        I changed my mind
+      </Button>
+
+      <EscapeHatch context={context} target={target} />
+    </div>
+  );
+}

--- a/extension/src/entrypoints/blocked/DelayView.tsx
+++ b/extension/src/entrypoints/blocked/DelayView.tsx
@@ -1,0 +1,100 @@
+/**
+ * Delay — a circular countdown ring over `decision.delaySeconds`, showing
+ * `context.delayTitle`/`context.delaySubtitle`. On completion, COMPLETE_PAUSE then
+ * navigate to `target`. "I changed my mind" logs WALKED_AWAY and leaves for the
+ * dashboard.
+ */
+
+import type { BlockContext } from '../../core/protocol';
+import { Button } from '../../ui/components';
+import { send } from '../../ui/rpc';
+import { resolveDashboardUrl, useCompleteOnZero, useCountdownMs } from './BlockPage';
+import { EscapeHatch } from './EscapeHatch';
+
+const RING_SIZE = 160;
+const RING_STROKE = 10;
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+export function DelayView({ context, target }: { context: BlockContext; target: string }) {
+  const decision = context.decision;
+  if (decision.type !== 'BLOCK') return null;
+
+  const totalMs = Math.max(0, decision.delaySeconds * 1000);
+  const remainingMs = useCountdownMs(totalMs);
+  const { status, retry } = useCompleteOnZero(remainingMs, target);
+
+  const fraction = totalMs > 0 ? remainingMs / totalMs : 0;
+  const dashOffset = RING_CIRCUMFERENCE * (1 - fraction);
+  const secondsLeft = Math.ceil(remainingMs / 1000);
+
+  const handleWalkAway = async () => {
+    try {
+      await send({ type: 'WALKED_AWAY', target });
+    } catch {
+      // Best-effort stat log — still leave even if the service worker missed it.
+    }
+    window.location.replace(resolveDashboardUrl());
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 20, width: '100%' }}>
+      <p style={{ margin: 0, fontSize: 18, fontWeight: 600 }}>{context.delayTitle}</p>
+      <p style={{ margin: 0, fontSize: 14, color: 'var(--nudge-on-surface-variant)' }}>
+        {context.delaySubtitle}
+      </p>
+
+      <svg width={RING_SIZE} height={RING_SIZE} viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}>
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={RING_RADIUS}
+          fill="none"
+          stroke="var(--nudge-surface-variant)"
+          strokeWidth={RING_STROKE}
+        />
+        <circle
+          cx={RING_SIZE / 2}
+          cy={RING_SIZE / 2}
+          r={RING_RADIUS}
+          fill="none"
+          stroke="var(--nudge-primary)"
+          strokeWidth={RING_STROKE}
+          strokeLinecap="round"
+          strokeDasharray={RING_CIRCUMFERENCE}
+          strokeDashoffset={dashOffset}
+          transform={`rotate(-90 ${RING_SIZE / 2} ${RING_SIZE / 2})`}
+          style={{ transition: 'stroke-dashoffset 100ms linear' }}
+        />
+        <text
+          x="50%"
+          y="50%"
+          dominantBaseline="middle"
+          textAnchor="middle"
+          fontSize="28"
+          fontWeight="700"
+          fill="var(--nudge-on-surface)"
+        >
+          {secondsLeft}
+        </text>
+      </svg>
+
+      {status === 'error' && (
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-danger)' }}>
+            Couldn&apos;t reach Nudge.
+          </p>
+          <Button variant="secondary" onClick={retry}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      <Button variant="muted" onClick={handleWalkAway}>
+        I changed my mind
+      </Button>
+
+      <EscapeHatch context={context} target={target} />
+    </div>
+  );
+}

--- a/extension/src/entrypoints/blocked/DelayView.tsx
+++ b/extension/src/entrypoints/blocked/DelayView.tsx
@@ -18,11 +18,15 @@ const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 export function DelayView({ context, target }: { context: BlockContext; target: string }) {
   const decision = context.decision;
-  if (decision.type !== 'BLOCK') return null;
-
-  const totalMs = Math.max(0, decision.delaySeconds * 1000);
+  // Hooks run unconditionally so their order is stable across renders; the view bails out
+  // AFTER them. `isBlocked` disarms the completion hook so a non-block render — which has a
+  // zero-length countdown — cannot instantly "complete" a pause and grant access.
+  const isBlocked = decision.type === 'BLOCK';
+  const totalMs = isBlocked ? Math.max(0, decision.delaySeconds * 1000) : 0;
   const remainingMs = useCountdownMs(totalMs);
-  const { status, retry } = useCompleteOnZero(remainingMs, target);
+  const { status, retry } = useCompleteOnZero(remainingMs, target, isBlocked);
+
+  if (!isBlocked) return null;
 
   const fraction = totalMs > 0 ? remainingMs / totalMs : 0;
   const dashOffset = RING_CIRCUMFERENCE * (1 - fraction);

--- a/extension/src/entrypoints/blocked/EscapeHatch.tsx
+++ b/extension/src/entrypoints/blocked/EscapeHatch.tsx
@@ -1,0 +1,51 @@
+/**
+ * "Daily 2-minute pass" — rendered below the primary action on ALL THREE block views
+ * (Android parity: EmergencyPassAction). Three states: available, spent (visibly
+ * disabled, still rendered), or hidden entirely (Strict Mode / pass disabled — a
+ * commitment lock must not have a one-tap bypass).
+ */
+
+import { useState } from 'react';
+import type { BlockContext } from '../../core/protocol';
+import { Button } from '../../ui/components';
+import { formatNextPass } from '../../ui/format';
+import { send } from '../../ui/rpc';
+import { isNavigableTarget } from './BlockPage';
+
+export function EscapeHatch({ context, target }: { context: BlockContext; target: string }) {
+  const [pending, setPending] = useState(false);
+
+  if (!context.passEnabled || context.strictModeEnabled) {
+    return null;
+  }
+
+  if (!context.passAvailable) {
+    return (
+      <Button variant="muted" disabled style={{ marginTop: 16 }}>
+        Daily pass used · next in {formatNextPass(context.passNextAvailableMs)}
+      </Button>
+    );
+  }
+
+  const handleUsePass = async () => {
+    if (pending) return;
+    setPending(true);
+    try {
+      const result = await send({ type: 'USE_EMERGENCY_PASS', target });
+      if (result.ok && isNavigableTarget(target)) {
+        window.location.replace(target);
+        return;
+      }
+    } catch {
+      // Service worker asleep/restarting — fall through and re-enable the button below
+      // so the user can try again rather than being stuck on a dead tap.
+    }
+    setPending(false);
+  };
+
+  return (
+    <Button variant="muted" onClick={handleUsePass} disabled={pending} style={{ marginTop: 16 }}>
+      Use for 2 minutes · once a day
+    </Button>
+  );
+}

--- a/extension/src/entrypoints/blocked/HardBlockView.tsx
+++ b/extension/src/entrypoints/blocked/HardBlockView.tsx
@@ -1,0 +1,58 @@
+/**
+ * Hard Block — the rotating hardBlockMessage, a "Go Back" button, no way through.
+ * `decision.limitReached` additionally shows "Daily limit reached" (Android parity);
+ * the "(limit reached)" suffix already lives inside `decision.ruleName` (shown by the
+ * RuleFooter in BlockPage) and must NOT be added again here.
+ */
+
+import type { BlockContext } from '../../core/protocol';
+import { Button } from '../../ui/components';
+import { EscapeHatch } from './EscapeHatch';
+
+function goBack() {
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.replace('about:blank');
+  }
+}
+
+function BlockGlyph() {
+  return (
+    <svg width={56} height={56} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" fill="none" stroke="var(--nudge-error)" strokeWidth="2" />
+      <line x1="6" y1="6" x2="18" y2="18" stroke="var(--nudge-error)" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function HardBlockView({ context, target }: { context: BlockContext; target: string }) {
+  const decision = context.decision;
+  if (decision.type !== 'BLOCK') return null;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 20, width: '100%' }}>
+      <BlockGlyph />
+      <p
+        style={{
+          margin: 0,
+          fontSize: 19,
+          fontWeight: 600,
+          lineHeight: 1.45,
+          color: 'var(--nudge-on-surface)',
+        }}
+      >
+        {context.hardBlockMessage}
+      </p>
+      {decision.limitReached && (
+        <p style={{ margin: 0, fontSize: 14, fontWeight: 600, color: 'var(--nudge-danger)' }}>
+          Daily limit reached
+        </p>
+      )}
+      <Button variant="primary" onClick={goBack} style={{ marginTop: 8 }}>
+        Go Back
+      </Button>
+      <EscapeHatch context={context} target={target} />
+    </div>
+  );
+}

--- a/extension/src/entrypoints/blocked/index.html
+++ b/extension/src/entrypoints/blocked/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Nudge — Blocked</title>
+    <!-- Declare an empty favicon so Chrome does not request /favicon.ico and log a stray
+         net::ERR_FAILED on every block. We ship no icon file, and the request is pure noise. -->
+    <link rel="icon" href="data:," />
   </head>
   <body>
     <div id="root"></div>

--- a/extension/src/entrypoints/blocked/index.html
+++ b/extension/src/entrypoints/blocked/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nudge — Blocked</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/src/entrypoints/blocked/main.tsx
+++ b/extension/src/entrypoints/blocked/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client';
+import '../../ui/tokens.css';
+import { BlockPage } from './BlockPage';
+
+createRoot(document.getElementById('root')!).render(<BlockPage />);

--- a/extension/src/entrypoints/dashboard/ChallengeDialog.tsx
+++ b/extension/src/entrypoints/dashboard/ChallengeDialog.tsx
@@ -1,19 +1,6 @@
 import { useEffect, useState } from 'react';
+import { forDisplay, rawLength } from '../../core/strictMode';
 import { Button } from '../../ui/components';
-
-/** Strip whitespace/dashes so display formatting never affects the length/match check. */
-function normalizeChallengeInput(value: string): string {
-  return value.replace(/[\s-]/g, '');
-}
-
-/** Dash-group in chunks of 5 for display, matching the Android Strict Mode challenge UI. */
-function formatChallengeDisplay(code: string): string {
-  const chunks: string[] = [];
-  for (let i = 0; i < code.length; i += 5) {
-    chunks.push(code.slice(i, i + 5));
-  }
-  return chunks.join('-');
-}
 
 /**
  * "Commitment Lock" unlock UI. A save the background rejects for weakening protection while
@@ -42,9 +29,11 @@ export function ChallengeDialog({
     setTyped('');
   }, [challenge]);
 
-  const normalized = normalizeChallengeInput(typed);
-  const targetLength = normalizeChallengeInput(challenge).length;
-  const canSubmit = normalized.length === targetLength && !submitting;
+  // `rawLength` is the SAME normalization `strictMode.verify` compares against (dashes and
+  // surrounding whitespace stripped), so the counter can never disagree with the actual match.
+  const typedLength = rawLength(typed);
+  const targetLength = rawLength(challenge);
+  const canSubmit = typedLength === targetLength && !submitting;
 
   return (
     <div
@@ -88,7 +77,7 @@ export function ChallengeDialog({
             wordBreak: 'break-all',
           }}
         >
-          {formatChallengeDisplay(challenge)}
+          {forDisplay(challenge)}
         </p>
 
         <input
@@ -118,7 +107,7 @@ export function ChallengeDialog({
           data-testid="challenge-progress"
           style={{ margin: '0 0 12px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}
         >
-          {normalized.length}/{targetLength}
+          {typedLength}/{targetLength}
         </p>
 
         {error && (

--- a/extension/src/entrypoints/dashboard/ChallengeDialog.tsx
+++ b/extension/src/entrypoints/dashboard/ChallengeDialog.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { Button } from '../../ui/components';
+
+/** Strip whitespace/dashes so display formatting never affects the length/match check. */
+function normalizeChallengeInput(value: string): string {
+  return value.replace(/[\s-]/g, '');
+}
+
+/** Dash-group in chunks of 5 for display, matching the Android Strict Mode challenge UI. */
+function formatChallengeDisplay(code: string): string {
+  const chunks: string[] = [];
+  for (let i = 0; i < code.length; i += 5) {
+    chunks.push(code.slice(i, i + 5));
+  }
+  return chunks.join('-');
+}
+
+/**
+ * "Commitment Lock" unlock UI. A save the background rejects for weakening protection while
+ * Strict Mode is on comes back as `SaveResult { ok: false, challenge }` — this dialog makes the
+ * user TYPE that code back (never auto-filled, paste blocked) before retrying the save. The
+ * friction is the point: it's the only thing standing between "I'll just turn it off" and
+ * actually following through.
+ */
+export function ChallengeDialog({
+  challenge,
+  onSubmit,
+  onCancel,
+  submitting = false,
+  error = null,
+}: {
+  challenge: string;
+  onSubmit: (typed: string) => void;
+  onCancel: () => void;
+  submitting?: boolean;
+  error?: string | null;
+}) {
+  const [typed, setTyped] = useState('');
+
+  // A fresh (or re-issued, after a wrong attempt) challenge always starts from a blank input.
+  useEffect(() => {
+    setTyped('');
+  }, [challenge]);
+
+  const normalized = normalizeChallengeInput(typed);
+  const targetLength = normalizeChallengeInput(challenge).length;
+  const canSubmit = normalized.length === targetLength && !submitting;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Commitment Lock unlock"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          width: 360,
+          maxWidth: '90vw',
+          background: 'var(--nudge-surface)',
+          borderRadius: 'var(--nudge-radius)',
+          padding: 24,
+          boxShadow: '0 12px 40px rgba(0,0,0,0.35)',
+        }}
+      >
+        <h2 style={{ margin: '0 0 8px', fontSize: 18, fontWeight: 700 }}>Commitment Lock</h2>
+        <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          This change weakens protection. Type the code below exactly — pasting is disabled on
+          purpose, that friction is the whole point.
+        </p>
+
+        <p
+          data-testid="challenge-code"
+          style={{
+            margin: '0 0 12px',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 20,
+            letterSpacing: 2,
+            fontWeight: 700,
+            wordBreak: 'break-all',
+          }}
+        >
+          {formatChallengeDisplay(challenge)}
+        </p>
+
+        <input
+          type="text"
+          autoFocus
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
+          aria-label="Unlock code"
+          value={typed}
+          onChange={(e) => setTyped(e.target.value)}
+          onPaste={(e) => e.preventDefault()}
+          placeholder="Type the code above"
+          style={{
+            width: '100%',
+            padding: '10px 12px',
+            fontSize: 15,
+            borderRadius: 8,
+            border: '1px solid var(--nudge-outline)',
+            background: 'var(--nudge-background)',
+            color: 'var(--nudge-on-surface)',
+            marginBottom: 8,
+          }}
+        />
+
+        <p
+          data-testid="challenge-progress"
+          style={{ margin: '0 0 12px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}
+        >
+          {normalized.length}/{targetLength}
+        </p>
+
+        {error && (
+          <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-danger)' }}>{error}</p>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <Button variant="muted" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={() => onSubmit(typed)} disabled={!canSubmit}>
+            {submitting ? 'Checking…' : 'Unlock'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/dashboard/Dashboard.tsx
+++ b/extension/src/entrypoints/dashboard/Dashboard.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { DashboardState } from '../../core/protocol';
+import type { NudgeSettings } from '../../core/settingsSchema';
+import { send } from '../../ui/rpc';
+import { Button, NudgeMark } from '../../ui/components';
+import { ChallengeDialog } from './ChallengeDialog';
+import { SettingsPanel } from './SettingsPanel';
+import { StatsPanel } from './StatsPanel';
+
+type Tab = 'stats' | 'settings';
+
+/** A save the Commitment Lock intercepted, held until the user types the code (or gives up). */
+interface PendingChallenge {
+  challenge: string;
+  settings: NudgeSettings;
+  /** Set after a wrong answer so the dialog can say so; the background reissues the SAME code. */
+  incorrect: boolean;
+}
+
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : 'Could not reach the extension.';
+}
+
+export function Dashboard() {
+  const [data, setData] = useState<DashboardState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('stats');
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingChallenge | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    send({ type: 'GET_DASHBOARD_STATE' })
+      .then((next) => {
+        setData(next);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setLoadError(errorText(e));
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  /**
+   * Persist settings through the background, which owns the Commitment Lock gate.
+   *
+   * A rejected save comes back as `{ ok: false, challenge }` — we render the challenge and retry
+   * the SAME settings with `challengeResponse`. Optimistic local state is applied only after the
+   * background confirms, so a gated change never appears to have taken effect when it hasn't.
+   */
+  const saveSettings = useCallback(
+    (next: NudgeSettings, challengeResponse?: string) => {
+      setSaveError(null);
+      setSubmitting(challengeResponse !== undefined);
+      send({ type: 'SAVE_SETTINGS', settings: next, challengeResponse })
+        .then((result) => {
+          setSubmitting(false);
+          if (result.ok) {
+            setPending(null);
+            setData((current) => (current ? { ...current, settings: next } : current));
+            return;
+          }
+          if (result.challenge !== undefined) {
+            setPending({
+              challenge: result.challenge,
+              settings: next,
+              incorrect: result.reason === 'challenge-incorrect',
+            });
+            return;
+          }
+          setPending(null);
+          setSaveError(result.reason ?? 'That change could not be saved.');
+        })
+        .catch((e: unknown) => {
+          setSubmitting(false);
+          setSaveError(errorText(e));
+        });
+    },
+    [],
+  );
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--nudge-background)',
+        color: 'var(--nudge-on-surface)',
+        fontFamily: 'var(--nudge-font)',
+      }}
+    >
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '32px 24px 64px' }}>
+        <header style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+          <NudgeMark size={32} />
+          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 700 }}>Nudge</h1>
+        </header>
+        <p style={{ margin: '0 0 28px', fontSize: 14, color: 'var(--nudge-on-surface-variant)' }}>
+          Break the scroll. Take back your time.
+        </p>
+
+        <nav
+          role="tablist"
+          style={{
+            display: 'flex',
+            gap: 4,
+            marginBottom: 28,
+            borderBottom: '1px solid var(--nudge-surface-variant)',
+          }}
+        >
+          {(['stats', 'settings'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={tab === t}
+              onClick={() => setTab(t)}
+              style={{
+                padding: '10px 18px',
+                border: 'none',
+                background: 'transparent',
+                color: tab === t ? 'var(--nudge-primary)' : 'var(--nudge-on-surface-variant)',
+                fontSize: 15,
+                fontWeight: 600,
+                borderBottom:
+                  tab === t ? '2px solid var(--nudge-primary)' : '2px solid transparent',
+                marginBottom: -1,
+                cursor: 'pointer',
+              }}
+            >
+              {t === 'stats' ? 'Stats' : 'Settings'}
+            </button>
+          ))}
+        </nav>
+
+        {loading && (
+          <p style={{ fontSize: 14, color: 'var(--nudge-on-surface-variant)' }}>Loading…</p>
+        )}
+
+        {!loading && loadError && (
+          <div>
+            <p style={{ fontSize: 14, color: 'var(--nudge-danger)', marginTop: 0 }}>{loadError}</p>
+            <Button variant="secondary" onClick={load}>
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {!loading && !loadError && data && (
+          <>
+            {tab === 'stats' ? (
+              <StatsPanel data={data} />
+            ) : (
+              <SettingsPanel
+                settings={data.settings}
+                onChange={(next) => saveSettings(next)}
+                saveError={saveError}
+              />
+            )}
+          </>
+        )}
+      </div>
+
+      {pending && (
+        <ChallengeDialog
+          challenge={pending.challenge}
+          submitting={submitting}
+          error={pending.incorrect ? "That code doesn't match. Try again." : null}
+          onCancel={() => {
+            setPending(null);
+            setSaveError(null);
+          }}
+          onSubmit={(typed) => saveSettings(pending.settings, typed)}
+        />
+      )}
+    </div>
+  );
+}

--- a/extension/src/entrypoints/dashboard/Dashboard.tsx
+++ b/extension/src/entrypoints/dashboard/Dashboard.tsx
@@ -49,6 +49,26 @@ export function Dashboard() {
   }, [load]);
 
   /**
+   * Re-fetch when the dashboard comes back to the foreground.
+   *
+   * This is a normal tab people leave open, and usage accrues in the service worker while
+   * they browse elsewhere — without this it keeps showing whatever was true when it was
+   * opened, which reads as "the stats are broken". Refreshing on focus/visibility rather than
+   * polling costs nothing while the tab sits in the background.
+   */
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState === 'visible') load();
+    };
+    document.addEventListener('visibilitychange', refresh);
+    window.addEventListener('focus', refresh);
+    return () => {
+      document.removeEventListener('visibilitychange', refresh);
+      window.removeEventListener('focus', refresh);
+    };
+  }, [load]);
+
+  /**
    * Persist settings through the background, which owns the Commitment Lock gate.
    *
    * A rejected save comes back as `{ ok: false, challenge }` — we render the challenge and retry

--- a/extension/src/entrypoints/dashboard/RuleEditor.tsx
+++ b/extension/src/entrypoints/dashboard/RuleEditor.tsx
@@ -217,6 +217,17 @@ export function RuleEditor({
         <Card title="Delay">{delayPicker(draft.delaySeconds, (delaySeconds) => setDraft((d) => ({ ...d, delaySeconds })), 'default')}</Card>
 
         <Card title="Daily Time Limit">
+          {draft.mode === 'HARD_BLOCK' ? (
+            // A budget only means something for a mode that lets you through. Hard Block bars
+            // the site outright, so there is no browsing time to limit — offering the control
+            // here would invite a combination that reads as "blocked, but only after 30
+            // minutes", which is not what it does.
+            <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+              Not used with Hard Block — the site is always blocked, so there is no time to
+              budget. Switch to Delay or Breathing to set a daily limit.
+            </p>
+          ) : (
+          <>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
             <button
               type="button"
@@ -295,6 +306,8 @@ export function RuleEditor({
                 label="Show time remaining"
               />
             </div>
+          )}
+          </>
           )}
         </Card>
 

--- a/extension/src/entrypoints/dashboard/RuleEditor.tsx
+++ b/extension/src/entrypoints/dashboard/RuleEditor.tsx
@@ -1,0 +1,415 @@
+import { useState } from 'react';
+import type { ScheduleOverride, SiteRule } from '../../core/settingsSchema';
+import {
+  DAILY_LIMIT_MAX_MINUTES,
+  DAILY_LIMIT_MIN_MINUTES,
+  DAILY_LIMIT_PRESETS,
+  DELAY_MAX_SECONDS,
+  DELAY_MIN_SECONDS,
+  DELAY_PRESETS,
+} from '../../core/settingsSchema';
+import type { BlockMode } from '../../core/types';
+import { MODE_LABELS } from '../../core/types';
+import { formatMinuteOfDay } from '../../ui/format';
+import { Button, Card, Toggle } from '../../ui/components';
+
+const MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+const DAY_LABELS: { iso: number; label: string }[] = [
+  { iso: 1, label: 'Mon' },
+  { iso: 2, label: 'Tue' },
+  { iso: 3, label: 'Wed' },
+  { iso: 4, label: 'Thu' },
+  { iso: 5, label: 'Fri' },
+  { iso: 6, label: 'Sat' },
+  { iso: 7, label: 'Sun' },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+/** `<input type="time">` uses `HH:MM`, which is exactly `formatMinuteOfDay`'s output. */
+function minutesToTimeValue(minutes: number | null): string {
+  return formatMinuteOfDay(minutes ?? 0);
+}
+
+function timeValueToMinutes(value: string): number | null {
+  const match = /^(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+  const h = Number(match[1]);
+  const m = Number(match[2]);
+  return clamp(h * 60 + m, 0, 1439);
+}
+
+function modePicker(value: BlockMode, onChange: (mode: BlockMode) => void, idPrefix: string) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as BlockMode)}
+      aria-label={`${idPrefix} mode`}
+      style={{
+        padding: '8px 10px',
+        borderRadius: 8,
+        border: '1px solid var(--nudge-outline)',
+        background: 'var(--nudge-background)',
+        color: 'var(--nudge-on-surface)',
+        fontSize: 13,
+      }}
+    >
+      {MODES.map((m) => (
+        <option key={m} value={m}>
+          {MODE_LABELS[m]}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function delayPicker(
+  value: number,
+  onChange: (seconds: number) => void,
+  idPrefix: string,
+) {
+  const isPreset = (DELAY_PRESETS as readonly number[]).includes(value);
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+      {DELAY_PRESETS.map((preset) => (
+        <button
+          key={preset}
+          type="button"
+          onClick={() => onChange(preset)}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 999,
+            border: '1px solid var(--nudge-outline)',
+            background: value === preset ? 'var(--nudge-primary)' : 'transparent',
+            color: value === preset ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+            fontSize: 12,
+            cursor: 'pointer',
+          }}
+        >
+          {preset}s
+        </button>
+      ))}
+      <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+        Custom
+        <input
+          type="number"
+          aria-label={`${idPrefix} custom delay seconds`}
+          min={DELAY_MIN_SECONDS}
+          max={DELAY_MAX_SECONDS}
+          value={isPreset ? '' : value}
+          placeholder={String(value)}
+          onChange={(e) => {
+            const parsed = Number(e.target.value);
+            if (e.target.value !== '' && Number.isFinite(parsed)) {
+              onChange(clamp(parsed, DELAY_MIN_SECONDS, DELAY_MAX_SECONDS));
+            }
+          }}
+          style={{
+            width: 64,
+            marginLeft: 6,
+            padding: '6px 8px',
+            borderRadius: 8,
+            border: '1px solid var(--nudge-outline)',
+            background: 'var(--nudge-background)',
+            color: 'var(--nudge-on-surface)',
+          }}
+        />
+      </label>
+    </div>
+  );
+}
+
+export function RuleEditor({
+  rule,
+  onSave,
+  onCancel,
+  onDelete,
+}: {
+  rule: SiteRule;
+  onSave: (next: SiteRule) => void;
+  onCancel: () => void;
+  onDelete?: (id: string) => void;
+}) {
+  const [draft, setDraft] = useState<SiteRule>(rule);
+
+  const limitPreset = (DAILY_LIMIT_PRESETS as readonly number[]).includes(
+    draft.dailyLimitMinutes ?? -1,
+  );
+
+  const schedule: ScheduleOverride | null = draft.schedule;
+
+  function setSchedule(patch: Partial<ScheduleOverride>) {
+    setDraft((d) => ({
+      ...d,
+      schedule: d.schedule ? { ...d.schedule, ...patch } : null,
+    }));
+  }
+
+  function toggleScheduleEnabled(enabled: boolean) {
+    setDraft((d) => ({
+      ...d,
+      schedule: enabled
+        ? (d.schedule ?? {
+            enabled: true,
+            days: null,
+            startMinute: 540, // 09:00 — a concrete starting window, not "always"
+            endMinute: 1020, // 17:00
+            mode: d.mode,
+            delaySeconds: d.delaySeconds,
+          })
+        : d.schedule
+          ? { ...d.schedule, enabled: false }
+          : null,
+    }));
+  }
+
+  function toggleDay(iso: number) {
+    setSchedule({
+      days: schedule?.days?.includes(iso)
+        ? schedule.days.filter((d) => d !== iso)
+        : [...(schedule?.days ?? []), iso],
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Edit rule for ${draft.domain}`}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        overflowY: 'auto',
+        padding: '5vh 16px',
+        zIndex: 900,
+      }}
+    >
+      <div
+        style={{
+          width: 480,
+          maxWidth: '100%',
+          background: 'var(--nudge-surface)',
+          borderRadius: 'var(--nudge-radius)',
+          padding: 24,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 18,
+        }}
+      >
+        <div>
+          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700 }}>{draft.domain}</h2>
+          <Toggle
+            checked={draft.enabled}
+            onChange={(enabled) => setDraft((d) => ({ ...d, enabled }))}
+            label="Rule enabled"
+          />
+        </div>
+
+        <Card title="Mode">{modePicker(draft.mode, (mode) => setDraft((d) => ({ ...d, mode })), 'default')}</Card>
+
+        <Card title="Delay">{delayPicker(draft.delaySeconds, (delaySeconds) => setDraft((d) => ({ ...d, delaySeconds })), 'default')}</Card>
+
+        <Card title="Daily Time Limit">
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <button
+              type="button"
+              onClick={() => setDraft((d) => ({ ...d, dailyLimitMinutes: null }))}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 999,
+                border: '1px solid var(--nudge-outline)',
+                background: draft.dailyLimitMinutes === null ? 'var(--nudge-primary)' : 'transparent',
+                color:
+                  draft.dailyLimitMinutes === null
+                    ? 'var(--nudge-on-primary)'
+                    : 'var(--nudge-on-surface)',
+                fontSize: 12,
+                cursor: 'pointer',
+              }}
+            >
+              No limit
+            </button>
+            {DAILY_LIMIT_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => setDraft((d) => ({ ...d, dailyLimitMinutes: preset }))}
+                style={{
+                  padding: '6px 12px',
+                  borderRadius: 999,
+                  border: '1px solid var(--nudge-outline)',
+                  background: draft.dailyLimitMinutes === preset ? 'var(--nudge-primary)' : 'transparent',
+                  color:
+                    draft.dailyLimitMinutes === preset
+                      ? 'var(--nudge-on-primary)'
+                      : 'var(--nudge-on-surface)',
+                  fontSize: 12,
+                  cursor: 'pointer',
+                }}
+              >
+                {preset < 60 ? `${preset}m` : `${preset / 60}h`}
+              </button>
+            ))}
+            <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+              Custom
+              <input
+                type="number"
+                aria-label="Custom daily limit minutes"
+                min={DAILY_LIMIT_MIN_MINUTES}
+                max={DAILY_LIMIT_MAX_MINUTES}
+                value={limitPreset || draft.dailyLimitMinutes === null ? '' : draft.dailyLimitMinutes}
+                placeholder={draft.dailyLimitMinutes === null ? '—' : String(draft.dailyLimitMinutes)}
+                onChange={(e) => {
+                  const parsed = Number(e.target.value);
+                  if (e.target.value !== '' && Number.isFinite(parsed)) {
+                    setDraft((d) => ({
+                      ...d,
+                      dailyLimitMinutes: clamp(parsed, DAILY_LIMIT_MIN_MINUTES, DAILY_LIMIT_MAX_MINUTES),
+                    }));
+                  }
+                }}
+                style={{
+                  width: 64,
+                  marginLeft: 6,
+                  padding: '6px 8px',
+                  borderRadius: 8,
+                  border: '1px solid var(--nudge-outline)',
+                  background: 'var(--nudge-background)',
+                  color: 'var(--nudge-on-surface)',
+                }}
+              />
+            </label>
+          </div>
+          {draft.dailyLimitMinutes !== null && (
+            <div style={{ marginTop: 12 }}>
+              <Toggle
+                checked={draft.showTimeRemaining}
+                onChange={(showTimeRemaining) => setDraft((d) => ({ ...d, showTimeRemaining }))}
+                label="Show time remaining"
+              />
+            </div>
+          )}
+        </Card>
+
+        <Card title="Scheduled Override">
+          <Toggle
+            checked={schedule?.enabled === true}
+            onChange={toggleScheduleEnabled}
+            label="Enable scheduled override"
+          />
+          {schedule?.enabled && (
+            <div style={{ marginTop: 14, display: 'flex', flexDirection: 'column', gap: 14 }}>
+              <div>
+                <p style={{ margin: '0 0 6px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                  Days (none selected = every day)
+                </p>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  {DAY_LABELS.map(({ iso, label }) => {
+                    const active = schedule.days?.includes(iso) ?? false;
+                    return (
+                      <button
+                        key={iso}
+                        type="button"
+                        onClick={() => toggleDay(iso)}
+                        style={{
+                          width: 40,
+                          height: 32,
+                          borderRadius: 8,
+                          border: '1px solid var(--nudge-outline)',
+                          background: active ? 'var(--nudge-primary)' : 'transparent',
+                          color: active ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+                          fontSize: 12,
+                          cursor: 'pointer',
+                        }}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+                <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                  Start
+                  <input
+                    type="time"
+                    step={900}
+                    aria-label="Scheduled override start time"
+                    value={minutesToTimeValue(schedule.startMinute)}
+                    onChange={(e) => setSchedule({ startMinute: timeValueToMinutes(e.target.value) })}
+                    style={{
+                      display: 'block',
+                      marginTop: 4,
+                      padding: '6px 8px',
+                      borderRadius: 8,
+                      border: '1px solid var(--nudge-outline)',
+                      background: 'var(--nudge-background)',
+                      color: 'var(--nudge-on-surface)',
+                    }}
+                  />
+                </label>
+                <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                  End
+                  <input
+                    type="time"
+                    step={900}
+                    aria-label="Scheduled override end time"
+                    value={minutesToTimeValue(schedule.endMinute)}
+                    onChange={(e) => setSchedule({ endMinute: timeValueToMinutes(e.target.value) })}
+                    style={{
+                      display: 'block',
+                      marginTop: 4,
+                      padding: '6px 8px',
+                      borderRadius: 8,
+                      border: '1px solid var(--nudge-outline)',
+                      background: 'var(--nudge-background)',
+                      color: 'var(--nudge-on-surface)',
+                    }}
+                  />
+                </label>
+              </div>
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                Overnight spans are supported — e.g. start 23:00, end 06:00 applies from 11pm
+                through 6am the next morning.
+              </p>
+
+              <div>
+                <p style={{ margin: '0 0 6px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                  Mode + delay inside the window
+                </p>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center' }}>
+                  {modePicker(schedule.mode, (mode) => setSchedule({ mode }), 'scheduled')}
+                  {delayPicker(schedule.delaySeconds, (delaySeconds) => setSchedule({ delaySeconds }), 'scheduled')}
+                </div>
+              </div>
+            </div>
+          )}
+        </Card>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          {onDelete ? (
+            <Button variant="danger" onClick={() => onDelete(draft.id)}>
+              Delete rule
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Button variant="muted" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={() => onSave(draft)}>Save rule</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/dashboard/SettingsPanel.tsx
+++ b/extension/src/entrypoints/dashboard/SettingsPanel.tsx
@@ -1,0 +1,613 @@
+import { useRef, useState } from 'react';
+import { normalizeUserInput } from '../../core/domainMatcher';
+import {
+  DEFAULT_DELAY_SUBTITLES,
+  DEFAULT_DELAY_TITLES,
+  DEFAULT_HARD_BLOCK_MESSAGES,
+} from '../../core/messages';
+import {
+  CHALLENGE_LENGTH_EASY,
+  CHALLENGE_LENGTH_HARD,
+  CHALLENGE_LENGTH_MEDIUM,
+  DAILY_LIMIT_MAX_MINUTES,
+  DAILY_LIMIT_MIN_MINUTES,
+  DAILY_LIMIT_PRESETS,
+  DEFAULT_DELAY_SECONDS,
+  DELAY_MAX_SECONDS,
+  DELAY_MIN_SECONDS,
+  DELAY_PRESETS,
+  TEMP_ALLOW_MAX_MINUTES,
+  TEMP_ALLOW_MIN_MINUTES,
+} from '../../core/settingsSchema';
+import type { NudgeSettings, SiteRule } from '../../core/settingsSchema';
+import type { BlockMode } from '../../core/types';
+import { MODE_LABELS } from '../../core/types';
+import { buildExport, dedupeImportedRules, parseImport } from '../../ui/exportImport';
+import { formatMinuteOfDay } from '../../ui/format';
+import { Button, Card, Toggle } from '../../ui/components';
+import { RuleEditor } from './RuleEditor';
+
+const MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+const DIFFICULTIES: { label: string; length: number }[] = [
+  { label: 'Easy', length: CHALLENGE_LENGTH_EASY },
+  { label: 'Medium', length: CHALLENGE_LENGTH_MEDIUM },
+  { label: 'Hard', length: CHALLENGE_LENGTH_HARD },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function Chip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        padding: '6px 14px',
+        borderRadius: 999,
+        border: '1px solid var(--nudge-outline)',
+        background: active ? 'var(--nudge-primary)' : 'transparent',
+        color: active ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+        fontSize: 13,
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function minuteLabel(minutes: number): string {
+  return minutes < 60 ? `${minutes}m` : `${minutes / 60}h`;
+}
+
+/** One "Delay title / Delay subtitle / Hard-block message" textarea + its reset action. */
+function MessageField({
+  label,
+  value,
+  defaults,
+  onChange,
+}: {
+  label: string;
+  value: string[];
+  defaults: string[];
+  onChange: (lines: string[]) => void;
+}) {
+  const usingDefaults = value.length === 0;
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: 6,
+        }}
+      >
+        <label htmlFor={`msg-${label}`} style={{ fontSize: 13, fontWeight: 600 }}>
+          {label}
+        </label>
+        <Button
+          variant="muted"
+          onClick={() => onChange([])}
+          disabled={usingDefaults}
+          style={{ padding: '2px 8px', fontSize: 12 }}
+        >
+          Reset to defaults
+        </Button>
+      </div>
+      <textarea
+        id={`msg-${label}`}
+        rows={5}
+        value={(usingDefaults ? defaults : value).join('\n')}
+        placeholder="One message per line"
+        onChange={(e) => {
+          const lines = e.target.value.split('\n').map((l) => l.trimEnd());
+          // All-blank means "use the bundled defaults" — the same convention the
+          // background's `resolvePool` applies when rendering a block page.
+          onChange(lines.every((l) => l.trim() === '') ? [] : lines);
+        }}
+        style={{
+          width: '100%',
+          padding: 10,
+          fontSize: 13,
+          lineHeight: 1.5,
+          fontFamily: 'inherit',
+          borderRadius: 8,
+          border: '1px solid var(--nudge-outline)',
+          background: 'var(--nudge-background)',
+          color: 'var(--nudge-on-surface)',
+          resize: 'vertical',
+        }}
+      />
+      {usingDefaults && (
+        <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+          Using the built-in messages. Edit above to use your own.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** A compact summary line for a rule row: "Delay · 15s · 30m/day · Scheduled 23:00–06:00". */
+function ruleSummary(rule: SiteRule): string {
+  const parts: string[] = [MODE_LABELS[rule.mode]];
+  if (rule.mode !== 'HARD_BLOCK') parts.push(`${rule.delaySeconds}s`);
+  if (rule.dailyLimitMinutes !== null) parts.push(`${minuteLabel(rule.dailyLimitMinutes)}/day`);
+  if (rule.schedule?.enabled) {
+    const start = rule.schedule.startMinute;
+    const end = rule.schedule.endMinute;
+    parts.push(
+      start !== null && end !== null
+        ? `Scheduled ${formatMinuteOfDay(start)}–${formatMinuteOfDay(end)}`
+        : 'Scheduled',
+    );
+  }
+  if (!rule.enabled) parts.push('disabled');
+  return parts.join(' · ');
+}
+
+export function SettingsPanel({
+  settings,
+  onChange,
+  saveError,
+}: {
+  settings: NudgeSettings;
+  /** Every mutation goes straight to the background so Strict Mode can gate it there. */
+  onChange: (next: NudgeSettings) => void;
+  saveError?: string | null;
+}) {
+  const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
+  const [newDomain, setNewDomain] = useState('');
+  const [newDomainError, setNewDomainError] = useState<string | null>(null);
+  const [importMessage, setImportMessage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const editingRule = settings.rules.find((r) => r.id === editingRuleId) ?? null;
+
+  function patch(changes: Partial<NudgeSettings>) {
+    onChange({ ...settings, ...changes });
+  }
+
+  function handleAddDomain() {
+    const normalized = normalizeUserInput(newDomain);
+    if (normalized === null) {
+      setNewDomainError("That doesn't look like a website address.");
+      return;
+    }
+    if (settings.rules.some((r) => r.domain === normalized)) {
+      setNewDomainError('There is already a rule for that site.');
+      return;
+    }
+    setNewDomainError(null);
+    setNewDomain('');
+    patch({
+      rules: [
+        ...settings.rules,
+        {
+          id: `rule-${normalized}-${Date.now()}`,
+          domain: normalized,
+          mode: 'DELAY',
+          delaySeconds: DEFAULT_DELAY_SECONDS,
+          dailyLimitMinutes: null,
+          enabled: true,
+          createdAt: Date.now(),
+          showTimeRemaining: false,
+          schedule: null,
+        },
+      ],
+    });
+  }
+
+  function handleExport() {
+    const payload = buildExport(settings);
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `nudge-rules-${new Date().toISOString().slice(0, 10)}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleImportFile(file: File) {
+    setImportMessage(null);
+    file
+      .text()
+      .then((text) => {
+        const result = parseImport(text);
+        if (!result.ok || !result.rules) {
+          setImportMessage(result.error ?? 'Could not read that file.');
+          return;
+        }
+        const merged = dedupeImportedRules(settings.rules, result.rules);
+        const added = merged.length - settings.rules.length;
+        patch({ rules: merged });
+        setImportMessage(
+          added === 0
+            ? 'Nothing new to import — every site in that file already has a rule.'
+            : `Imported ${added} rule${added === 1 ? '' : 's'}.`,
+        );
+      })
+      .catch(() => setImportMessage('Could not read that file.'));
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {saveError && (
+        <Card style={{ borderColor: 'var(--nudge-danger)' }}>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-danger)' }}>{saveError}</p>
+        </Card>
+      )}
+
+      <Card>
+        <Toggle
+          checked={settings.globalEnabled}
+          onChange={(globalEnabled) => patch({ globalEnabled })}
+          label="Nudge is on"
+        />
+        <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          Turning this off suspends every rule — Nudge behaves as if it weren't installed.
+        </p>
+      </Card>
+
+      <Card title="Blocked sites">
+        <div style={{ display: 'flex', gap: 8, marginBottom: 16, flexWrap: 'wrap' }}>
+          <input
+            type="text"
+            aria-label="Site to block"
+            value={newDomain}
+            placeholder="youtube.com"
+            onChange={(e) => {
+              setNewDomain(e.target.value);
+              setNewDomainError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAddDomain();
+            }}
+            style={{
+              flex: '1 1 200px',
+              padding: '10px 12px',
+              fontSize: 14,
+              borderRadius: 8,
+              border: '1px solid var(--nudge-outline)',
+              background: 'var(--nudge-background)',
+              color: 'var(--nudge-on-surface)',
+            }}
+          />
+          <Button onClick={handleAddDomain}>Add site</Button>
+        </div>
+        {newDomainError && (
+          <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-danger)' }}>
+            {newDomainError}
+          </p>
+        )}
+
+        {settings.rules.length === 0 ? (
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            No sites yet. Add one above, or use "Block this site" from the toolbar popup.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {settings.rules.map((rule) => (
+              <div
+                key={rule.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  padding: '10px 12px',
+                  borderRadius: 'var(--nudge-radius-sm)',
+                  border: '1px solid var(--nudge-surface-variant)',
+                }}
+              >
+                <div style={{ minWidth: 0 }}>
+                  <p
+                    style={{
+                      margin: 0,
+                      fontSize: 14,
+                      fontWeight: 600,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {rule.domain}
+                  </p>
+                  <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                    {ruleSummary(rule)}
+                  </p>
+                </div>
+                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setEditingRuleId(rule.id)}
+                    style={{ padding: '6px 14px', fontSize: 13 }}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    variant="muted"
+                    onClick={() => patch({ rules: settings.rules.filter((r) => r.id !== rule.id) })}
+                    style={{ padding: '6px 14px', fontSize: 13 }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
+          <Button variant="muted" onClick={handleExport} style={{ padding: '8px 14px', fontSize: 13 }}>
+            Export rules
+          </Button>
+          <Button
+            variant="muted"
+            onClick={() => fileInputRef.current?.click()}
+            style={{ padding: '8px 14px', fontSize: 13 }}
+          >
+            Import rules
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            aria-label="Import rules file"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleImportFile(file);
+              e.target.value = '';
+            }}
+          />
+        </div>
+        {importMessage && (
+          <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            {importMessage}
+          </p>
+        )}
+      </Card>
+
+      <Card title="Daily Time Limit defaults">
+        <p style={{ margin: '0 0 10px', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          Limits are set per site in each rule. Presets: {DAILY_LIMIT_PRESETS.map(minuteLabel).join(' · ')},
+          or any value from {DAILY_LIMIT_MIN_MINUTES} to {DAILY_LIMIT_MAX_MINUTES} minutes.
+        </p>
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          Delay presets: {DELAY_PRESETS.map((d) => `${d}s`).join(' · ')}, or {DELAY_MIN_SECONDS}–
+          {DELAY_MAX_SECONDS} seconds.
+        </p>
+      </Card>
+
+      <Card title="After a pause">
+        <label style={{ fontSize: 13 }}>
+          Temporary access (minutes)
+          <input
+            type="number"
+            aria-label="Temporary access minutes"
+            min={TEMP_ALLOW_MIN_MINUTES}
+            max={TEMP_ALLOW_MAX_MINUTES}
+            value={settings.tempAllowMinutes}
+            onChange={(e) => {
+              const parsed = Number(e.target.value);
+              if (e.target.value !== '' && Number.isFinite(parsed)) {
+                patch({
+                  tempAllowMinutes: clamp(parsed, TEMP_ALLOW_MIN_MINUTES, TEMP_ALLOW_MAX_MINUTES),
+                });
+              }
+            }}
+            style={{
+              display: 'block',
+              width: 90,
+              marginTop: 6,
+              padding: '8px 10px',
+              borderRadius: 8,
+              border: '1px solid var(--nudge-outline)',
+              background: 'var(--nudge-background)',
+              color: 'var(--nudge-on-surface)',
+            }}
+          />
+        </label>
+        <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          How long a site stays open after you complete a Delay or Breathing pause
+          ({TEMP_ALLOW_MIN_MINUTES}–{TEMP_ALLOW_MAX_MINUTES} minutes).
+        </p>
+      </Card>
+
+      <Card title="Block messages">
+        <MessageField
+          label="Delay title"
+          value={settings.messages.delayTitles}
+          defaults={DEFAULT_DELAY_TITLES}
+          onChange={(delayTitles) => patch({ messages: { ...settings.messages, delayTitles } })}
+        />
+        <MessageField
+          label="Delay subtitle"
+          value={settings.messages.delaySubtitles}
+          defaults={DEFAULT_DELAY_SUBTITLES}
+          onChange={(delaySubtitles) => patch({ messages: { ...settings.messages, delaySubtitles } })}
+        />
+        <MessageField
+          label="Hard-block message"
+          value={settings.messages.hardBlockMessages}
+          defaults={DEFAULT_HARD_BLOCK_MESSAGES}
+          onChange={(hardBlockMessages) =>
+            patch({ messages: { ...settings.messages, hardBlockMessages } })
+          }
+        />
+        <p style={{ margin: 0, fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+          One message per line. Nudge picks one at random each time.
+        </p>
+      </Card>
+
+      <Card title="YouTube Shorts">
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 14 }}>
+          <Chip
+            label="Inherit"
+            active={settings.youtube.shortsMode === 'INHERIT'}
+            onClick={() => patch({ youtube: { ...settings.youtube, shortsMode: 'INHERIT' } })}
+          />
+          {MODES.map((m) => (
+            <Chip
+              key={m}
+              label={MODE_LABELS[m]}
+              active={settings.youtube.shortsMode === m}
+              onClick={() => patch({ youtube: { ...settings.youtube, shortsMode: m } })}
+            />
+          ))}
+        </div>
+        <p style={{ margin: '0 0 14px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+          "Inherit" follows whatever rule you set for youtube.com.
+        </p>
+
+        {settings.youtube.shortsMode !== 'INHERIT' && settings.youtube.shortsMode !== 'HARD_BLOCK' && (
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', marginBottom: 14 }}>
+            {DELAY_PRESETS.map((preset) => (
+              <Chip
+                key={preset}
+                label={`${preset}s`}
+                active={settings.youtube.shortsDelaySeconds === preset}
+                onClick={() => patch({ youtube: { ...settings.youtube, shortsDelaySeconds: preset } })}
+              />
+            ))}
+            <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+              Custom
+              <input
+                type="number"
+                aria-label="Shorts custom delay seconds"
+                min={DELAY_MIN_SECONDS}
+                max={DELAY_MAX_SECONDS}
+                value={settings.youtube.shortsDelaySeconds}
+                onChange={(e) => {
+                  const parsed = Number(e.target.value);
+                  if (e.target.value !== '' && Number.isFinite(parsed)) {
+                    patch({
+                      youtube: {
+                        ...settings.youtube,
+                        shortsDelaySeconds: clamp(parsed, DELAY_MIN_SECONDS, DELAY_MAX_SECONDS),
+                      },
+                    });
+                  }
+                }}
+                style={{
+                  width: 64,
+                  marginLeft: 6,
+                  padding: '6px 8px',
+                  borderRadius: 8,
+                  border: '1px solid var(--nudge-outline)',
+                  background: 'var(--nudge-background)',
+                  color: 'var(--nudge-on-surface)',
+                }}
+              />
+            </label>
+          </div>
+        )}
+
+        <Toggle
+          checked={settings.youtube.hideShortsShelf}
+          onChange={(hideShortsShelf) => patch({ youtube: { ...settings.youtube, hideShortsShelf } })}
+          label="Hide Shorts shelf"
+        />
+      </Card>
+
+      <Card title="Escape Hatch">
+        <Toggle
+          checked={settings.emergencyPass.enabled && !settings.strictMode.enabled}
+          onChange={(enabled) => patch({ emergencyPass: { enabled } })}
+          label="Allow a daily 2-minute pass"
+          disabled={settings.strictMode.enabled}
+        />
+        <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          {settings.strictMode.enabled
+            ? 'Unavailable while Commitment Lock is on — a commitment device cannot have a one-tap bypass.'
+            : 'One 2-minute window per day, shared across every blocked site.'}
+        </p>
+      </Card>
+
+      <Card title="Commitment Lock">
+        <Toggle
+          checked={settings.strictMode.enabled}
+          onChange={(enabled) => patch({ strictMode: { ...settings.strictMode, enabled } })}
+          label="Lock my settings (Strict Mode)"
+        />
+        <p style={{ margin: '10px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          While this is on, anything that weakens your protection — turning Nudge off, deleting or
+          softening a rule, shortening a delay, raising a limit — requires typing a random unlock
+          code by hand. Strengthening protection is never gated.
+        </p>
+
+        <div style={{ marginTop: 16 }}>
+          <p style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>Difficulty</p>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {DIFFICULTIES.map(({ label, length }) => (
+              <Chip
+                key={label}
+                label={`${label} (${length})`}
+                active={settings.strictMode.challengeLength === length}
+                onClick={() =>
+                  patch({ strictMode: { ...settings.strictMode, challengeLength: length } })
+                }
+              />
+            ))}
+          </div>
+          <p style={{ margin: '8px 0 0', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+            The number of characters you have to type to unlock a weakening change.
+          </p>
+        </div>
+
+        <div
+          style={{
+            marginTop: 18,
+            padding: 14,
+            borderRadius: 'var(--nudge-radius-sm)',
+            border: '1px solid var(--nudge-outline)',
+          }}
+        >
+          <p style={{ margin: '0 0 6px', fontSize: 13, fontWeight: 700 }}>
+            What this lock cannot do
+          </p>
+          <p style={{ margin: 0, fontSize: 13, lineHeight: 1.55, color: 'var(--nudge-on-surface-variant)' }}>
+            A Chrome extension cannot prevent its own removal. Anyone can open{' '}
+            <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>
+              chrome://extensions
+            </span>{' '}
+            and uninstall or disable Nudge in two clicks, and no extension — ours or anyone
+            else's — can stop that. Commitment Lock is a commitment device, not an unbreakable
+            lock: it makes an impulsive bypass slow and deliberate enough that you notice you're
+            doing it. We'd rather tell you that plainly than pretend otherwise.
+          </p>
+        </div>
+      </Card>
+
+      {editingRule && (
+        <RuleEditor
+          rule={editingRule}
+          onCancel={() => setEditingRuleId(null)}
+          onSave={(next) => {
+            patch({ rules: settings.rules.map((r) => (r.id === next.id ? next : r)) });
+            setEditingRuleId(null);
+          }}
+          onDelete={(id) => {
+            patch({ rules: settings.rules.filter((r) => r.id !== id) });
+            setEditingRuleId(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/extension/src/entrypoints/dashboard/StatsPanel.tsx
+++ b/extension/src/entrypoints/dashboard/StatsPanel.tsx
@@ -1,0 +1,234 @@
+import type { DashboardState, UsageByDay } from '../../core/protocol';
+import { formatDuration } from '../../ui/format';
+import { Card } from '../../ui/components';
+
+/** Sum active seconds for every domain on `day`; 0 when the day has no rollup yet. */
+function dayActiveSeconds(usage: UsageByDay, day: string): number {
+  const dayUsage = usage[day];
+  if (!dayUsage) return 0;
+  return Object.values(dayUsage).reduce((sum, d) => sum + d.activeSec, 0);
+}
+
+function dayCounts(usage: UsageByDay, day: string): { blocked: number; walkedAway: number } {
+  const dayUsage = usage[day];
+  if (!dayUsage) return { blocked: 0, walkedAway: 0 };
+  let blocked = 0;
+  let walkedAway = 0;
+  for (const d of Object.values(dayUsage)) {
+    blocked += d.blocked;
+    walkedAway += d.walkedAway;
+  }
+  return { blocked, walkedAway };
+}
+
+function hourlyTotals(usage: UsageByDay, days: string[]): number[] {
+  const hours = new Array<number>(24).fill(0);
+  for (const day of days) {
+    const dayUsage = usage[day];
+    if (!dayUsage) continue;
+    for (const d of Object.values(dayUsage)) {
+      d.hourly.forEach((v, h) => {
+        hours[h] = (hours[h] ?? 0) + v;
+      });
+    }
+  }
+  return hours;
+}
+
+function domainTotals(usage: UsageByDay, days: string[]): { domain: string; activeSec: number }[] {
+  const totals: Record<string, number> = {};
+  for (const day of days) {
+    const dayUsage = usage[day];
+    if (!dayUsage) continue;
+    for (const [domain, d] of Object.entries(dayUsage)) {
+      totals[domain] = (totals[domain] ?? 0) + d.activeSec;
+    }
+  }
+  return Object.entries(totals)
+    .map(([domain, activeSec]) => ({ domain, activeSec }))
+    .sort((a, b) => b.activeSec - a.activeSec);
+}
+
+function weekdayLabel(day: string): string {
+  // `day` is a local yyyy-mm-dd key; parse as local (not UTC) to avoid an off-by-one.
+  const parts = day.split('-').map(Number);
+  const [y, m, d] = parts as [number, number, number];
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, { weekday: 'short' });
+}
+
+export function StatsPanel({ data }: { data: DashboardState }) {
+  const { usage, recentDays, allTimeBlocked, allTimeWalkedAway } = data;
+  const todayKey = recentDays[recentDays.length - 1] ?? '';
+  const todayActive = dayActiveSeconds(usage, todayKey);
+  const todayCounts = dayCounts(usage, todayKey);
+
+  const dayValues = recentDays.map((day) => ({
+    day,
+    active: dayActiveSeconds(usage, day),
+    ...dayCounts(usage, day),
+  }));
+  const maxDay = Math.max(1, ...dayValues.map((d) => d.active));
+
+  const hours = hourlyTotals(usage, recentDays);
+  const maxHour = Math.max(1, ...hours);
+
+  const topSites = domainTotals(usage, recentDays).slice(0, 8);
+  const maxSite = Math.max(1, ...topSites.map((s) => s.activeSec));
+
+  const isAllZero = todayActive === 0 && maxDay === 1 && topSites.length === 0;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 16 }}>
+        <Card title="Today">
+          <p style={{ margin: 0, fontSize: 32, fontWeight: 700 }}>{formatDuration(todayActive)}</p>
+          <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            screen time
+          </p>
+        </Card>
+        <Card title="Blocked">
+          <p style={{ margin: 0, fontSize: 32, fontWeight: 700 }}>{todayCounts.blocked}</p>
+          <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            today · {allTimeBlocked} all-time
+          </p>
+        </Card>
+        <Card title="Walked Away">
+          <p style={{ margin: 0, fontSize: 32, fontWeight: 700 }}>{todayCounts.walkedAway}</p>
+          <p style={{ margin: '4px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            today · {allTimeWalkedAway} all-time
+          </p>
+        </Card>
+      </div>
+
+      {isAllZero && (
+        <Card>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            No activity tracked yet. Stats fill in as you browse.
+          </p>
+        </Card>
+      )}
+
+      <Card title="Last 7 days">
+        <svg
+          role="img"
+          aria-label="7-day screen time bar chart"
+          viewBox="0 0 280 110"
+          width="100%"
+          height={140}
+          preserveAspectRatio="xMidYMid meet"
+        >
+          {dayValues.map((d, i) => {
+            const barWidth = 28;
+            const gap = (280 - barWidth * 7) / 8;
+            const x = gap + i * (barWidth + gap);
+            const maxBarHeight = 80;
+            const height = Math.max(2, (d.active / maxDay) * maxBarHeight);
+            const y = 90 - height;
+            return (
+              <g key={d.day}>
+                <rect
+                  x={x}
+                  y={y}
+                  width={barWidth}
+                  height={height}
+                  rx={4}
+                  fill="var(--nudge-primary)"
+                  opacity={d.active === 0 ? 0.25 : 1}
+                />
+                <text
+                  x={x + barWidth / 2}
+                  y={104}
+                  textAnchor="middle"
+                  fontSize={10}
+                  fill="var(--nudge-on-surface-variant)"
+                >
+                  {weekdayLabel(d.day)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </Card>
+
+      <Card title="Hourly activity">
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(24, 1fr)', gap: 3 }}>
+          {hours.map((v, h) => {
+            const intensity = maxHour === 0 ? 0 : v / maxHour;
+            return (
+              <div
+                key={h}
+                title={`${h}:00 — ${formatDuration(v)}`}
+                style={{
+                  aspectRatio: '1 / 1',
+                  borderRadius: 3,
+                  background:
+                    intensity === 0
+                      ? 'var(--nudge-surface-variant)'
+                      : `color-mix(in srgb, var(--nudge-primary) ${Math.round(20 + intensity * 80)}%, var(--nudge-surface-variant))`,
+                }}
+              />
+            );
+          })}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginTop: 6,
+            fontSize: 10,
+            color: 'var(--nudge-on-surface-variant)',
+          }}
+        >
+          <span>12am</span>
+          <span>12pm</span>
+          <span>11pm</span>
+        </div>
+      </Card>
+
+      <Card title="Top sites">
+        {topSites.length === 0 ? (
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+            Nothing tracked in the last 7 days.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {topSites.map((s) => (
+              <div key={s.domain}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: 13,
+                    marginBottom: 4,
+                  }}
+                >
+                  <span>{s.domain}</span>
+                  <span style={{ color: 'var(--nudge-on-surface-variant)' }}>
+                    {formatDuration(s.activeSec)}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 6,
+                    borderRadius: 3,
+                    background: 'var(--nudge-surface-variant)',
+                    overflow: 'hidden',
+                  }}
+                >
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${Math.max(2, (s.activeSec / maxSite) * 100)}%`,
+                      background: 'var(--nudge-primary)',
+                      borderRadius: 3,
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/dashboard/index.html
+++ b/extension/src/entrypoints/dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nudge — Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/src/entrypoints/dashboard/main.tsx
+++ b/extension/src/entrypoints/dashboard/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client';
+import '../../ui/tokens.css';
+import { Dashboard } from './Dashboard';
+
+createRoot(document.getElementById('root')!).render(<Dashboard />);

--- a/extension/src/entrypoints/onboarding/Onboarding.tsx
+++ b/extension/src/entrypoints/onboarding/Onboarding.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useState } from 'react';
+import { normalizeUserInput } from '../../core/domainMatcher';
+import { DEFAULT_DELAY_SECONDS } from '../../core/settingsSchema';
+import type { NudgeSettings, SiteRule } from '../../core/settingsSchema';
+import type { BlockMode } from '../../core/types';
+import { MODE_LABELS } from '../../core/types';
+import { send } from '../../ui/rpc';
+import { Button, Card, NudgeMark } from '../../ui/components';
+
+const MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+/** The sites people actually ask a blocker for first — one tap instead of typing. */
+const SUGGESTED_SITES = [
+  'youtube.com',
+  'instagram.com',
+  'tiktok.com',
+  'reddit.com',
+  'x.com',
+  'facebook.com',
+];
+
+const MODE_BLURBS: Record<BlockMode, string> = {
+  HARD_BLOCK: "The site doesn't open at all.",
+  DELAY: 'A countdown runs before the site opens — enough time to change your mind.',
+  BREATHING: 'A guided breathing pause runs before the site opens.',
+};
+
+/** Copyable, non-clickable instruction row. Extensions cannot navigate to chrome:// URLs. */
+function CopyableStep({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+      <code
+        style={{
+          padding: '6px 10px',
+          borderRadius: 6,
+          border: '1px solid var(--nudge-outline)',
+          background: 'var(--nudge-surface-variant)',
+          color: 'var(--nudge-on-surface)',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 13,
+          userSelect: 'all',
+        }}
+      >
+        {text}
+      </code>
+      <Button
+        variant="muted"
+        style={{ padding: '4px 10px', fontSize: 12 }}
+        onClick={() => {
+          navigator.clipboard
+            ?.writeText(text)
+            .then(() => setCopied(true))
+            .catch(() => setCopied(false));
+        }}
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    </div>
+  );
+}
+
+export function Onboarding() {
+  const [step, setStep] = useState(0);
+  const [settings, setSettings] = useState<NudgeSettings | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [customDomain, setCustomDomain] = useState('');
+  const [customError, setCustomError] = useState<string | null>(null);
+  const [mode, setMode] = useState<BlockMode>('DELAY');
+  const [finishing, setFinishing] = useState(false);
+  const [finishError, setFinishError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoadError(null);
+    send({ type: 'GET_SETTINGS' })
+      .then(setSettings)
+      .catch((e: unknown) =>
+        setLoadError(e instanceof Error ? e.message : 'Could not reach the extension.'),
+      );
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function toggleSite(domain: string) {
+    setSelected((current) =>
+      current.includes(domain) ? current.filter((d) => d !== domain) : [...current, domain],
+    );
+  }
+
+  function addCustom() {
+    const normalized = normalizeUserInput(customDomain);
+    if (normalized === null) {
+      setCustomError("That doesn't look like a website address.");
+      return;
+    }
+    setCustomError(null);
+    setCustomDomain('');
+    setSelected((current) => (current.includes(normalized) ? current : [...current, normalized]));
+  }
+
+  /** Write the chosen rules + `onboardingComplete: true` in ONE save, then close the tab. */
+  const finish = useCallback(() => {
+    if (!settings) return;
+    setFinishing(true);
+    setFinishError(null);
+
+    const existingDomains = new Set(settings.rules.map((r) => r.domain));
+    const now = Date.now();
+    const newRules: SiteRule[] = selected
+      .filter((domain) => !existingDomains.has(domain))
+      .map((domain, index) => ({
+        id: `rule-${domain}-${now + index}`,
+        domain,
+        mode,
+        delaySeconds: DEFAULT_DELAY_SECONDS,
+        dailyLimitMinutes: null,
+        enabled: true,
+        createdAt: now,
+        showTimeRemaining: false,
+        schedule: null,
+      }));
+
+    send({
+      type: 'SAVE_SETTINGS',
+      settings: {
+        ...settings,
+        onboardingComplete: true,
+        rules: [...settings.rules, ...newRules],
+      },
+    })
+      .then((result) => {
+        setFinishing(false);
+        if (!result.ok) {
+          setFinishError(result.reason ?? 'Could not save your choices.');
+          return;
+        }
+        window.close();
+      })
+      .catch((e: unknown) => {
+        setFinishing(false);
+        setFinishError(e instanceof Error ? e.message : 'Could not reach the extension.');
+      });
+  }, [settings, selected, mode]);
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: 'var(--nudge-background)',
+        color: 'var(--nudge-on-surface)',
+        fontFamily: 'var(--nudge-font)',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <div style={{ width: '100%', maxWidth: 620, padding: '56px 24px 64px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 32 }}>
+          <NudgeMark size={32} />
+          <span style={{ fontSize: 18, fontWeight: 700 }}>Nudge</span>
+          <span
+            style={{
+              marginLeft: 'auto',
+              fontSize: 13,
+              color: 'var(--nudge-on-surface-variant)',
+            }}
+          >
+            Step {step + 1} of 3
+          </span>
+        </div>
+
+        {loadError && (
+          <Card style={{ marginBottom: 20, borderColor: 'var(--nudge-danger)' }}>
+            <p style={{ margin: '0 0 10px', fontSize: 13, color: 'var(--nudge-danger)' }}>
+              {loadError}
+            </p>
+            <Button variant="secondary" onClick={load}>
+              Retry
+            </Button>
+          </Card>
+        )}
+
+        {step === 0 && (
+          <div>
+            <h1 style={{ margin: '0 0 12px', fontSize: 34, fontWeight: 700, lineHeight: 1.2 }}>
+              Break the scroll. Take back your time.
+            </h1>
+            <p
+              style={{
+                margin: '0 0 28px',
+                fontSize: 16,
+                lineHeight: 1.6,
+                color: 'var(--nudge-on-surface-variant)',
+              }}
+            >
+              Nudge works with friction instead of walls. Instead of only slamming a door, it puts a
+              countdown or a breathing pause between you and the site — long enough to notice
+              whether you actually meant to go there.
+            </p>
+            <Card style={{ marginBottom: 28 }}>
+              <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6 }}>
+                Everything stays on this device. No account, no sign-in, no telemetry — Nudge makes
+                zero network requests, and your browsing stats never leave your computer.
+              </p>
+            </Card>
+            <Button onClick={() => setStep(1)}>Get started</Button>
+          </div>
+        )}
+
+        {step === 1 && (
+          <div>
+            <h1 style={{ margin: '0 0 12px', fontSize: 28, fontWeight: 700 }}>
+              Pick your first sites
+            </h1>
+            <p style={{ margin: '0 0 20px', fontSize: 15, color: 'var(--nudge-on-surface-variant)' }}>
+              Start with the one or two that pull you in most. You can change all of this later.
+            </p>
+
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 18 }}>
+              {SUGGESTED_SITES.map((domain) => {
+                const active = selected.includes(domain);
+                return (
+                  <button
+                    key={domain}
+                    type="button"
+                    onClick={() => toggleSite(domain)}
+                    aria-pressed={active}
+                    style={{
+                      padding: '8px 16px',
+                      borderRadius: 999,
+                      border: '1px solid var(--nudge-outline)',
+                      background: active ? 'var(--nudge-primary)' : 'transparent',
+                      color: active ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+                      fontSize: 14,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {domain}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                aria-label="Another site"
+                value={customDomain}
+                placeholder="Another site…"
+                onChange={(e) => {
+                  setCustomDomain(e.target.value);
+                  setCustomError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addCustom();
+                }}
+                style={{
+                  flex: '1 1 200px',
+                  padding: '10px 12px',
+                  fontSize: 14,
+                  borderRadius: 8,
+                  border: '1px solid var(--nudge-outline)',
+                  background: 'var(--nudge-background)',
+                  color: 'var(--nudge-on-surface)',
+                }}
+              />
+              <Button variant="secondary" onClick={addCustom}>
+                Add
+              </Button>
+            </div>
+            {customError && (
+              <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-danger)' }}>
+                {customError}
+              </p>
+            )}
+
+            {selected.filter((d) => !SUGGESTED_SITES.includes(d)).length > 0 && (
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', margin: '12px 0 0' }}>
+                {selected
+                  .filter((d) => !SUGGESTED_SITES.includes(d))
+                  .map((domain) => (
+                    <button
+                      key={domain}
+                      type="button"
+                      onClick={() => toggleSite(domain)}
+                      style={{
+                        padding: '8px 16px',
+                        borderRadius: 999,
+                        border: '1px solid var(--nudge-outline)',
+                        background: 'var(--nudge-primary)',
+                        color: 'var(--nudge-on-primary)',
+                        fontSize: 14,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {domain}
+                    </button>
+                  ))}
+              </div>
+            )}
+
+            <h2 style={{ margin: '28px 0 10px', fontSize: 16, fontWeight: 600 }}>
+              How should Nudge handle them?
+            </h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 28 }}>
+              {MODES.map((m) => (
+                <label
+                  key={m}
+                  style={{
+                    display: 'flex',
+                    gap: 12,
+                    alignItems: 'flex-start',
+                    padding: 14,
+                    borderRadius: 'var(--nudge-radius-sm)',
+                    border: `1px solid ${mode === m ? 'var(--nudge-primary)' : 'var(--nudge-surface-variant)'}`,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="mode"
+                    checked={mode === m}
+                    onChange={() => setMode(m)}
+                    style={{ marginTop: 3, accentColor: 'var(--nudge-primary)' }}
+                  />
+                  <span>
+                    <span style={{ display: 'block', fontSize: 15, fontWeight: 600 }}>
+                      {MODE_LABELS[m]}
+                    </span>
+                    <span
+                      style={{ display: 'block', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}
+                    >
+                      {MODE_BLURBS[m]}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Button variant="muted" onClick={() => setStep(0)}>
+                Back
+              </Button>
+              <Button onClick={() => setStep(2)}>Continue</Button>
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div>
+            <h1 style={{ margin: '0 0 12px', fontSize: 28, fontWeight: 700 }}>Two last things</h1>
+
+            <Card title="Incognito windows" style={{ marginBottom: 16 }}>
+              <p style={{ margin: '0 0 14px', fontSize: 14, lineHeight: 1.6 }}>
+                Chrome turns every extension OFF in Incognito by default — including Nudge. If you
+                skip this, an Incognito window is an open door around your rules. Turning it on
+                takes about ten seconds:
+              </p>
+              <ol style={{ margin: 0, paddingLeft: 20, fontSize: 14, lineHeight: 1.9 }}>
+                <li>
+                  Copy this address and open it in a new tab:
+                  <div style={{ margin: '6px 0 10px' }}>
+                    <CopyableStep text="chrome://extensions" />
+                  </div>
+                </li>
+                <li>Find Nudge in the list and click "Details".</li>
+                <li>Scroll down and turn on "Allow in Incognito".</li>
+              </ol>
+              <p style={{ margin: '14px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+                Chrome doesn't let an extension open that page for you, which is why you have to
+                paste the address yourself.
+              </p>
+            </Card>
+
+            <Card title="Pin Nudge to your toolbar" style={{ marginBottom: 16 }}>
+              <p style={{ margin: 0, fontSize: 14, lineHeight: 1.6 }}>
+                Click the puzzle-piece icon at the right of Chrome's toolbar, find Nudge, and click
+                the pin next to it. The popup then shows today's screen time and lets you block the
+                site you're on in one click.
+              </p>
+            </Card>
+
+            <Card style={{ marginBottom: 24 }}>
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: 'var(--nudge-on-surface-variant)' }}>
+                Honest limit, up front: any Chrome extension can be disabled or removed from{' '}
+                <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>
+                  chrome://extensions
+                </span>
+                . Nudge adds deliberate friction — it can't make a decision for you.
+              </p>
+            </Card>
+
+            {finishError && (
+              <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-danger)' }}>
+                {finishError}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Button variant="muted" onClick={() => setStep(1)} disabled={finishing}>
+                Back
+              </Button>
+              <Button onClick={finish} disabled={finishing || settings === null}>
+                {finishing ? 'Saving…' : "I'm all set"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/onboarding/index.html
+++ b/extension/src/entrypoints/onboarding/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Welcome to Nudge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/src/entrypoints/onboarding/main.tsx
+++ b/extension/src/entrypoints/onboarding/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from 'react-dom/client';
+import '../../ui/tokens.css';
+import { Onboarding } from './Onboarding';
+
+createRoot(document.getElementById('root')!).render(<Onboarding />);

--- a/extension/src/entrypoints/popup/Popup.tsx
+++ b/extension/src/entrypoints/popup/Popup.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { PopupState } from '../../core/protocol';
+import type { SiteRule } from '../../core/settingsSchema';
+import { DEFAULT_DELAY_SECONDS } from '../../core/settingsSchema';
+import type { BlockMode } from '../../core/types';
+import { MODE_LABELS } from '../../core/types';
+import { send } from '../../ui/rpc';
+import { formatDuration } from '../../ui/format';
+import { Button, NudgeMark } from '../../ui/components';
+
+const MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+type SiteStatus = 'blocked' | 'limited' | 'not-blocked';
+
+function computeSiteStatus(rule: SiteRule | null, remainingMs: number | null): SiteStatus {
+  if (!rule || !rule.enabled) return 'not-blocked';
+  const limitExhausted =
+    rule.dailyLimitMinutes !== null && remainingMs !== null && remainingMs <= 0;
+  if (rule.mode === 'HARD_BLOCK' || limitExhausted) return 'blocked';
+  if (rule.dailyLimitMinutes !== null) return 'limited';
+  return 'blocked';
+}
+
+function statusColor(status: SiteStatus): string {
+  if (status === 'not-blocked') return 'var(--nudge-on-surface-variant)';
+  if (status === 'limited') return 'var(--nudge-warn)';
+  return 'var(--nudge-danger)';
+}
+
+function openDashboard() {
+  chrome.tabs.create({ url: chrome.runtime.getURL('dashboard.html') });
+  window.close();
+}
+
+export function Popup() {
+  const [state, setState] = useState<PopupState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<BlockMode>('DELAY');
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    send({ type: 'GET_POPUP_STATE' })
+      .then((s) => {
+        setState(s);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(e instanceof Error ? e.message : 'Could not reach the extension.');
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAddSite = useCallback(() => {
+    if (!state?.currentDomain) return;
+    setAdding(true);
+    setAddError(null);
+    send({
+      type: 'ADD_SITE',
+      domain: state.currentDomain,
+      mode,
+      delaySeconds: DEFAULT_DELAY_SECONDS,
+    })
+      .then((result) => {
+        setAdding(false);
+        if (!result.ok) {
+          setAddError(result.reason ?? 'Could not add this site.');
+          return;
+        }
+        load();
+      })
+      .catch((e) => {
+        setAdding(false);
+        setAddError(e instanceof Error ? e.message : 'Could not reach the extension.');
+      });
+  }, [state?.currentDomain, mode, load]);
+
+  return (
+    <div
+      style={{
+        width: 320,
+        fontFamily: 'var(--nudge-font)',
+        background: 'var(--nudge-background)',
+        color: 'var(--nudge-on-surface)',
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '16px 16px 12px',
+        }}
+      >
+        <NudgeMark size={24} />
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Nudge</span>
+      </header>
+
+      {loading && (
+        <div style={{ padding: '24px 16px', fontSize: 14, color: 'var(--nudge-on-surface-variant)' }}>
+          Loading…
+        </div>
+      )}
+
+      {!loading && error && (
+        <div style={{ padding: '0 16px 16px' }}>
+          <p style={{ fontSize: 13, color: 'var(--nudge-danger)', margin: '0 0 10px' }}>
+            {error}
+          </p>
+          <Button variant="secondary" onClick={load}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {!loading && !error && state && (
+        <div style={{ padding: '0 16px 16px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <section>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 12,
+                color: 'var(--nudge-on-surface-variant)',
+                textTransform: 'uppercase',
+                letterSpacing: 0.4,
+              }}
+            >
+              Today
+            </p>
+            <p style={{ margin: '2px 0 0', fontSize: 28, fontWeight: 700 }}>
+              {formatDuration(state.todayTotalSeconds)}
+            </p>
+            {!state.globalEnabled && (
+              <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--nudge-warn)' }}>
+                Nudge is currently off
+              </p>
+            )}
+          </section>
+
+          <section
+            style={{
+              background: 'var(--nudge-surface)',
+              border: '1px solid var(--nudge-surface-variant)',
+              borderRadius: 'var(--nudge-radius-sm)',
+              padding: 14,
+            }}
+          >
+            {state.currentDomain === null ? (
+              <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+                This isn't a site Nudge can block.
+              </p>
+            ) : (
+              <>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: 14,
+                    fontWeight: 600,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={state.currentDomain}
+                >
+                  {state.currentDomain}
+                </p>
+
+                {(() => {
+                  const status = computeSiteStatus(state.currentRule, state.currentRemainingMs);
+                  const rule = state.currentRule;
+                  return (
+                    <div style={{ marginTop: 6 }}>
+                      <p style={{ margin: 0, fontSize: 13, fontWeight: 600, color: statusColor(status) }}>
+                        {status === 'not-blocked' ? 'Not blocked' : MODE_LABELS[rule!.mode]}
+                      </p>
+                      {rule?.dailyLimitMinutes !== null &&
+                        rule !== null &&
+                        rule !== undefined &&
+                        state.currentRemainingMs !== null && (
+                          <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                            {state.currentRemainingMs > 0
+                              ? `${formatDuration(Math.floor(state.currentRemainingMs / 1000))} left today`
+                              : 'Daily limit reached'}
+                          </p>
+                        )}
+                    </div>
+                  );
+                })()}
+
+                {state.currentRule === null && (
+                  <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+                      Mode
+                      <select
+                        value={mode}
+                        onChange={(e) => setMode(e.target.value as BlockMode)}
+                        style={{
+                          display: 'block',
+                          width: '100%',
+                          marginTop: 4,
+                          padding: '8px 10px',
+                          borderRadius: 8,
+                          border: '1px solid var(--nudge-outline)',
+                          background: 'var(--nudge-background)',
+                          color: 'var(--nudge-on-surface)',
+                          fontSize: 13,
+                        }}
+                      >
+                        {MODES.map((m) => (
+                          <option key={m} value={m}>
+                            {MODE_LABELS[m]}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <Button onClick={handleAddSite} disabled={adding} style={{ width: '100%' }}>
+                      {adding ? 'Adding…' : 'Block this site'}
+                    </Button>
+                    {addError && (
+                      <p style={{ margin: 0, fontSize: 12, color: 'var(--nudge-danger)' }}>{addError}</p>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+
+          <Button variant="muted" onClick={openDashboard} style={{ padding: '8px 0', textAlign: 'left' }}>
+            Open dashboard →
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/extension/src/entrypoints/popup/index.html
+++ b/extension/src/entrypoints/popup/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nudge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/extension/src/entrypoints/popup/main.tsx
+++ b/extension/src/entrypoints/popup/main.tsx
@@ -1,0 +1,3 @@
+import { createRoot } from 'react-dom/client';
+
+createRoot(document.getElementById('root')!).render(<p>Nudge</p>);

--- a/extension/src/entrypoints/popup/main.tsx
+++ b/extension/src/entrypoints/popup/main.tsx
@@ -1,3 +1,5 @@
 import { createRoot } from 'react-dom/client';
+import '../../ui/tokens.css';
+import { Popup } from './Popup';
 
-createRoot(document.getElementById('root')!).render(<p>Nudge</p>);
+createRoot(document.getElementById('root')!).render(<Popup />);

--- a/extension/src/entrypoints/youtube.content.ts
+++ b/extension/src/entrypoints/youtube.content.ts
@@ -1,0 +1,30 @@
+/**
+ * YouTube content script entrypoint — thin on purpose.
+ *
+ * All logic lives in src/content/youtube.ts + src/content/selectors.ts so it can be unit
+ * tested against fixture DOM without a browser. This file only decides WHERE and WHEN.
+ *
+ *  - `matches`: every YouTube host (www., m., music. — the mobile layout ships the same
+ *    `ytd-*` custom elements).
+ *  - `runAt: 'document_idle'`: the hiding pass runs once YouTube has rendered its feed
+ *    (ext-03 §1 — every shipped OSS Shorts hider does this). The no-flash guarantee comes
+ *    from the CSS below, not from running JS earlier.
+ *  - `cssInjectionMode: 'manifest'`: WXT puts the imported CSS into the content script's
+ *    manifest `css` array, which Chrome injects before any DOM is constructed. That is
+ *    the FOUC-safe path (ext-03 §4/§6); JS-injected styles are not.
+ */
+
+import '../content/youtube.css';
+import { initYoutubeContentScript } from '../content/youtube';
+
+export default defineContentScript({
+  matches: ['*://*.youtube.com/*'],
+  runAt: 'document_idle',
+  cssInjectionMode: 'manifest',
+  main(ctx) {
+    const controller = initYoutubeContentScript();
+    // An extension reload leaves the old script alive on the page; without this it keeps
+    // its observer and interval running against a dead message port.
+    ctx.onInvalidated(() => controller.stop());
+  },
+});

--- a/extension/src/ui/components.tsx
+++ b/extension/src/ui/components.tsx
@@ -1,0 +1,162 @@
+/**
+ * Shared UI primitives on the Nudge design tokens (src/ui/tokens.css).
+ * Small and hand-rolled deliberately — no UI kit, keep the bundle lean (ext-08 Stack).
+ *
+ * Iconography rule: NEVER emoji-as-icon. Use inline SVG or text.
+ */
+
+import type { CSSProperties, ReactNode } from 'react';
+
+export function Button({
+  children,
+  onClick,
+  variant = 'primary',
+  disabled = false,
+  style,
+  ...rest
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  variant?: 'primary' | 'secondary' | 'muted' | 'danger';
+  disabled?: boolean;
+  style?: CSSProperties;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'style' | 'onClick'>) {
+  const base: CSSProperties = {
+    border: 'none',
+    borderRadius: 999,
+    padding: '12px 24px',
+    fontSize: 15,
+    fontWeight: 600,
+    transition: 'opacity 120ms ease',
+    opacity: disabled ? 0.45 : 1,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+  };
+  const variants: Record<string, CSSProperties> = {
+    primary: {
+      background: 'var(--nudge-primary)',
+      color: 'var(--nudge-on-primary)',
+    },
+    secondary: {
+      background: 'var(--nudge-primary-container)',
+      color: 'var(--nudge-on-primary-container)',
+    },
+    muted: {
+      background: 'transparent',
+      color: 'var(--nudge-on-surface-variant)',
+      fontWeight: 500,
+    },
+    danger: {
+      background: 'var(--nudge-error)',
+      color: 'var(--nudge-on-error)',
+    },
+  };
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      style={{ ...base, ...variants[variant], ...style }}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function Card({
+  children,
+  title,
+  style,
+}: {
+  children: ReactNode;
+  title?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <section
+      style={{
+        background: 'var(--nudge-surface)',
+        border: '1px solid var(--nudge-surface-variant)',
+        borderRadius: 'var(--nudge-radius)',
+        padding: 20,
+        ...style,
+      }}
+    >
+      {title !== undefined && (
+        <h2
+          style={{
+            margin: '0 0 14px',
+            fontSize: 15,
+            fontWeight: 600,
+            color: 'var(--nudge-on-surface-variant)',
+            letterSpacing: 0.2,
+          }}
+        >
+          {title}
+        </h2>
+      )}
+      {children}
+    </section>
+  );
+}
+
+/** The "Rule: X" transparency footer shown on every block surface (Android parity). */
+export function RuleFooter({ ruleName }: { ruleName: string | null }) {
+  if (ruleName === null || ruleName === '') return null;
+  return (
+    <p
+      style={{
+        marginTop: 32,
+        fontSize: 13,
+        color: 'var(--nudge-on-surface-variant)',
+        opacity: 0.8,
+      }}
+    >
+      Rule: {ruleName}
+    </p>
+  );
+}
+
+export function Toggle({
+  checked,
+  onChange,
+  label,
+  disabled = false,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  label: string;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ width: 18, height: 18, accentColor: 'var(--nudge-primary)' }}
+      />
+      <span style={{ fontSize: 15 }}>{label}</span>
+    </label>
+  );
+}
+
+/** Nudge wordmark: the two-bar "pause" glyph from the Android launcher icon. */
+export function NudgeMark({ size = 28 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <rect width="24" height="24" rx="6" fill="var(--nudge-primary)" />
+      <rect x="8" y="6" width="3" height="12" rx="1.5" fill="var(--nudge-on-primary)" />
+      <rect x="13" y="6" width="3" height="12" rx="1.5" fill="var(--nudge-on-primary)" />
+    </svg>
+  );
+}

--- a/extension/src/ui/exportImport.ts
+++ b/extension/src/ui/exportImport.ts
@@ -1,0 +1,169 @@
+/**
+ * Settings/rules export-import. PURE — no chrome.* imports.
+ *
+ * Android parity (data/export/RuleExporter.kt + RuleExporterTest.kt): version:1 envelope,
+ * `exportedAt`, tolerant field-by-field parsing that never throws, version-gate on import,
+ * and de-duplication of imported rows against what's already there. The extension's `SiteRule`
+ * is domain-keyed (not packageName-keyed) and has no app-groups concept at MVP, so the export
+ * carries `rules: SiteRule[]` directly rather than mirroring Android's flattened row shape —
+ * the PARITY that matters is the envelope shape + the defensive parsing discipline, not a
+ * byte-identical field list.
+ */
+
+import type { SiteRule } from '../core/settingsSchema';
+import type { NudgeSettings } from '../core/settingsSchema';
+import {
+  DAILY_LIMIT_MAX_MINUTES,
+  DAILY_LIMIT_MIN_MINUTES,
+  DELAY_MAX_SECONDS,
+  DELAY_MIN_SECONDS,
+  DEFAULT_DELAY_SECONDS,
+} from '../core/settingsSchema';
+import type { BlockMode } from '../core/types';
+
+export const EXPORT_VERSION = 1;
+
+export interface NudgeRuleExport {
+  version: number;
+  exportedAt: string;
+  rules: SiteRule[];
+}
+
+export interface ImportResult {
+  ok: boolean;
+  rules?: SiteRule[];
+  error?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+const VALID_MODES: readonly BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+function coerceMode(value: unknown, fallback: BlockMode): BlockMode {
+  return VALID_MODES.includes(value as BlockMode) ? (value as BlockMode) : fallback;
+}
+
+function coerceSchedule(value: unknown): SiteRule['schedule'] {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const days = Array.isArray(raw.days)
+    ? raw.days.filter((d): d is number => Number.isInteger(d) && d >= 1 && d <= 7)
+    : null;
+  return {
+    enabled: raw.enabled !== false,
+    days: days && days.length > 0 ? days : null,
+    startMinute: typeof raw.startMinute === 'number' ? clamp(raw.startMinute, 0, 1439) : null,
+    endMinute: typeof raw.endMinute === 'number' ? clamp(raw.endMinute, 0, 1439) : null,
+    mode: coerceMode(raw.mode, 'HARD_BLOCK'),
+    delaySeconds: clamp(
+      typeof raw.delaySeconds === 'number' ? raw.delaySeconds : DEFAULT_DELAY_SECONDS,
+      DELAY_MIN_SECONDS,
+      DELAY_MAX_SECONDS,
+    ),
+  };
+}
+
+/**
+ * Parse one entry of the `rules` array. Returns null (never throws) for anything that
+ * can't be salvaged into a usable rule — the caller filters nulls out, so one garbage
+ * entry in a batch never poisons the rest of the import.
+ */
+function coerceImportedRule(value: unknown): SiteRule | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.domain !== 'string' || raw.domain.trim() === '') return null;
+
+  const domain = raw.domain.trim().toLowerCase();
+  return {
+    id: typeof raw.id === 'string' && raw.id ? raw.id : `rule-${domain}-${Date.now()}`,
+    domain,
+    mode: coerceMode(raw.mode, 'HARD_BLOCK'),
+    delaySeconds: clamp(
+      typeof raw.delaySeconds === 'number' ? raw.delaySeconds : DEFAULT_DELAY_SECONDS,
+      DELAY_MIN_SECONDS,
+      DELAY_MAX_SECONDS,
+    ),
+    dailyLimitMinutes:
+      typeof raw.dailyLimitMinutes === 'number'
+        ? clamp(raw.dailyLimitMinutes, DAILY_LIMIT_MIN_MINUTES, DAILY_LIMIT_MAX_MINUTES)
+        : null,
+    enabled: raw.enabled !== false,
+    createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : Date.now(),
+    showTimeRemaining: raw.showTimeRemaining === true,
+    schedule: coerceSchedule(raw.schedule),
+  };
+}
+
+/** Build the exportable envelope from current settings. */
+export function buildExport(settings: NudgeSettings): NudgeRuleExport {
+  return {
+    version: EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    rules: settings.rules.map((r) => ({
+      ...r,
+      schedule: r.schedule ? { ...r.schedule, days: r.schedule.days ? [...r.schedule.days] : null } : null,
+    })),
+  };
+}
+
+/**
+ * Parse + validate an arbitrary JSON string into a rules array.
+ *
+ * Total and defensive by design (same posture as Android's `migrateSettings`/`RuleExporter`):
+ * malformed JSON, a non-object root, a wrong/missing version, and garbage rule entries are
+ * all reported via `{ ok: false, error }` rather than thrown — a settings-import surface must
+ * never crash the dashboard.
+ */
+export function parseImport(json: string): ImportResult {
+  let root: unknown;
+  try {
+    root = JSON.parse(json);
+  } catch (e) {
+    return { ok: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` };
+  }
+
+  if (!root || typeof root !== 'object' || Array.isArray(root)) {
+    return { ok: false, error: 'Import file is not a valid export object.' };
+  }
+
+  const raw = root as Record<string, unknown>;
+  const version = typeof raw.version === 'number' ? raw.version : 0;
+  if (version < 1) {
+    return { ok: false, error: 'Missing or invalid version field.' };
+  }
+  if (version > EXPORT_VERSION) {
+    return {
+      ok: false,
+      error: `Export version ${version} is newer than supported (${EXPORT_VERSION}). Please update the extension.`,
+    };
+  }
+
+  const rulesRaw = Array.isArray(raw.rules) ? raw.rules : [];
+  const rules = rulesRaw
+    .map(coerceImportedRule)
+    .filter((r): r is SiteRule => r !== null);
+
+  return { ok: true, rules };
+}
+
+/**
+ * De-duplicate imported rules against what's already stored, keyed by normalized domain
+ * (one rule per domain — matches the SiteRule model). Existing rules win; new domains from
+ * the import are appended.
+ */
+export function dedupeImportedRules(existing: SiteRule[], imported: SiteRule[]): SiteRule[] {
+  const existingDomains = new Set(existing.map((r) => r.domain));
+  const additions = imported.filter((r) => !existingDomains.has(r.domain));
+  // De-dupe within the imported batch too, keeping the first occurrence.
+  const seen = new Set<string>();
+  const deduped: SiteRule[] = [];
+  for (const rule of additions) {
+    if (seen.has(rule.domain)) continue;
+    seen.add(rule.domain);
+    deduped.push(rule);
+  }
+  return [...existing, ...deduped];
+}

--- a/extension/src/ui/format.ts
+++ b/extension/src/ui/format.ts
@@ -1,0 +1,49 @@
+/** Presentation-layer formatting helpers. PURE — safe to unit test. */
+
+/** "2h 14m" / "14m" / "42s". Used for screen-time readouts. */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
+}
+
+/**
+ * Badge text for remaining budget. The badge fits only ~4 characters (ext-01 §5),
+ * so hours collapse to "1h" / "1h2" rather than "1h 20m".
+ */
+export function formatBadge(remainingMs: number): string {
+  const minutes = Math.max(0, Math.floor(remainingMs / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rem = Math.floor((minutes % 60) / 10);
+  if (hours >= 10) return `${hours}h`;
+  return rem === 0 ? `${hours}h` : `${hours}h${rem}`;
+}
+
+/**
+ * Badge color by fraction of budget remaining — Android parity:
+ * green >50%, orange 25–50%, red <25%.
+ */
+export function badgeColor(remainingMs: number, limitMs: number): string {
+  if (limitMs <= 0) return '#1b6b5a';
+  const fraction = remainingMs / limitMs;
+  if (fraction > 0.5) return '#1b6b5a';
+  if (fraction >= 0.25) return '#b26a00';
+  return '#ba1a1a';
+}
+
+/** "next in 5h" for the spent-pass hint. Rounds UP so it never reads "next in 0h". */
+export function formatNextPass(ms: number): string {
+  const hours = Math.ceil(Math.max(0, ms) / 3_600_000);
+  return `${hours}h`;
+}
+
+/** Minutes-from-midnight -> "09:30". */
+export function formatMinuteOfDay(minute: number): string {
+  const m = Math.max(0, Math.min(1439, Math.round(minute)));
+  return `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+}

--- a/extension/src/ui/rpc.ts
+++ b/extension/src/ui/rpc.ts
@@ -1,0 +1,13 @@
+/**
+ * Typed wrapper over chrome.runtime.sendMessage for the UI surfaces.
+ * The response type is derived from the request type via the protocol's ResponseFor map,
+ * so a mismatched handler is a compile error.
+ */
+
+import type { Request, ResponseFor } from '../core/protocol';
+
+export async function send<T extends Request>(
+  request: T,
+): Promise<ResponseFor<T['type']>> {
+  return (await chrome.runtime.sendMessage(request)) as ResponseFor<T['type']>;
+}

--- a/extension/src/ui/tokens.css
+++ b/extension/src/ui/tokens.css
@@ -1,0 +1,71 @@
+/*
+ * Nudge design tokens — ported from the Android in-app theme (ui/theme/Theme.kt).
+ * Source of truth: ops/routes/nudge/research/ext-05-android-feature-inventory.md §3.
+ * Teal family; the maroon palette is MARKETING ONLY and never appears in the UI.
+ */
+
+:root {
+  /* Light (Android light color scheme) */
+  --nudge-primary: #1b6b5a;
+  --nudge-on-primary: #ffffff;
+  --nudge-primary-container: #a7f2dc;
+  --nudge-on-primary-container: #00201a;
+  --nudge-secondary: #4b635b;
+  --nudge-background: #fbfdf9;
+  --nudge-surface: #fbfdf9;
+  --nudge-surface-variant: #dbe5df;
+  --nudge-on-surface: #191c1b;
+  --nudge-on-surface-variant: #3f4945;
+  --nudge-outline: #6f7975;
+  --nudge-error: #ba1a1a;
+  --nudge-on-error: #ffffff;
+
+  /* Budget-remaining thresholds (Android: green >50%, orange 25–50%, red <25%) */
+  --nudge-ok: #1b6b5a;
+  --nudge-warn: #b26a00;
+  --nudge-danger: #ba1a1a;
+
+  --nudge-radius: 16px;
+  --nudge-radius-sm: 10px;
+  --nudge-font: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Dark (Android dark color scheme) */
+    --nudge-primary: #8bd6c1;
+    --nudge-on-primary: #00382d;
+    --nudge-primary-container: #005143;
+    --nudge-on-primary-container: #a7f2dc;
+    --nudge-secondary: #b1ccc2;
+    --nudge-background: #191c1b;
+    --nudge-surface: #191c1b;
+    --nudge-surface-variant: #3f4945;
+    --nudge-on-surface: #e1e3e0;
+    --nudge-on-surface-variant: #bfc9c4;
+    --nudge-outline: #899390;
+    --nudge-error: #ffb4ab;
+    --nudge-on-error: #690005;
+
+    --nudge-ok: #8bd6c1;
+    --nudge-warn: #ffb95c;
+    --nudge-danger: #ffb4ab;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--nudge-font);
+  background: var(--nudge-background);
+  color: var(--nudge-on-surface);
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font-family: inherit;
+  cursor: pointer;
+}

--- a/extension/tests/content/fixtures/youtube.ts
+++ b/extension/tests/content/fixtures/youtube.ts
@@ -1,0 +1,243 @@
+/**
+ * YouTube DOM fixtures for the selector tests.
+ *
+ * HAND-AUTHORED, NOT LIVE CAPTURES. These strings reproduce the element structures
+ * documented in ops/routes/nudge/research/ext-03-youtube-techniques.md §1 — the taxonomy
+ * read out of shipped OSS extensions (`Vulpelo/hide-youtube-shorts`,
+ * `malekwael229/FocusTube`, `tobiasdalhof/sanersocialmedia`). They are deliberately
+ * minimal: the wrapper tags, the attributes and the nesting our chains depend on, and
+ * nothing else.
+ *
+ * REFRESH THEM FROM REAL DOM WHEN POSSIBLE. The whole point of the fixture pattern
+ * (ext-03 §6 pattern 4, Vulpelo's `tests/fixtures/*`) is that upstream YouTube churn
+ * fails CI instead of users — and a hand-authored fixture can only catch churn we already
+ * modelled. Capturing `document.body.outerHTML` from a real logged-in session and pruning
+ * it down beats this file the moment someone has a browser open.
+ *
+ * Every fixture contains at least one NORMAL (non-Shorts) video card that must survive
+ * hiding. A selector that also eats regular videos is worse than no selector at all.
+ */
+
+/** Left nav in its collapsed mini-guide form, present on most pages. */
+const MINI_GUIDE = `
+  <ytd-mini-guide-renderer id="mini-guide">
+    <ytd-mini-guide-entry-renderer class="guide-entry"><a href="/" title="Home"><span>Home</span></a></ytd-mini-guide-entry-renderer>
+    <ytd-mini-guide-entry-renderer class="guide-entry"><a href="/shorts/" title="Shorts"><span>Shorts</span></a></ytd-mini-guide-entry-renderer>
+    <ytd-mini-guide-entry-renderer class="guide-entry"><a href="/feed/subscriptions" title="Subscriptions"><span>Subscriptions</span></a></ytd-mini-guide-entry-renderer>
+  </ytd-mini-guide-renderer>
+`;
+
+/** The expanded left nav, used on the home page when the window is wide. */
+const FULL_GUIDE = `
+  <ytd-guide-renderer id="guide">
+    <ytd-guide-entry-renderer><a href="/"><yt-formatted-string>Home</yt-formatted-string></a></ytd-guide-entry-renderer>
+    <ytd-guide-entry-renderer><a href="/shorts/" title="Shorts"><yt-formatted-string>Shorts</yt-formatted-string></a></ytd-guide-entry-renderer>
+    <ytd-guide-entry-renderer><a href="/feed/subscriptions"><yt-formatted-string>Subscriptions</yt-formatted-string></a></ytd-guide-entry-renderer>
+  </ytd-guide-renderer>
+`;
+
+/** A normal long-form video card in the rich grid. MUST survive every hiding pass. */
+const NORMAL_RICH_ITEM = (id: string, title: string) => `
+  <ytd-rich-item-renderer class="normal-video" data-testid="normal-${id}">
+    <ytd-rich-grid-media>
+      <a id="thumbnail" href="/watch?v=${id}">
+        <ytd-thumbnail-overlay-time-status-renderer>12:04</ytd-thumbnail-overlay-time-status-renderer>
+      </a>
+      <div id="details">
+        <a id="video-title-link" href="/watch?v=${id}" title="${title}"><yt-formatted-string id="video-title">${title}</yt-formatted-string></a>
+        <ytd-channel-name><a class="yt-formatted-string" href="/@somechannel">Some Channel</a></ytd-channel-name>
+      </div>
+    </ytd-rich-grid-media>
+  </ytd-rich-item-renderer>
+`;
+
+/**
+ * HOME FEED — the shelf variant. `ytd-rich-section-renderer > div > ytd-rich-shelf-renderer`
+ * with `[is-shorts]`, which is the structure both Vulpelo and FocusTube target.
+ */
+export const HOME_FEED_HTML = `
+  <div id="page-manager">
+    ${FULL_GUIDE}
+    <ytd-browse page-subtype="home">
+      <ytd-rich-grid-renderer>
+        <div id="contents">
+          ${NORMAL_RICH_ITEM('aaa11111111', 'A long video about nothing')}
+          ${NORMAL_RICH_ITEM('bbb22222222', 'Another perfectly normal video')}
+          <ytd-rich-section-renderer class="shorts-shelf" data-testid="home-shelf">
+            <div>
+              <ytd-rich-shelf-renderer is-shorts>
+                <div id="title-container"><span id="title">Shorts</span></div>
+                <div id="contents">
+                  <ytd-rich-item-renderer class="shorts-card" data-testid="home-shorts-card-1">
+                    <ytm-shorts-lockup-view-model>
+                      <a href="/shorts/sss11111111" title="A short">
+                        <yt-thumbnail-view-model></yt-thumbnail-view-model>
+                      </a>
+                    </ytm-shorts-lockup-view-model>
+                  </ytd-rich-item-renderer>
+                  <ytd-rich-item-renderer class="shorts-card" data-testid="home-shorts-card-2">
+                    <ytm-shorts-lockup-view-model>
+                      <a href="/shorts/sss22222222" title="Another short">
+                        <yt-thumbnail-view-model></yt-thumbnail-view-model>
+                      </a>
+                    </ytm-shorts-lockup-view-model>
+                  </ytd-rich-item-renderer>
+                </div>
+              </ytd-rich-shelf-renderer>
+            </div>
+          </ytd-rich-section-renderer>
+          ${NORMAL_RICH_ITEM('ccc33333333', 'Yet another normal video')}
+        </div>
+      </ytd-rich-grid-renderer>
+    </ytd-browse>
+  </div>
+`;
+
+/**
+ * SUBSCRIPTIONS FEED — the `ytd-rich-grid-group` variant (Vulpelo's "shorts container
+ * home/sub feed"), plus a plain grid video card that must survive.
+ */
+export const SUBSCRIPTIONS_FEED_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-browse page-subtype="subscriptions">
+      <ytd-rich-grid-renderer>
+        <div id="contents">
+          ${NORMAL_RICH_ITEM('ddd44444444', 'Subscribed channel upload')}
+          <ytd-rich-grid-group class="shorts-group" data-testid="subs-group">
+            <div id="title">Shorts</div>
+            <div id="contents">
+              <ytd-rich-item-renderer class="shorts-card">
+                <a href="/shorts/sss33333333" title="Short in subs"></a>
+              </ytd-rich-item-renderer>
+            </div>
+          </ytd-rich-grid-group>
+          <ytd-grid-video-renderer class="normal-video" data-testid="subs-grid-normal">
+            <a id="thumbnail" href="/watch?v=eee55555555"></a>
+          </ytd-grid-video-renderer>
+        </div>
+      </ytd-rich-grid-renderer>
+    </ytd-browse>
+  </div>
+`;
+
+/**
+ * SEARCH RESULTS — `ytd-reel-shelf-renderer`, the shelf variant unique to search
+ * (ext-03 §1, first line of the taxonomy). The normal `ytd-video-renderer` results
+ * around it must survive.
+ */
+export const SEARCH_RESULTS_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-search>
+      <ytd-section-list-renderer>
+        <div id="contents">
+          <ytd-video-renderer class="normal-video" data-testid="search-normal-1">
+            <a id="thumbnail" href="/watch?v=fff66666666"></a>
+            <yt-formatted-string id="video-title">How to actually watch shorts responsibly</yt-formatted-string>
+          </ytd-video-renderer>
+          <ytd-reel-shelf-renderer class="shorts-shelf" data-testid="search-reel-shelf">
+            <div id="title-container"><span>Shorts</span></div>
+            <div id="items">
+              <ytd-reel-item-renderer><a href="/shorts/sss44444444"></a></ytd-reel-item-renderer>
+              <ytd-reel-item-renderer><a href="/shorts/sss55555555"></a></ytd-reel-item-renderer>
+            </div>
+          </ytd-reel-shelf-renderer>
+          <ytd-video-renderer class="normal-video" data-testid="search-normal-2">
+            <a id="thumbnail" href="/watch?v=ggg77777777"></a>
+            <yt-formatted-string id="video-title">A video literally titled shorts</yt-formatted-string>
+          </ytd-video-renderer>
+        </div>
+      </ytd-section-list-renderer>
+    </ytd-search>
+  </div>
+`;
+
+/**
+ * WATCH PAGE SIDEBAR — `ytd-compact-video-renderer` recommendations, one of which is a
+ * Short, plus the collapsed mini-guide Shorts tab.
+ */
+export const WATCH_PAGE_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-watch-flexy>
+      <div id="primary"><div id="player"><video></video></div></div>
+      <div id="secondary">
+        <div id="related">
+          <ytd-compact-video-renderer class="normal-video" data-testid="watch-normal-1">
+            <a id="thumbnail" href="/watch?v=hhh88888888"></a>
+          </ytd-compact-video-renderer>
+          <ytd-compact-video-renderer class="shorts-card" data-testid="watch-shorts-rec">
+            <a id="thumbnail" href="/shorts/sss66666666"></a>
+          </ytd-compact-video-renderer>
+          <ytd-compact-video-renderer class="normal-video" data-testid="watch-normal-2">
+            <a id="thumbnail" href="/watch?v=iii99999999"></a>
+          </ytd-compact-video-renderer>
+        </div>
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/** Just the sidebar, for testing the nav chain in isolation. */
+export const MINI_GUIDE_HTML = `<div id="page-manager">${MINI_GUIDE}</div>`;
+
+/** The `/shorts/<id>` player page. Nothing to hide here — this surface gets gated. */
+export const SHORTS_PLAYER_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-shorts>
+      <div id="shorts-inner-container">
+        <ytd-reel-video-renderer is-active>
+          <div id="player-container"><video id="shorts-video"></video></div>
+          <div id="actions">
+            <ytd-toggle-button-renderer id="like-button"></ytd-toggle-button-renderer>
+          </div>
+        </ytd-reel-video-renderer>
+        <ytd-reel-video-renderer>
+          <div id="player-container"><video></video></div>
+        </ytd-reel-video-renderer>
+      </div>
+    </ytd-shorts>
+  </div>
+`;
+
+/**
+ * THE UPSTREAM-CHURN SCENARIO. Same home feed, but every `ytd-*` Shorts wrapper has been
+ * renamed the way Google periodically renames them (`ytd-rich-section-renderer` ->
+ * `yt-feed-section-view-model`, `ytd-rich-item-renderer` -> `yt-lockup-view-model`).
+ *
+ * Only the generic `[href^="/shorts/"]` fallback can still find anything — which is
+ * precisely when the loud console warning must fire. Normal video cards are renamed too,
+ * so a chain that "recovers" by matching them would be caught here.
+ */
+export const HOME_FEED_RENAMED_HTML = `
+  <div id="page-manager">
+    <yt-nav-view-model id="guide">
+      <yt-nav-entry-view-model><a href="/">Home</a></yt-nav-entry-view-model>
+      <yt-nav-entry-view-model><a href="/shorts/">Shorts</a></yt-nav-entry-view-model>
+    </yt-nav-view-model>
+    <yt-browse-view-model page-subtype="home">
+      <div id="contents">
+        <yt-lockup-view-model class="normal-video" data-testid="renamed-normal-1">
+          <a href="/watch?v=jjj00000000">A normal video</a>
+        </yt-lockup-view-model>
+        <yt-feed-section-view-model data-testid="renamed-shelf">
+          <div>
+            <yt-shelf-view-model shelf-type="shorts">
+              <yt-lockup-view-model class="shorts-card" data-testid="renamed-shorts-1">
+                <a href="/shorts/sss77777777">A short</a>
+              </yt-lockup-view-model>
+              <yt-lockup-view-model class="shorts-card" data-testid="renamed-shorts-2">
+                <a href="/shorts/sss88888888">Another short</a>
+              </yt-lockup-view-model>
+            </yt-shelf-view-model>
+          </div>
+        </yt-feed-section-view-model>
+        <yt-lockup-view-model class="normal-video" data-testid="renamed-normal-2">
+          <a href="/watch?v=kkk00000000">Another normal video</a>
+        </yt-lockup-view-model>
+      </div>
+    </yt-browse-view-model>
+  </div>
+`;

--- a/extension/tests/content/selectors.test.ts
+++ b/extension/tests/content/selectors.test.ts
@@ -1,0 +1,571 @@
+// @vitest-environment jsdom
+/**
+ * Fixture tests for the YouTube selector layer (ext-03 §6 pattern 4).
+ *
+ * The contract these tests defend: when YouTube renames a wrapper, CI goes red and a
+ * human updates the chain — the extension does NOT quietly stop blocking Shorts while
+ * still reporting itself as on. That failure mode is invisible to users until they
+ * notice they have been scrolling for an hour, which is the exact thing Nudge sells
+ * against.
+ *
+ * Fixtures are hand-authored from the documented taxonomy, not scraped — see the header
+ * of tests/content/fixtures/youtube.ts.
+ *
+ * The repo's default vitest environment is `node` (src/core is pure); this file opts into
+ * jsdom with the directive above.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  HIDDEN_CLASS,
+  SHORTS_FALLBACK_SURFACE,
+  SHORTS_SURFACES,
+  fallbackWarningMessage,
+  pageTypeFor,
+  queryWithFallback,
+  resetFallbackWarnings,
+  type SelectorRule,
+} from '../../src/content/selectors';
+import {
+  BAIL_LABEL,
+  applyShortsHiding,
+  createShortsOverlay,
+  shouldGateShorts,
+} from '../../src/content/youtube';
+import {
+  HOME_FEED_HTML,
+  HOME_FEED_RENAMED_HTML,
+  MINI_GUIDE_HTML,
+  SEARCH_RESULTS_HTML,
+  SHORTS_PLAYER_HTML,
+  SUBSCRIPTIONS_FEED_HTML,
+  WATCH_PAGE_HTML,
+} from './fixtures/youtube';
+
+/** Mount a fixture in a detached root so tests never fight over document.body. */
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  document.body.replaceChildren(root);
+  return root;
+}
+
+function surface(pageType: keyof typeof SHORTS_SURFACES, id: string) {
+  const found = SHORTS_SURFACES[pageType].find((s) => s.id === id);
+  if (!found) throw new Error(`no surface "${id}" for page type "${pageType}"`);
+  return found;
+}
+
+/** Every normal (non-Shorts) card in the fixture. These must never be touched. */
+function normalCards(root: HTMLElement): Element[] {
+  return Array.from(root.querySelectorAll('.normal-video'));
+}
+
+beforeEach(() => {
+  resetFallbackWarnings();
+});
+
+describe('pageTypeFor', () => {
+  it('classifies the standard YouTube surfaces', () => {
+    expect(pageTypeFor('https://www.youtube.com/')).toBe('home');
+    expect(pageTypeFor('https://www.youtube.com/feed/subscriptions')).toBe('subscriptions');
+    expect(pageTypeFor('https://www.youtube.com/results?search_query=cats')).toBe('search');
+    expect(pageTypeFor('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('watch');
+    expect(pageTypeFor('https://www.youtube.com/channel/UC1234567890')).toBe('channel');
+    expect(pageTypeFor('https://www.youtube.com/c/SomeChannel')).toBe('channel');
+    expect(pageTypeFor('https://www.youtube.com/user/SomeUser')).toBe('channel');
+    expect(pageTypeFor('https://www.youtube.com/@somehandle')).toBe('channel');
+    expect(pageTypeFor('https://www.youtube.com/@somehandle/videos')).toBe('channel');
+    expect(pageTypeFor('https://www.youtube.com/feed/history')).toBe('other');
+  });
+
+  it('recognizes /shorts/<id> and its bare/mobile forms', () => {
+    expect(pageTypeFor('https://www.youtube.com/shorts/abc123XYZ')).toBe('shorts');
+    expect(pageTypeFor('https://www.youtube.com/shorts/abc123XYZ?feature=share')).toBe('shorts');
+    expect(pageTypeFor('https://m.youtube.com/shorts/abc123XYZ')).toBe('shorts');
+    expect(pageTypeFor('https://www.youtube.com/shorts/')).toBe('shorts');
+    expect(pageTypeFor('https://www.youtube.com/shorts')).toBe('shorts');
+  });
+
+  it('does NOT classify a video merely titled or searched as "shorts" as Shorts', () => {
+    // The precision case: "shorts" in a query string, a fragment or a longer path
+    // segment is not the Shorts surface. Gating these would block ordinary videos.
+    expect(pageTypeFor('https://www.youtube.com/watch?v=abc&title=shorts')).toBe('watch');
+    expect(pageTypeFor('https://www.youtube.com/results?search_query=shorts')).toBe('search');
+    expect(pageTypeFor('https://www.youtube.com/watch?v=shorts')).toBe('watch');
+    expect(pageTypeFor('https://www.youtube.com/watch?v=abc#shorts')).toBe('watch');
+    expect(pageTypeFor('https://www.youtube.com/shortsomething')).toBe('other');
+    expect(pageTypeFor('https://www.youtube.com/@shorts')).toBe('channel');
+  });
+
+  it('ignores non-YouTube hosts and unparseable input', () => {
+    expect(pageTypeFor('https://notyoutube.com/shorts/abc')).toBe('other');
+    expect(pageTypeFor('https://youtube.com.evil.example/shorts/abc')).toBe('other');
+    expect(pageTypeFor('chrome-extension://abcdef/blocked.html')).toBe('other');
+    expect(pageTypeFor('not a url')).toBe('other');
+    // The apex and every subdomain ARE YouTube.
+    expect(pageTypeFor('https://youtube.com/shorts/abc')).toBe('shorts');
+    expect(pageTypeFor('https://music.youtube.com/')).toBe('home');
+  });
+});
+
+describe('selector chains match the intended elements per page type', () => {
+  it('home: matches the Shorts shelf without touching normal video cards', () => {
+    const root = mount(HOME_FEED_HTML);
+    const result = queryWithFallback(root, surface('home', 'shorts-shelf').chain, {
+      surfaceId: 'shorts-shelf',
+      warn: () => {},
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.matchedSelector).toBe(
+      'ytd-rich-section-renderer:has(>div>ytd-rich-shelf-renderer)',
+    );
+    expect(result.elements).toHaveLength(1);
+    expect(result.elements[0]?.getAttribute('data-testid')).toBe('home-shelf');
+    for (const card of normalCards(root)) {
+      expect(result.elements).not.toContain(card);
+    }
+  });
+
+  it('subscriptions: matches the rich-grid Shorts group, not the plain grid video', () => {
+    const root = mount(SUBSCRIPTIONS_FEED_HTML);
+    const result = queryWithFallback(root, surface('subscriptions', 'shorts-grid-group').chain, {
+      surfaceId: 'shorts-grid-group',
+      warn: () => {},
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.elements.map((e) => e.getAttribute('data-testid'))).toEqual(['subs-group']);
+    expect(root.querySelector('[data-testid="subs-grid-normal"]')).not.toBeNull();
+  });
+
+  it('search: matches ytd-reel-shelf-renderer and leaves both normal results alone', () => {
+    const root = mount(SEARCH_RESULTS_HTML);
+    const result = queryWithFallback(root, surface('search', 'shorts-shelf').chain, {
+      surfaceId: 'shorts-shelf',
+      warn: () => {},
+    });
+
+    expect(result.matchedSelector).toBe('ytd-reel-shelf-renderer');
+    expect(result.usedFallback).toBe(false);
+    expect(result.elements.map((e) => e.getAttribute('data-testid'))).toEqual([
+      'search-reel-shelf',
+    ]);
+    expect(normalCards(root)).toHaveLength(2);
+  });
+
+  it('watch: matches only the Shorts recommendation in the sidebar', () => {
+    const root = mount(WATCH_PAGE_HTML);
+    const result = queryWithFallback(root, surface('watch', 'shorts-cards').chain, {
+      surfaceId: 'shorts-cards',
+      warn: () => {},
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.matchedSelector).toBe('ytd-compact-video-renderer:has(a[href^="/shorts/"])');
+    expect(result.elements.map((e) => e.getAttribute('data-testid'))).toEqual([
+      'watch-shorts-rec',
+    ]);
+  });
+
+  it('nav: matches the mini-guide Shorts entry, not Home or Subscriptions', () => {
+    const root = mount(MINI_GUIDE_HTML);
+    const result = queryWithFallback(root, surface('home', 'shorts-nav').chain, {
+      surfaceId: 'shorts-nav',
+      warn: () => {},
+    });
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.matchedSelector).toBe("ytd-mini-guide-entry-renderer>a[href='/shorts/']");
+    expect(result.elements).toHaveLength(1);
+    expect(result.elements[0]?.getAttribute('title')).toBe('Shorts');
+  });
+
+  it('shorts player page: has no hiding surfaces beyond the nav (it gets gated instead)', () => {
+    const root = mount(SHORTS_PLAYER_HTML);
+    expect(SHORTS_SURFACES.shorts.map((s) => s.id)).toEqual(['shorts-nav']);
+    expect(root.querySelector('ytd-shorts')).not.toBeNull();
+  });
+
+  it('returns an empty result when nothing in the chain matches', () => {
+    const root = mount('<div><p>no youtube here</p></div>');
+    const warn = vi.fn();
+    const result = queryWithFallback(root, surface('home', 'shorts-shelf').chain, {
+      surfaceId: 'shorts-shelf',
+      warn,
+    });
+
+    expect(result.elements).toEqual([]);
+    expect(result.matchedSelector).toBeNull();
+    expect(result.usedFallback).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('skips a rung the CSS engine cannot parse instead of aborting the chain', () => {
+    const root = mount(HOME_FEED_HTML);
+    const chain: SelectorRule[] = [
+      { selector: 'ytd-rich-section-renderer:::broken' },
+      { selector: 'ytd-rich-section-renderer' },
+    ];
+    const result = queryWithFallback(root, chain, { warn: () => {} });
+    expect(result.matchedSelector).toBe('ytd-rich-section-renderer');
+  });
+});
+
+describe('fallback path (the upstream-churn scenario)', () => {
+  it('warns loudly, naming the selector, when ONLY the generic fallback matches', () => {
+    // Every ytd-* Shorts wrapper in this fixture has been renamed — precisely what
+    // Google does periodically, and the day this extension quietly stops working.
+    const root = mount(HOME_FEED_RENAMED_HTML);
+    const warn = vi.fn();
+
+    const result = queryWithFallback(root, SHORTS_FALLBACK_SURFACE.chain, {
+      surfaceId: SHORTS_FALLBACK_SURFACE.id,
+      warn,
+    });
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.matchedSelector).toBe('[href^="/shorts/"]');
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toBe(fallbackWarningMessage('shorts-fallback', '[href^="/shorts/"]'));
+    expect(message).toContain('[href^="/shorts/"]');
+    expect(message).toContain('shorts-fallback');
+    expect(message).toMatch(/YouTube DOM changed/i);
+    expect(message).toMatch(/degraded/i);
+  });
+
+  it('none of the specific chains match once the wrappers are renamed', () => {
+    const root = mount(HOME_FEED_RENAMED_HTML);
+    const warn = vi.fn();
+
+    for (const s of SHORTS_SURFACES.home) {
+      const result = queryWithFallback(root, s.chain, { surfaceId: s.id, warn });
+      expect(result.matchedSelector).toBeNull();
+    }
+    // Specific chains carry no fallback rung, so a page without that surface is silent.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn on a healthy page — no crying wolf', () => {
+    const warn = vi.fn();
+
+    for (const [html, pageType] of [
+      [HOME_FEED_HTML, 'home'],
+      [SUBSCRIPTIONS_FEED_HTML, 'subscriptions'],
+      [SEARCH_RESULTS_HTML, 'search'],
+      [WATCH_PAGE_HTML, 'watch'],
+    ] as const) {
+      const root = mount(html);
+      const result = applyShortsHiding(
+        root,
+        { enabled: true, hideShortsShelf: true },
+        { pageType, warn },
+      );
+      expect(result.degradedSurfaces).toEqual([]);
+    }
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('the fallback still finds every Shorts link and still spares normal videos', () => {
+    const root = mount(HOME_FEED_RENAMED_HTML);
+    const result = queryWithFallback(root, SHORTS_FALLBACK_SURFACE.chain, {
+      surfaceId: SHORTS_FALLBACK_SURFACE.id,
+      warn: () => {},
+    });
+
+    expect(result.usedFallback).toBe(true);
+    // Both renamed Shorts cards plus the renamed nav entry all link to /shorts/.
+    expect(result.elements).toHaveLength(3);
+    for (const element of result.elements) {
+      expect(element.getAttribute('href')?.startsWith('/shorts/')).toBe(true);
+    }
+    for (const card of normalCards(root)) {
+      expect(result.elements).not.toContain(card);
+    }
+  });
+
+  it('applyShortsHiding warns, hides anyway, and flags the degraded surface', () => {
+    const root = mount(HOME_FEED_RENAMED_HTML);
+    const warn = vi.fn();
+
+    const result = applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { pageType: 'home', warn },
+    );
+
+    expect(result.degradedSurfaces).toEqual(['shorts-fallback']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('[href^="/shorts/"]');
+
+    // Degraded still means blocking: every Shorts anchor is hidden...
+    expect(result.hidden).toBe(3);
+    expect(root.querySelectorAll(`.${HIDDEN_CLASS}`)).toHaveLength(3);
+    // ...and normal videos are still untouched.
+    for (const card of normalCards(root)) {
+      expect(card.classList.contains(HIDDEN_CLASS)).toBe(false);
+    }
+  });
+
+  it('the default warn sink dedupes so the observer cannot flood the console', () => {
+    const root = mount(HOME_FEED_RENAMED_HTML);
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        applyShortsHiding(root, { enabled: true, hideShortsShelf: true }, { pageType: 'home' });
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('applyShortsHiding', () => {
+  it('adds the hidden class to the Shorts shelf and nav, never to normal videos', () => {
+    const root = mount(HOME_FEED_HTML);
+
+    const result = applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    expect(result.hidden).toBeGreaterThan(0);
+    expect(result.degradedSurfaces).toEqual([]);
+    expect(
+      root.querySelector('[data-testid="home-shelf"]')?.classList.contains(HIDDEN_CLASS),
+    ).toBe(true);
+    for (const card of normalCards(root)) {
+      expect(card.classList.contains(HIDDEN_CLASS)).toBe(false);
+    }
+  });
+
+  it('is reversible: hiding is a class toggle, and no node is ever removed', () => {
+    const root = mount(HOME_FEED_HTML);
+    const before = root.querySelectorAll('*').length;
+
+    applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { pageType: 'home', warn: () => {} },
+    );
+    expect(root.querySelectorAll(`.${HIDDEN_CLASS}`).length).toBeGreaterThan(0);
+
+    const off = applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: false },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    expect(off.revealed).toBeGreaterThan(0);
+    expect(root.querySelectorAll(`.${HIDDEN_CLASS}`)).toHaveLength(0);
+    expect(root.querySelectorAll('*').length).toBe(before);
+    expect(root.querySelector('[data-testid="home-shelf"]')).not.toBeNull();
+  });
+
+  it('is idempotent — a second pass hides nothing new', () => {
+    const root = mount(SUBSCRIPTIONS_FEED_HTML);
+    const opts = { pageType: 'subscriptions' as const, warn: () => {} };
+    const first = applyShortsHiding(root, { enabled: true, hideShortsShelf: true }, opts);
+    const second = applyShortsHiding(root, { enabled: true, hideShortsShelf: true }, opts);
+
+    expect(first.hidden).toBeGreaterThan(0);
+    expect(second.hidden).toBe(0);
+  });
+
+  it('does nothing (and unhides) when Nudge is globally disabled', () => {
+    const root = mount(HOME_FEED_HTML);
+    applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    const result = applyShortsHiding(
+      root,
+      { enabled: false, hideShortsShelf: true },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    expect(result.hidden).toBe(0);
+    expect(result.revealed).toBeGreaterThan(0);
+    expect(root.querySelectorAll(`.${HIDDEN_CLASS}`)).toHaveLength(0);
+  });
+
+  it('derives the page type from the document URL when none is passed', () => {
+    const root = mount(SEARCH_RESULTS_HTML);
+    const result = applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { url: 'https://www.youtube.com/results?search_query=cats', warn: () => {} },
+    );
+
+    expect(result.hidden).toBeGreaterThan(0);
+    expect(
+      root.querySelector('[data-testid="search-reel-shelf"]')?.classList.contains(HIDDEN_CLASS),
+    ).toBe(true);
+    expect(normalCards(root).every((c) => !c.classList.contains(HIDDEN_CLASS))).toBe(true);
+  });
+});
+
+describe('shouldGateShorts', () => {
+  const shortsUrl = 'https://www.youtube.com/shorts/abc123XYZ';
+  const watchUrl = 'https://www.youtube.com/watch?v=abc123XYZ';
+  const homeUrl = 'https://www.youtube.com/';
+
+  it('gates /shorts/* in every blocking mode', () => {
+    for (const mode of ['HARD_BLOCK', 'DELAY', 'BREATHING'] as const) {
+      expect(shouldGateShorts(shortsUrl, { enabled: true, shortsMode: mode })).toBe(true);
+    }
+  });
+
+  it('never gates when the resolved mode is ALLOW', () => {
+    expect(shouldGateShorts(shortsUrl, { enabled: true, shortsMode: 'ALLOW' })).toBe(false);
+  });
+
+  it('never gates when Nudge is globally disabled', () => {
+    for (const mode of ['HARD_BLOCK', 'DELAY', 'BREATHING'] as const) {
+      expect(shouldGateShorts(shortsUrl, { enabled: false, shortsMode: mode })).toBe(false);
+    }
+  });
+
+  it('never gates a non-Shorts surface, whatever the mode', () => {
+    for (const url of [watchUrl, homeUrl, 'https://www.youtube.com/results?search_query=shorts']) {
+      expect(shouldGateShorts(url, { enabled: true, shortsMode: 'HARD_BLOCK' })).toBe(false);
+    }
+  });
+
+  it('never gates a non-YouTube page', () => {
+    expect(
+      shouldGateShorts('https://example.com/shorts/abc', {
+        enabled: true,
+        shortsMode: 'HARD_BLOCK',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('the /shorts/* interstitial overlay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('offers "I changed my mind" verbatim in every mode (Android parity)', () => {
+    mount(SHORTS_PLAYER_HTML);
+
+    for (const mode of ['HARD_BLOCK', 'DELAY', 'BREATHING'] as const) {
+      const overlay = createShortsOverlay(
+        document,
+        { shortsMode: mode, shortsDelaySeconds: 5 },
+        { onComplete: () => {}, onBail: () => {} },
+      );
+      const bail = overlay.element.querySelector('button');
+      // Exact wording, not "Nevermind" or "Go back" — it matches the Android app.
+      expect(bail?.textContent).toBe('I changed my mind');
+      expect(BAIL_LABEL).toBe('I changed my mind');
+      overlay.dispose();
+    }
+  });
+
+  it('DELAY counts down and then releases the gate', () => {
+    vi.useFakeTimers();
+    mount(SHORTS_PLAYER_HTML);
+    const onComplete = vi.fn();
+
+    const overlay = createShortsOverlay(
+      document,
+      { shortsMode: 'DELAY', shortsDelaySeconds: 3 },
+      { onComplete, onBail: () => {} },
+    );
+    document.body.append(overlay.element);
+
+    const counter = overlay.element.querySelector('.nudge-overlay__count');
+    expect(counter?.textContent).toBe('3');
+    vi.advanceTimersByTime(2000);
+    expect(counter?.textContent).toBe('1');
+    expect(onComplete).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    // The timer is cleared on completion — no runaway interval on a swipe-heavy page.
+    vi.advanceTimersByTime(10_000);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    overlay.dispose();
+  });
+
+  it('HARD_BLOCK has no countdown and never self-releases', () => {
+    vi.useFakeTimers();
+    mount(SHORTS_PLAYER_HTML);
+    const onComplete = vi.fn();
+
+    const overlay = createShortsOverlay(
+      document,
+      { shortsMode: 'HARD_BLOCK', shortsDelaySeconds: 3 },
+      { onComplete, onBail: () => {} },
+    );
+
+    expect(overlay.element.querySelector('.nudge-overlay__count')).toBeNull();
+    expect(overlay.element.querySelector('.nudge-overlay__breath')).toBeNull();
+    vi.advanceTimersByTime(60_000);
+    expect(onComplete).not.toHaveBeenCalled();
+    // The footer names the acting rule — Android's "Rule: X" transparency parity.
+    expect(overlay.element.querySelector('.nudge-overlay__footer')?.textContent).toContain(
+      'Hard Block',
+    );
+    overlay.dispose();
+  });
+
+  it('BREATHING runs a 4s-in/4s-out cycle and shows the remaining time', () => {
+    vi.useFakeTimers();
+    mount(SHORTS_PLAYER_HTML);
+    const onComplete = vi.fn();
+
+    const overlay = createShortsOverlay(
+      document,
+      { shortsMode: 'BREATHING', shortsDelaySeconds: 16 },
+      { onComplete, onBail: () => {} },
+    );
+    const phase = overlay.element.querySelector('.nudge-overlay__phase');
+    const remaining = overlay.element.querySelector('.nudge-overlay__remaining');
+
+    expect(phase?.textContent).toBe('Breathe in');
+    expect(remaining?.textContent).toBe('16s remaining');
+
+    vi.advanceTimersByTime(4200);
+    expect(phase?.textContent).toBe('Breathe out');
+    vi.advanceTimersByTime(4000);
+    expect(phase?.textContent).toBe('Breathe in');
+
+    vi.advanceTimersByTime(16_000);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    overlay.dispose();
+  });
+
+  it('the bail button fires onBail and never hides itself as a Shorts surface', () => {
+    const root = mount(SHORTS_PLAYER_HTML);
+    const onBail = vi.fn();
+    const overlay = createShortsOverlay(
+      document,
+      { shortsMode: 'HARD_BLOCK', shortsDelaySeconds: 5 },
+      { onComplete: () => {}, onBail },
+    );
+    root.append(overlay.element);
+
+    overlay.element.querySelector('button')?.click();
+    expect(onBail).toHaveBeenCalledTimes(1);
+
+    root.append(overlay.element);
+    applyShortsHiding(
+      root,
+      { enabled: true, hideShortsShelf: true },
+      { pageType: 'shorts', warn: () => {} },
+    );
+    expect(overlay.element.classList.contains(HIDDEN_CLASS)).toBe(false);
+    overlay.dispose();
+  });
+});

--- a/extension/tests/core/blockEngine.test.ts
+++ b/extension/tests/core/blockEngine.test.ts
@@ -115,29 +115,32 @@ describe('evaluate — budget-exceeded escalation', () => {
 
 describe('evaluate — daily budget boundary is >=, not >', () => {
   const limitMinutes = 30;
+  // A DELAY rule, deliberately: the boundary being tested is when a budget ESCALATES a rule
+  // to HARD_BLOCK. A Hard Block rule blocks either way, so it cannot show the transition.
   function rules(): ActiveRule[] {
-    return [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: limitMinutes, ruleName: 'Site' })];
+    return [activeRule({ mode: 'DELAY', dailyLimitMinutes: limitMinutes, ruleName: 'Site' })];
   }
 
-  it('1ms under the limit allows (rule is conditional, not unconditional)', () => {
+  it('1ms under the limit still gets the rule’s own mode, not an escalation', () => {
     const usageMs = limitMinutes * 60_000 - 1;
-    expect(evaluate(rules(), usageMs).type).toBe('ALLOW');
+    const decision = evaluate(rules(), usageMs);
+    expect(decision).toMatchObject({ type: 'BLOCK', mode: 'DELAY', limitReached: false });
   });
 
-  it('exactly at the limit blocks', () => {
+  it('exactly at the limit escalates to HARD_BLOCK', () => {
     const usageMs = limitMinutes * 60_000;
     const decision = evaluate(rules(), usageMs);
-    expect(decision.type).toBe('BLOCK');
-    if (decision.type === 'BLOCK') {
-      expect(decision.mode).toBe('HARD_BLOCK');
-      expect(decision.limitReached).toBe(true);
-    }
+    expect(decision).toMatchObject({
+      type: 'BLOCK',
+      mode: 'HARD_BLOCK',
+      limitReached: true,
+    });
   });
 
-  it('over the limit blocks', () => {
+  it('over the limit escalates to HARD_BLOCK', () => {
     const usageMs = limitMinutes * 60_000 + 5_000;
     const decision = evaluate(rules(), usageMs);
-    expect(decision.type).toBe('BLOCK');
+    expect(decision).toMatchObject({ type: 'BLOCK', mode: 'HARD_BLOCK', limitReached: true });
   });
 });
 
@@ -188,11 +191,121 @@ describe('evaluate — dailyTimeRemainingMs', () => {
   });
 });
 
-describe('evaluate — a HARD_BLOCK rule with a daily limit is NOT unconditional', () => {
-  it('under budget it does not hard-block via the unconditional branch', () => {
+describe('evaluate — a HARD_BLOCK rule with a daily limit still hard-blocks', () => {
+  /**
+   * REGRESSION (live-Chrome QA, 2026-07-26): this case previously matched NO branch and fell
+   * through to ALLOW. Because DNR has already redirected the navigation by the time the
+   * engine runs, that ALLOW sent the user back to the site, which redirected again — an
+   * infinite block-page loop that also hammered the service worker. Reproduced on 3 domains.
+   *
+   * A daily limit is meaningless on a Hard Block: the site is barred outright, so there is no
+   * browsing time to budget.
+   */
+  it('under budget it hard-blocks rather than falling through to ALLOW', () => {
     const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 60 })];
     const usageMs = 30 * 60_000; // 30 of 60 minutes used
-    expect(evaluate(rules, usageMs).type).toBe('ALLOW');
+    const decision = evaluate(rules, usageMs);
+
+    expect(decision.type).toBe('BLOCK');
+    expect(decision).toMatchObject({ mode: 'HARD_BLOCK' });
+  });
+
+  it('under budget it is NOT reported as limit-reached', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 60 })];
+    const decision = evaluate(rules, 30 * 60_000);
+
+    // The block is unconditional in effect, but it is not the budget that caused it, so the
+    // "(limit reached)" naming must not appear.
+    expect(decision).toMatchObject({ limitReached: false, ruleName: 'Test Rule' });
+  });
+
+  it('with zero usage it still hard-blocks', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 60 })];
+    expect(evaluate(rules, 0)).toMatchObject({ type: 'BLOCK', mode: 'HARD_BLOCK' });
+  });
+
+  it('over budget it reports limit-reached, as any exhausted rule does', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 60 })];
+    const decision = evaluate(rules, 60 * 60_000);
+
+    expect(decision).toMatchObject({
+      type: 'BLOCK',
+      mode: 'HARD_BLOCK',
+      limitReached: true,
+      ruleName: `Test Rule${LIMIT_REACHED_SUFFIX}`,
+    });
+  });
+});
+
+/**
+ * The whole class, not just the reported instance.
+ *
+ * The engine is a chain of `find` branches ending in ALLOW, so ANY (mode x limit x usage)
+ * combination that matches no branch silently becomes ALLOW. In the browser that is not a
+ * harmless no-op: DNR has already redirected, so ALLOW-while-a-rule-applies is an infinite
+ * redirect loop. This drives every combination and asserts the invariant directly.
+ */
+describe('evaluate — combination matrix: an applicable rule can NEVER produce ALLOW', () => {
+  const MODES = ['HARD_BLOCK', 'DELAY', 'BREATHING'] as const;
+  const LIMITS = [null, 60] as const;
+  /** under budget / exactly at the limit / over it — relative to a 60-minute limit. */
+  const USAGES = [
+    { label: 'no usage', ms: 0 },
+    { label: 'under budget', ms: 30 * 60_000 },
+    { label: 'one ms under the limit', ms: 60 * 60_000 - 1 },
+    { label: 'exactly at the limit', ms: 60 * 60_000 },
+    { label: 'over the limit', ms: 90 * 60_000 },
+  ];
+
+  for (const mode of MODES) {
+    for (const limit of LIMITS) {
+      for (const usage of USAGES) {
+        const label = `${mode} + ${limit === null ? 'no limit' : `${limit}m limit`} + ${usage.label}`;
+
+        it(`blocks: ${label}`, () => {
+          const decision = evaluate([activeRule({ mode, dailyLimitMinutes: limit })], usage.ms);
+
+          expect(decision.type, `${label} must not fall through to ALLOW`).toBe('BLOCK');
+        });
+      }
+    }
+  }
+
+  it('every combination yields a mode that is one of the three real block modes', () => {
+    for (const mode of MODES) {
+      for (const limit of LIMITS) {
+        for (const usage of USAGES) {
+          const decision = evaluate([activeRule({ mode, dailyLimitMinutes: limit })], usage.ms);
+          if (decision.type !== 'BLOCK') throw new Error('unreachable — asserted above');
+          expect(MODES).toContain(decision.mode);
+        }
+      }
+    }
+  });
+
+  it('an exhausted budget always escalates to HARD_BLOCK regardless of the rule mode', () => {
+    for (const mode of MODES) {
+      const decision = evaluate(
+        [activeRule({ mode, dailyLimitMinutes: 60 })],
+        60 * 60_000,
+      );
+      expect(decision, `${mode} over budget`).toMatchObject({
+        mode: 'HARD_BLOCK',
+        limitReached: true,
+      });
+    }
+  });
+
+  it('ALLOW remains reachable ONLY when no rule applies', () => {
+    expect(evaluate([], 0).type).toBe('ALLOW');
+    expect(evaluate([activeRule({ enabled: false })], 0).type).toBe('ALLOW');
+    // Applicable-but-out-of-schedule is also "no rule applies".
+    const outsideWindow = at(2026, 1, 7, 20, 0);
+    const scheduled = activeRule({
+      scheduleStartMinute: 9 * 60,
+      scheduleEndMinute: 17 * 60,
+    });
+    expect(evaluate([scheduled], 0, outsideWindow).type).toBe('ALLOW');
   });
 });
 

--- a/extension/tests/core/blockEngine.test.ts
+++ b/extension/tests/core/blockEngine.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluate, LIMIT_REACHED_SUFFIX } from '../../src/core/blockEngine';
+import type { ActiveRule } from '../../src/core/types';
+
+/**
+ * Port of app/src/test/java/.../BlockEngineTest.kt, plus the priority-ladder and
+ * budget-boundary edge cases the extension spec calls out explicitly.
+ *
+ * Note: unlike the Kotlin engine, this TS port's `ActiveRule` has no `inAppFeatures` /
+ * feature-scoping — that concept doesn't exist in src/core/types.ts, so the Kotlin
+ * feature-scoped-rule tests have no analog here and are intentionally not ported.
+ */
+
+function activeRule(overrides: Partial<ActiveRule> = {}): ActiveRule {
+  return {
+    mode: 'HARD_BLOCK',
+    delaySeconds: 15,
+    dailyLimitMinutes: null,
+    enabled: true,
+    scheduleDays: null,
+    scheduleStartMinute: null,
+    scheduleEndMinute: null,
+    ruleName: 'Test Rule',
+    ...overrides,
+  };
+}
+
+/** 1-based month, matching how humans read dates ("January" = 1), unlike raw `Date`. */
+function at(year: number, month: number, day: number, hour: number, minute: number): Date {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+describe('evaluate — empty / disabled inputs', () => {
+  it('an empty rule list allows', () => {
+    expect(evaluate([], 0)).toEqual({ type: 'ALLOW' });
+  });
+
+  it('all-disabled rules allow, even an otherwise-unconditional HARD_BLOCK', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: null, enabled: false })];
+    expect(evaluate(rules, 0)).toEqual({ type: 'ALLOW' });
+  });
+});
+
+describe('evaluate — priority ladder: unconditional HARD_BLOCK beats everything', () => {
+  it('beats a DELAY rule in the same list', () => {
+    const rules = [
+      activeRule({ mode: 'DELAY', delaySeconds: 30, ruleName: 'Delay Rule' }),
+      activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: null, ruleName: 'Hard Rule' }),
+    ];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('HARD_BLOCK');
+      expect(decision.ruleName).toBe('Hard Rule');
+    }
+  });
+
+  it('beats a BREATHING rule in the same list', () => {
+    const rules = [
+      activeRule({ mode: 'BREATHING', delaySeconds: 20, ruleName: 'Breathing Rule' }),
+      activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: null, ruleName: 'Hard Rule' }),
+    ];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('HARD_BLOCK');
+      expect(decision.ruleName).toBe('Hard Rule');
+    }
+  });
+
+  it('beats a budget-exceeded rule present in the same list', () => {
+    const rules = [
+      // This rule alone would trigger the budget-exceeded branch...
+      activeRule({ mode: 'DELAY', delaySeconds: 5, dailyLimitMinutes: 10, ruleName: 'Budget Rule' }),
+      // ...but the unconditional HARD_BLOCK short-circuits before that branch is reached.
+      activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: null, ruleName: 'Hard Rule' }),
+    ];
+    const usageMs = 11 * 60_000; // over Budget Rule's 10-minute limit
+    const decision = evaluate(rules, usageMs);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('HARD_BLOCK');
+      expect(decision.ruleName).toBe('Hard Rule');
+      expect(decision.limitReached).toBe(false);
+    }
+  });
+});
+
+describe('evaluate — budget-exceeded escalation', () => {
+  it('forces HARD_BLOCK, suffixes the rule name, and sets limitReached', () => {
+    const rules = [
+      activeRule({ mode: 'DELAY', delaySeconds: 20, dailyLimitMinutes: 30, ruleName: 'YouTube' }),
+    ];
+    const decision = evaluate(rules, 30 * 60_000); // exactly at the limit
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('HARD_BLOCK');
+      expect(decision.ruleName).toBe(`YouTube${LIMIT_REACHED_SUFFIX}`);
+      expect(decision.limitReached).toBe(true);
+    }
+  });
+
+  it('a null rule name stays null — never "null (limit reached)"', () => {
+    const rules = [
+      activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 30, ruleName: null }),
+    ];
+    const decision = evaluate(rules, 30 * 60_000);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.ruleName).toBeNull();
+    }
+  });
+});
+
+describe('evaluate — daily budget boundary is >=, not >', () => {
+  const limitMinutes = 30;
+  function rules(): ActiveRule[] {
+    return [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: limitMinutes, ruleName: 'Site' })];
+  }
+
+  it('1ms under the limit allows (rule is conditional, not unconditional)', () => {
+    const usageMs = limitMinutes * 60_000 - 1;
+    expect(evaluate(rules(), usageMs).type).toBe('ALLOW');
+  });
+
+  it('exactly at the limit blocks', () => {
+    const usageMs = limitMinutes * 60_000;
+    const decision = evaluate(rules(), usageMs);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('HARD_BLOCK');
+      expect(decision.limitReached).toBe(true);
+    }
+  });
+
+  it('over the limit blocks', () => {
+    const usageMs = limitMinutes * 60_000 + 5_000;
+    const decision = evaluate(rules(), usageMs);
+    expect(decision.type).toBe('BLOCK');
+  });
+});
+
+describe('evaluate — DELAY beats BREATHING', () => {
+  it('DELAY is chosen over BREATHING when both are present, and its delaySeconds propagates', () => {
+    const rules = [
+      activeRule({ mode: 'BREATHING', delaySeconds: 45, ruleName: 'Breathing Rule' }),
+      activeRule({ mode: 'DELAY', delaySeconds: 12, ruleName: 'Delay Rule' }),
+    ];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('DELAY');
+      expect(decision.delaySeconds).toBe(12);
+      expect(decision.ruleName).toBe('Delay Rule');
+    }
+  });
+});
+
+describe('evaluate — dailyTimeRemainingMs', () => {
+  it('is null when no applicable rule sets a daily limit', () => {
+    const rules = [activeRule({ mode: 'DELAY', dailyLimitMinutes: null })];
+    const decision = evaluate(rules, 5_000);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') expect(decision.dailyTimeRemainingMs).toBeNull();
+  });
+
+  it('is floored at zero, never negative, once usage exceeds the limit', () => {
+    const rules = [activeRule({ mode: 'DELAY', dailyLimitMinutes: 10 })];
+    const usageMs = 10 * 60_000 + 999_999; // way over
+    const decision = evaluate(rules, usageMs);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') expect(decision.dailyTimeRemainingMs).toBe(0);
+  });
+
+  it('uses the MINIMUM limit across several applicable rules with different limits', () => {
+    const rules = [
+      activeRule({ mode: 'BREATHING', dailyLimitMinutes: 60, ruleName: 'Loose' }),
+      activeRule({ mode: 'BREATHING', dailyLimitMinutes: 20, ruleName: 'Tight' }),
+    ];
+    const usageMs = 5 * 60_000; // 5 minutes used
+    const decision = evaluate(rules, usageMs);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.dailyLimitMinutes).toBe(20);
+      expect(decision.dailyTimeRemainingMs).toBe(15 * 60_000); // 20 - 5 = 15 min remaining
+    }
+  });
+});
+
+describe('evaluate — a HARD_BLOCK rule with a daily limit is NOT unconditional', () => {
+  it('under budget it does not hard-block via the unconditional branch', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: 60 })];
+    const usageMs = 30 * 60_000; // 30 of 60 minutes used
+    expect(evaluate(rules, usageMs).type).toBe('ALLOW');
+  });
+});
+
+describe('evaluate — schedule filtering (explicit `now`)', () => {
+  it('scheduled rules outside their window are filtered out entirely', () => {
+    const now = at(2026, 1, 7, 20, 0); // Wed 20:00 — outside 9:00-17:00
+    const rules = [
+      activeRule({
+        mode: 'HARD_BLOCK',
+        dailyLimitMinutes: null,
+        scheduleStartMinute: 9 * 60,
+        scheduleEndMinute: 17 * 60,
+      }),
+    ];
+    expect(evaluate(rules, 0, now).type).toBe('ALLOW');
+  });
+
+  it('scheduled rules inside their window are applied', () => {
+    const now = at(2026, 1, 7, 10, 0); // Wed 10:00 — inside 9:00-17:00
+    const rules = [
+      activeRule({
+        mode: 'HARD_BLOCK',
+        dailyLimitMinutes: null,
+        scheduleStartMinute: 9 * 60,
+        scheduleEndMinute: 17 * 60,
+      }),
+    ];
+    expect(evaluate(rules, 0, now).type).toBe('BLOCK');
+  });
+});
+
+describe('evaluate — Android-parity sanity checks (ported from BlockEngineTest.kt)', () => {
+  it('a single HARD_BLOCK rule blocks with mode HARD_BLOCK', () => {
+    const rules = [activeRule({ mode: 'HARD_BLOCK', dailyLimitMinutes: null })];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') expect(decision.mode).toBe('HARD_BLOCK');
+  });
+
+  it('a DELAY rule blocks with the configured delaySeconds', () => {
+    const rules = [activeRule({ mode: 'DELAY', delaySeconds: 30, dailyLimitMinutes: null })];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('DELAY');
+      expect(decision.delaySeconds).toBe(30);
+    }
+  });
+
+  it('a BREATHING rule blocks with the configured delaySeconds', () => {
+    const rules = [activeRule({ mode: 'BREATHING', delaySeconds: 20, dailyLimitMinutes: null })];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.mode).toBe('BREATHING');
+      expect(decision.delaySeconds).toBe(20);
+    }
+  });
+
+  it('multiple DELAY rules use the first matching rule\'s delaySeconds', () => {
+    const rules = [
+      activeRule({ mode: 'DELAY', delaySeconds: 10, ruleName: 'First' }),
+      activeRule({ mode: 'DELAY', delaySeconds: 30, ruleName: 'Second' }),
+    ];
+    const decision = evaluate(rules, 0);
+    expect(decision.type).toBe('BLOCK');
+    if (decision.type === 'BLOCK') {
+      expect(decision.delaySeconds).toBe(10);
+      expect(decision.ruleName).toBe('First');
+    }
+  });
+});

--- a/extension/tests/core/budgets.test.ts
+++ b/extension/tests/core/budgets.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  crossesLimit,
+  isOverBudget,
+  limitMs,
+  remainingFraction,
+  remainingMs,
+  tightestLimit,
+} from '../../src/core/budgets';
+import type { SiteRule } from '../../src/core/settingsSchema';
+
+function makeRule(overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: overrides.id ?? 'rule-1',
+    domain: overrides.domain ?? 'example.com',
+    mode: overrides.mode ?? 'HARD_BLOCK',
+    delaySeconds: overrides.delaySeconds ?? 15,
+    dailyLimitMinutes: overrides.dailyLimitMinutes ?? null,
+    enabled: overrides.enabled ?? true,
+    createdAt: overrides.createdAt ?? 0,
+    showTimeRemaining: overrides.showTimeRemaining ?? false,
+    schedule: overrides.schedule ?? null,
+  };
+}
+
+describe('limitMs', () => {
+  it('converts minutes to milliseconds', () => {
+    expect(limitMs(0)).toBe(0);
+    expect(limitMs(1)).toBe(60_000);
+    expect(limitMs(30)).toBe(1_800_000);
+  });
+});
+
+describe('remainingMs', () => {
+  it('is null when there is no limit', () => {
+    expect(remainingMs(null, 0)).toBeNull();
+    expect(remainingMs(null, 999_999)).toBeNull();
+  });
+
+  it('computes the remaining budget under the limit', () => {
+    expect(remainingMs(30, 0)).toBe(1_800_000);
+    expect(remainingMs(30, 600_000)).toBe(1_200_000);
+  });
+
+  it('floors at 0 and never goes negative once usage overshoots the limit', () => {
+    expect(remainingMs(30, 1_800_000)).toBe(0);
+    expect(remainingMs(30, 5_000_000)).toBe(0);
+    expect(remainingMs(1, 10_000_000)).not.toBeLessThan(0);
+  });
+});
+
+describe('isOverBudget', () => {
+  it('is false when there is no limit', () => {
+    expect(isOverBudget(null, 0)).toBe(false);
+    expect(isOverBudget(null, 999_999_999)).toBe(false);
+  });
+
+  it('is false while strictly under the limit', () => {
+    expect(isOverBudget(30, limitMs(30) - 1)).toBe(false);
+  });
+
+  it('is true exactly AT the limit boundary (>=, matches blockEngine.ts)', () => {
+    expect(isOverBudget(30, limitMs(30))).toBe(true);
+  });
+
+  it('is true once past the limit', () => {
+    expect(isOverBudget(30, limitMs(30) + 1)).toBe(true);
+  });
+});
+
+describe('remainingFraction', () => {
+  it('is null when there is no limit', () => {
+    expect(remainingFraction(null, 0)).toBeNull();
+  });
+
+  it('is 1 at zero usage and 0 once usage reaches the limit', () => {
+    expect(remainingFraction(30, 0)).toBe(1);
+    expect(remainingFraction(30, limitMs(30))).toBe(0);
+  });
+
+  it('is a fraction in between, and never negative past the limit', () => {
+    expect(remainingFraction(30, limitMs(30) / 2)).toBeCloseTo(0.5);
+    const past = remainingFraction(30, limitMs(30) * 2);
+    expect(past).not.toBeNull();
+    expect(past as number).toBeGreaterThanOrEqual(0);
+    expect(past as number).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('tightestLimit', () => {
+  it('is null for an empty list', () => {
+    expect(tightestLimit([])).toBeNull();
+  });
+
+  it('is null when every rule has no limit', () => {
+    expect(
+      tightestLimit([makeRule({ dailyLimitMinutes: null }), makeRule({ dailyLimitMinutes: null })]),
+    ).toBeNull();
+  });
+
+  it('picks the minimum non-null limit and ignores nulls', () => {
+    expect(
+      tightestLimit([
+        makeRule({ dailyLimitMinutes: null }),
+        makeRule({ dailyLimitMinutes: 60 }),
+        makeRule({ dailyLimitMinutes: 15 }),
+        makeRule({ dailyLimitMinutes: 30 }),
+      ]),
+    ).toBe(15);
+  });
+
+  it('works with a single rule', () => {
+    expect(tightestLimit([makeRule({ dailyLimitMinutes: 45 })])).toBe(45);
+  });
+});
+
+describe('crossesLimit', () => {
+  it('is false when there is no limit', () => {
+    expect(crossesLimit(null, 0, 999_999_999)).toBe(false);
+  });
+
+  it('is false while still under the limit after the tick', () => {
+    expect(crossesLimit(30, 0, limitMs(30) - 1)).toBe(false);
+  });
+
+  it('is true only on the exact tick that crosses INTO the limit boundary (>=)', () => {
+    expect(crossesLimit(30, limitMs(30) - 1, limitMs(30))).toBe(true);
+  });
+
+  it('is true on the tick that jumps straight past the limit', () => {
+    expect(crossesLimit(30, limitMs(30) - 1, limitMs(30) + 5_000)).toBe(true);
+  });
+
+  it('is false when usage was ALREADY at/over the limit before this tick', () => {
+    expect(crossesLimit(30, limitMs(30), limitMs(30) + 1_000)).toBe(false);
+    expect(crossesLimit(30, limitMs(30) + 1_000, limitMs(30) + 2_000)).toBe(false);
+  });
+
+  it('is false for a tick that stays flat exactly at the limit', () => {
+    expect(crossesLimit(30, limitMs(30), limitMs(30))).toBe(false);
+  });
+});

--- a/extension/tests/core/domainMatcher.test.ts
+++ b/extension/tests/core/domainMatcher.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dnrUrlFilter,
+  extractDomain,
+  matchesDomain,
+  normalizeToBaseDomain,
+  normalizeUserInput,
+} from '../../src/core/domainMatcher';
+
+/**
+ * Port of app/src/test/java/.../WebDomainMatcherTest.kt, extended for the TS port's
+ * wider internal-scheme set (chrome-extension, moz-extension, blob, view-source,
+ * devtools, ...), userinfo stripping, and the illegal-hostname-character guard —
+ * none of which exist in the Kotlin original (it only ever saw a Chrome URL bar).
+ */
+
+describe('extractDomain — happy paths', () => {
+  it('extracts from a full URL with path/query', () => {
+    expect(extractDomain('https://www.youtube.com/watch?v=abc')).toBe('youtube.com');
+  });
+
+  it('extracts from a bare domain', () => {
+    expect(extractDomain('instagram.com')).toBe('instagram.com');
+  });
+
+  it('strips path, query, fragment, and port together', () => {
+    expect(extractDomain('https://youtube.com:8080/watch?v=abc#t=10')).toBe('youtube.com');
+  });
+
+  it('strips userinfo (user:pass@host) before parsing the host', () => {
+    expect(extractDomain('https://user:pass@example.com/path')).toBe('example.com');
+  });
+
+  it('normalizes uppercase input to lowercase', () => {
+    expect(extractDomain('HTTPS://WWW.YOUTUBE.COM/WATCH')).toBe('youtube.com');
+  });
+
+  it.each(['www', 'm', 'mobile', 'l', 'lm'])('strips the known "%s." subdomain prefix', (sub) => {
+    expect(extractDomain(`${sub}.youtube.com/path`)).toBe('youtube.com');
+  });
+
+  it('leaves a NON-known multi-part subdomain intact', () => {
+    expect(extractDomain('foo.bar.example.com')).toBe('foo.bar.example.com');
+  });
+
+  it('leaves a two-part host untouched', () => {
+    expect(extractDomain('example.com')).toBe('example.com');
+  });
+});
+
+describe('extractDomain — returns null', () => {
+  it('for a blank string', () => {
+    expect(extractDomain('')).toBeNull();
+  });
+
+  it('for a whitespace-only string', () => {
+    expect(extractDomain('   ')).toBeNull();
+  });
+
+  it('for chrome://', () => {
+    expect(extractDomain('chrome://extensions')).toBeNull();
+  });
+
+  it('for chrome-extension://', () => {
+    expect(extractDomain('chrome-extension://abc/blocked.html')).toBeNull();
+  });
+
+  it('for about:blank', () => {
+    expect(extractDomain('about:blank')).toBeNull();
+  });
+
+  it('for javascript:', () => {
+    expect(extractDomain('javascript:void(0)')).toBeNull();
+  });
+
+  it('for file://', () => {
+    expect(extractDomain('file:///tmp/x.html')).toBeNull();
+  });
+
+  it('for data:', () => {
+    expect(extractDomain('data:text/html,x')).toBeNull();
+  });
+
+  it('for a host with no dot ("localhost")', () => {
+    expect(extractDomain('localhost')).toBeNull();
+    expect(extractDomain('localhost:3000/api')).toBeNull();
+  });
+
+  it('for a host containing illegal characters', () => {
+    expect(extractDomain('exam_ple.com')).toBeNull();
+  });
+});
+
+describe('normalizeToBaseDomain', () => {
+  it('strips a known subdomain prefix', () => {
+    expect(normalizeToBaseDomain('www.instagram.com')).toBe('instagram.com');
+  });
+
+  it('leaves a two-part host untouched', () => {
+    expect(normalizeToBaseDomain('instagram.com')).toBe('instagram.com');
+  });
+
+  it('leaves a non-known multi-part subdomain intact', () => {
+    expect(normalizeToBaseDomain('api.example.com')).toBe('api.example.com');
+  });
+});
+
+describe('matchesDomain', () => {
+  it('matches a www subdomain against a bare-domain rule', () => {
+    expect(matchesDomain('https://www.youtube.com/feed', 'youtube.com')).toBe(true);
+  });
+
+  it('matches an m subdomain against a bare-domain rule', () => {
+    expect(matchesDomain('https://m.youtube.com/shorts', 'youtube.com')).toBe(true);
+  });
+
+  it('does not match a different domain', () => {
+    expect(matchesDomain('https://vimeo.com/123', 'youtube.com')).toBe(false);
+  });
+
+  it('does not match when the rule domain is empty', () => {
+    expect(matchesDomain('https://youtube.com', '')).toBe(false);
+  });
+
+  it('does NOT false-positive on a superstring domain ("notyoutube.com" vs "youtube.com")', () => {
+    expect(matchesDomain('https://notyoutube.com/watch', 'youtube.com')).toBe(false);
+  });
+
+  it('returns false for an unparseable URL', () => {
+    expect(matchesDomain('chrome://settings', 'settings.com')).toBe(false);
+  });
+});
+
+describe('dnrUrlFilter', () => {
+  it('produces the anchored ||domain^ filter', () => {
+    expect(dnrUrlFilter('youtube.com')).toBe('||youtube.com^');
+  });
+
+  it('normalizes a www-prefixed rule domain to the same filter', () => {
+    expect(dnrUrlFilter('www.youtube.com')).toBe('||youtube.com^');
+  });
+});
+
+describe('normalizeUserInput', () => {
+  it('accepts a pasted full URL', () => {
+    expect(normalizeUserInput('https://www.youtube.com/feed')).toBe('youtube.com');
+  });
+
+  it('accepts a bare domain with a known subdomain prefix', () => {
+    expect(normalizeUserInput('m.youtube.com')).toBe('youtube.com');
+  });
+
+  it('accepts a plain bare domain', () => {
+    expect(normalizeUserInput('youtube.com')).toBe('youtube.com');
+  });
+
+  it('returns null on garbage input', () => {
+    expect(normalizeUserInput('this is not a url')).toBeNull();
+  });
+});

--- a/extension/tests/core/emergencyPass.test.ts
+++ b/extension/tests/core/emergencyPass.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GLOBAL_KEY,
+  LOCKOUT_MS,
+  PASS_DURATION_MS,
+  canUseGlobal,
+  globalLastUsed,
+  nextAvailableGlobalMs,
+  parse,
+  recordGlobal,
+  serialize,
+} from '../../src/core/emergencyPass';
+
+// Tests for the pure emergency-pass ledger logic. The pass gates a protection-WEAKENING escape
+// hatch with GLOBAL (one-per-24h-across-all-sites) semantics, so both the eligibility boundary
+// (exact-cooldown, never-used, cross-site lockout) and robustness of the persisted-ledger parser
+// (malformed input must never throw; a legacy per-site ledger must migrate) are load-bearing.
+
+const cooldown = LOCKOUT_MS;
+const t0 = 1_000_000_000_000; // arbitrary fixed "now" base
+
+describe('emergencyPass: parse() / serialize() round-trip', () => {
+  it('empty string parses to an empty object', () => {
+    expect(parse('')).toEqual({});
+    expect(parse('   ')).toEqual({});
+  });
+
+  it('single entry round-trips', () => {
+    const usage = { 'foo.com': 123456789 };
+    expect(parse(serialize(usage))).toEqual(usage);
+  });
+
+  it('global record round-trips through serialize', () => {
+    const recorded = recordGlobal(t0);
+    expect(recorded).toEqual({ [GLOBAL_KEY]: t0 });
+    expect(parse(serialize(recorded))).toEqual(recorded);
+  });
+
+  it('serialize of an empty object is an empty string', () => {
+    expect(serialize({})).toBe('');
+  });
+
+  it('malformed entries are ignored and never throw', () => {
+    // Missing value, missing key, non-numeric value, negative value, stray separators, no '='.
+    const raw = 'a.com=100;=200;b.com=;c.com=abc;;d.com=-5;garbage;e.com=300';
+    expect(() => parse(raw)).not.toThrow();
+    const parsed = parse(raw);
+    expect(parsed).toEqual({ 'a.com': 100, 'e.com': 300 });
+  });
+
+  it('entirely garbage input yields an empty object and never throws', () => {
+    expect(() => parse(';;;===;no-equals;')).not.toThrow();
+    expect(parse(';;;===;no-equals;')).toEqual({});
+  });
+});
+
+describe('emergencyPass: globalLastUsed() (migration-safe MAX)', () => {
+  it('is null when never used', () => {
+    expect(globalLastUsed({})).toBeNull();
+  });
+
+  it('is the single global entry', () => {
+    expect(globalLastUsed({ [GLOBAL_KEY]: t0 })).toBe(t0);
+  });
+
+  it('takes the MAX across a legacy per-site ledger (migration)', () => {
+    // Old per-site ledger: the most recent site's timestamp becomes the global last-used.
+    const legacy = {
+      'instagram.com': t0,
+      'tiktok.com': t0 + 5_000,
+      'youtube.com': t0 - 10_000,
+    };
+    expect(globalLastUsed(legacy)).toBe(t0 + 5_000);
+  });
+});
+
+describe('emergencyPass: canUseGlobal()', () => {
+  it('true when never used before', () => {
+    expect(canUseGlobal({}, t0, cooldown)).toBe(true);
+  });
+
+  it('false immediately after use', () => {
+    const usage = recordGlobal(t0);
+    expect(canUseGlobal(usage, t0, cooldown)).toBe(false);
+  });
+
+  it('false just before cooldown elapses', () => {
+    const usage = recordGlobal(t0);
+    expect(canUseGlobal(usage, t0 + cooldown - 1, cooldown)).toBe(false);
+  });
+
+  it('true exactly at the cooldown boundary', () => {
+    const usage = recordGlobal(t0);
+    expect(canUseGlobal(usage, t0 + cooldown, cooldown)).toBe(true);
+  });
+
+  it('is GLOBAL — using on any site locks out all sites', () => {
+    // A per-site ledger with a single recent entry (e.g. pass used on Instagram) still blocks
+    // the pass for every other site because the lockout is global, not per-domain.
+    const usedOnInstagram = { 'instagram.com': t0 };
+    // No matter which site's block screen we are on, the pass is locked until cooldown elapses.
+    expect(canUseGlobal(usedOnInstagram, t0 + 1, cooldown)).toBe(false);
+    expect(canUseGlobal(usedOnInstagram, t0 + cooldown, cooldown)).toBe(true);
+  });
+});
+
+describe('emergencyPass: nextAvailableGlobalMs()', () => {
+  it('is zero when never used', () => {
+    expect(nextAvailableGlobalMs({}, t0, cooldown)).toBe(0);
+  });
+
+  it('is the full cooldown immediately after use', () => {
+    const usage = recordGlobal(t0);
+    expect(nextAvailableGlobalMs(usage, t0, cooldown)).toBe(cooldown);
+  });
+
+  it('decreases as time passes (decay toward zero)', () => {
+    const usage = recordGlobal(t0);
+    const elapsed = 3_600_000; // 1h
+    expect(nextAvailableGlobalMs(usage, t0 + elapsed, cooldown)).toBe(cooldown - elapsed);
+  });
+
+  it('is zero once the cooldown has passed', () => {
+    const usage = recordGlobal(t0);
+    expect(nextAvailableGlobalMs(usage, t0 + cooldown, cooldown)).toBe(0);
+    expect(nextAvailableGlobalMs(usage, t0 + cooldown + 5_000, cooldown)).toBe(0);
+  });
+
+  it('uses the MAX timestamp of a legacy ledger', () => {
+    const legacy = { 'a.com': t0, 'b.com': t0 + 10_000 };
+    // Locked out relative to the most recent (b.com) entry.
+    expect(nextAvailableGlobalMs(legacy, t0 + 20_000, cooldown)).toBe(cooldown - 10_000);
+  });
+});
+
+describe('emergencyPass: recordGlobal()', () => {
+  it('collapses to a single global entry', () => {
+    expect(recordGlobal(t0)).toEqual({ [GLOBAL_KEY]: t0 });
+  });
+
+  it('overwrites any prior per-site entries (collapse, not merge)', () => {
+    // recordGlobal is a pure constructor — the "collapse" behavior is verified by the caller
+    // (settings write) discarding the old ledger entirely and using this return value as-is.
+    const fresh = recordGlobal(t0);
+    expect(Object.keys(fresh)).toEqual([GLOBAL_KEY]);
+  });
+
+  it('output round-trips through serialize and canUseGlobal', () => {
+    const recorded = recordGlobal(t0);
+    const reparsed = parse(serialize(recorded));
+    expect(canUseGlobal(reparsed, t0, cooldown)).toBe(false);
+    expect(canUseGlobal(reparsed, t0 + cooldown, cooldown)).toBe(true);
+  });
+});
+
+describe('emergencyPass: constants', () => {
+  it('match the spec', () => {
+    expect(PASS_DURATION_MS).toBe(120_000);
+    expect(LOCKOUT_MS).toBe(86_400_000);
+    expect(GLOBAL_KEY).toBe('*');
+  });
+});

--- a/extension/tests/core/messages.test.ts
+++ b/extension/tests/core/messages.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DELAY_SUBTITLES,
+  DEFAULT_DELAY_TITLES,
+  DEFAULT_HARD_BLOCK_MESSAGES,
+  pickRandom,
+  resolvePool,
+} from '../../src/core/messages';
+
+describe('messages: default pool contents', () => {
+  it('DEFAULT_DELAY_TITLES matches the Android defaults exactly', () => {
+    expect(DEFAULT_DELAY_TITLES).toEqual([
+      'Take a moment to think...',
+      'Pause and reflect',
+      'Is this intentional?',
+      'Before you scroll...',
+      'A moment of awareness',
+    ]);
+  });
+
+  it('DEFAULT_DELAY_SUBTITLES matches the Android defaults, with the one app->site swap', () => {
+    expect(DEFAULT_DELAY_SUBTITLES).toEqual([
+      'Do you really need to open this site right now?',
+      'What were you about to do instead?',
+      'Will this bring you closer to your goals?',
+      'You chose to add friction here for a reason.',
+      'This is your future self thanking you.',
+    ]);
+  });
+
+  it('DEFAULT_HARD_BLOCK_MESSAGES matches the Android defaults, with the two app->site swaps', () => {
+    expect(DEFAULT_HARD_BLOCK_MESSAGES).toEqual([
+      "You've blocked access to this site",
+      'This site is off-limits right now',
+      'Your future self will thank you',
+      'Time to do something else',
+      'You set this boundary for a reason',
+    ]);
+  });
+
+  it('every default pool is non-empty', () => {
+    expect(DEFAULT_DELAY_TITLES.length).toBeGreaterThan(0);
+    expect(DEFAULT_DELAY_SUBTITLES.length).toBeGreaterThan(0);
+    expect(DEFAULT_HARD_BLOCK_MESSAGES.length).toBeGreaterThan(0);
+  });
+
+  it('none of the default pools contain the word "app" (browser-appropriate copy)', () => {
+    for (const pool of [DEFAULT_DELAY_TITLES, DEFAULT_DELAY_SUBTITLES, DEFAULT_HARD_BLOCK_MESSAGES]) {
+      for (const message of pool) {
+        expect(message.toLowerCase()).not.toContain('app');
+      }
+    }
+  });
+});
+
+describe('messages: resolvePool() — string input', () => {
+  const defaults = ['Default A', 'Default B'];
+
+  it('falls back to defaults when custom is an empty string', () => {
+    expect(resolvePool('', defaults)).toEqual(defaults);
+  });
+
+  it('falls back to defaults when custom is blank (whitespace only)', () => {
+    expect(resolvePool('   ', defaults)).toEqual(defaults);
+  });
+
+  it('falls back to defaults when custom is only newlines and whitespace', () => {
+    expect(resolvePool('\n  \n\t\n', defaults)).toEqual(defaults);
+  });
+
+  it('parses multiline custom text into trimmed lines', () => {
+    const custom = 'First message\nSecond message\nThird message';
+    expect(resolvePool(custom, defaults)).toEqual([
+      'First message',
+      'Second message',
+      'Third message',
+    ]);
+  });
+
+  it('handles a single line', () => {
+    expect(resolvePool('Only one', defaults)).toEqual(['Only one']);
+  });
+
+  it('trims surrounding whitespace on each line', () => {
+    const custom = '  leading\ntrailing  \n  both  ';
+    expect(resolvePool(custom, defaults)).toEqual(['leading', 'trailing', 'both']);
+  });
+
+  it('drops blank lines mixed among real ones', () => {
+    const custom = 'First\n\n   \nSecond\n\t\nThird\n';
+    expect(resolvePool(custom, defaults)).toEqual(['First', 'Second', 'Third']);
+  });
+});
+
+describe('messages: resolvePool() — array input', () => {
+  const defaults = ['Default A', 'Default B'];
+
+  it('falls back to defaults when custom is an empty array', () => {
+    expect(resolvePool([], defaults)).toEqual(defaults);
+  });
+
+  it('falls back to defaults when custom is an array of blank strings', () => {
+    expect(resolvePool(['', '   ', '\t'], defaults)).toEqual(defaults);
+  });
+
+  it('trims and keeps non-blank array entries, dropping blanks mixed among them', () => {
+    expect(resolvePool([' First ', '', 'Second', '   '], defaults)).toEqual(['First', 'Second']);
+  });
+
+  it('an already-clean array round-trips unchanged', () => {
+    expect(resolvePool(['One', 'Two', 'Three'], defaults)).toEqual(['One', 'Two', 'Three']);
+  });
+});
+
+describe('messages: pickRandom()', () => {
+  it('returns an element that belongs to the pool (default Math.random)', () => {
+    const pool = ['a', 'b', 'c'];
+    for (let i = 0; i < 20; i++) {
+      expect(pool).toContain(pickRandom(pool));
+    }
+  });
+
+  it('is deterministic with an injected rng returning 0 -> first element', () => {
+    const pool = ['first', 'second', 'third'];
+    expect(pickRandom(pool, () => 0)).toBe('first');
+  });
+
+  it('is deterministic with an injected rng returning just under 1 -> last element', () => {
+    const pool = ['first', 'second', 'third'];
+    expect(pickRandom(pool, () => 0.999999)).toBe('third');
+  });
+
+  it('is deterministic with an injected rng landing mid-pool', () => {
+    const pool = ['first', 'second', 'third', 'fourth'];
+    // 0.5 * 4 = 2 -> index 2 -> 'third'.
+    expect(pickRandom(pool, () => 0.5)).toBe('third');
+  });
+
+  it('clamps a misbehaving rng that returns exactly 1', () => {
+    const pool = ['first', 'second', 'third'];
+    expect(pickRandom(pool, () => 1)).toBe('third');
+  });
+
+  it('throws on an empty pool rather than returning undefined', () => {
+    expect(() => pickRandom([])).toThrow(RangeError);
+  });
+
+  it('works over the real default message pools', () => {
+    const message = pickRandom(DEFAULT_DELAY_TITLES);
+    expect(DEFAULT_DELAY_TITLES).toContain(message);
+  });
+});

--- a/extension/tests/core/ruleResolver.test.ts
+++ b/extension/tests/core/ruleResolver.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveActiveRules, resolveRule, rulesForDomain } from '../../src/core/ruleResolver';
+import type { ScheduleOverride, SiteRule } from '../../src/core/settingsSchema';
+
+/**
+ * ruleResolver bridges stored SiteRule settings to engine ActiveRule input. The core
+ * semantic under test is "Scheduled Override": inside an active window the schedule's
+ * mode+delay REPLACE the rule's default, even when the scheduled mode is weaker than the
+ * default — that's deliberate (a user setting up "gentler at night" wants the gentler
+ * mode to actually apply, not just be advisory).
+ */
+
+function siteRule(overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: 'rule-1',
+    domain: 'youtube.com',
+    mode: 'HARD_BLOCK',
+    delaySeconds: 15,
+    dailyLimitMinutes: null,
+    enabled: true,
+    createdAt: 0,
+    showTimeRemaining: false,
+    schedule: null,
+    ...overrides,
+  };
+}
+
+function scheduleOverride(overrides: Partial<ScheduleOverride> = {}): ScheduleOverride {
+  return {
+    enabled: true,
+    days: null,
+    startMinute: null,
+    endMinute: null,
+    mode: 'BREATHING',
+    delaySeconds: 20,
+    ...overrides,
+  };
+}
+
+/** 1-based month, matching how humans read dates ("January" = 1), unlike raw `Date`. */
+function at(year: number, month: number, day: number, hour: number, minute: number): Date {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+describe('rulesForDomain', () => {
+  it('filters out disabled rules and rules for a different domain', () => {
+    const rules = [
+      siteRule({ id: 'a', domain: 'youtube.com', enabled: true }),
+      siteRule({ id: 'b', domain: 'youtube.com', enabled: false }),
+      siteRule({ id: 'c', domain: 'instagram.com', enabled: true }),
+    ];
+    const result = rulesForDomain(rules, 'youtube.com');
+    expect(result.map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(rulesForDomain([siteRule({ domain: 'instagram.com' })], 'youtube.com')).toEqual([]);
+  });
+});
+
+describe('resolveRule', () => {
+  it('outside the schedule window, uses the rule\'s default mode + delaySeconds', () => {
+    const rule = siteRule({
+      mode: 'HARD_BLOCK',
+      delaySeconds: 15,
+      schedule: scheduleOverride({
+        startMinute: 22 * 60,
+        endMinute: 23 * 60,
+        mode: 'BREATHING',
+        delaySeconds: 45,
+      }),
+    });
+    const outsideWindow = at(2026, 1, 7, 10, 0); // 10:00, window is 22:00-23:00
+    const active = resolveRule(rule, outsideWindow);
+    expect(active.mode).toBe('HARD_BLOCK');
+    expect(active.delaySeconds).toBe(15);
+  });
+
+  it('inside the schedule window, the scheduled mode+delay REPLACE the default — even when WEAKER', () => {
+    // Deliberate "override replaces default" semantic: default is HARD_BLOCK, the
+    // schedule downgrades to BREATHING inside the window, and BREATHING must win.
+    const rule = siteRule({
+      mode: 'HARD_BLOCK',
+      delaySeconds: 15,
+      schedule: scheduleOverride({
+        startMinute: 22 * 60,
+        endMinute: 23 * 60,
+        mode: 'BREATHING',
+        delaySeconds: 45,
+      }),
+    });
+    const insideWindow = at(2026, 1, 7, 22, 30);
+    const active = resolveRule(rule, insideWindow);
+    expect(active.mode).toBe('BREATHING');
+    expect(active.delaySeconds).toBe(45);
+  });
+
+  it('schedule.enabled === false means the schedule is ignored even when `now` is inside the window', () => {
+    const rule = siteRule({
+      mode: 'HARD_BLOCK',
+      delaySeconds: 15,
+      schedule: scheduleOverride({
+        enabled: false,
+        startMinute: 22 * 60,
+        endMinute: 23 * 60,
+        mode: 'BREATHING',
+        delaySeconds: 45,
+      }),
+    });
+    const insideWindow = at(2026, 1, 7, 22, 30);
+    const active = resolveRule(rule, insideWindow);
+    expect(active.mode).toBe('HARD_BLOCK');
+    expect(active.delaySeconds).toBe(15);
+  });
+
+  it('the daily limit applies in BOTH cases — inside and outside the window', () => {
+    const rule = siteRule({
+      dailyLimitMinutes: 30,
+      schedule: scheduleOverride({ startMinute: 22 * 60, endMinute: 23 * 60 }),
+    });
+    const outside = resolveRule(rule, at(2026, 1, 7, 10, 0));
+    const inside = resolveRule(rule, at(2026, 1, 7, 22, 30));
+    expect(outside.dailyLimitMinutes).toBe(30);
+    expect(inside.dailyLimitMinutes).toBe(30);
+  });
+
+  it('the resolved ActiveRule carries no schedule of its own', () => {
+    const rule = siteRule({
+      schedule: scheduleOverride({ days: [1, 2], startMinute: 0, endMinute: 60 }),
+    });
+    const active = resolveRule(rule, at(2026, 1, 7, 10, 0));
+    expect(active.scheduleDays).toBeNull();
+    expect(active.scheduleStartMinute).toBeNull();
+    expect(active.scheduleEndMinute).toBeNull();
+  });
+
+  it('resolves correctly at 02:00 inside an overnight scheduled window', () => {
+    const rule = siteRule({
+      mode: 'HARD_BLOCK',
+      delaySeconds: 15,
+      schedule: scheduleOverride({
+        startMinute: 23 * 60,
+        endMinute: 6 * 60,
+        mode: 'DELAY',
+        delaySeconds: 60,
+      }),
+    });
+    const at2am = at(2026, 1, 7, 2, 0);
+    const active = resolveRule(rule, at2am);
+    expect(active.mode).toBe('DELAY');
+    expect(active.delaySeconds).toBe(60);
+  });
+
+  it('a null schedule always resolves to the default, regardless of `now`', () => {
+    const rule = siteRule({ mode: 'DELAY', delaySeconds: 25, schedule: null });
+    const active = resolveRule(rule, at(2026, 1, 7, 22, 30));
+    expect(active.mode).toBe('DELAY');
+    expect(active.delaySeconds).toBe(25);
+  });
+});
+
+describe('resolveActiveRules', () => {
+  it('resolves every enabled rule matching the domain, in order', () => {
+    const rules = [
+      siteRule({ id: 'a', domain: 'youtube.com', mode: 'HARD_BLOCK' }),
+      siteRule({ id: 'b', domain: 'youtube.com', enabled: false }),
+      siteRule({ id: 'c', domain: 'instagram.com' }),
+    ];
+    const result = resolveActiveRules(rules, 'youtube.com', at(2026, 1, 7, 10, 0));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.ruleName).toBe('youtube.com');
+    expect(result[0]?.mode).toBe('HARD_BLOCK');
+  });
+});

--- a/extension/tests/core/scheduleEvaluator.test.ts
+++ b/extension/tests/core/scheduleEvaluator.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isoDayOfWeek,
+  isScheduleActiveAt,
+  localDayKey,
+  minutesSinceMidnight,
+  msUntilNextLocalMidnight,
+  type ScheduleWindow,
+} from '../../src/core/scheduleEvaluator';
+
+/**
+ * Port of app/src/test/java/.../ScheduleEvaluatorTest.kt, plus the overnight-boundary,
+ * start===end, and DST-safety cases the extension spec calls out explicitly.
+ *
+ * All dates are built with the local `new Date(y, m, d, h, mi)` constructor (never a
+ * hardcoded UTC string) and no test asserts a fixed absolute epoch — so the suite passes
+ * in any machine timezone.
+ *
+ * Reference week used throughout (verified 2026 calendar):
+ *   2026-01-04 Sun, 01-05 Mon, 01-06 Tue, 01-07 Wed, 01-08 Thu, 01-09 Fri, 01-10 Sat, 01-11 Sun.
+ */
+
+/** 1-based month, matching how humans read dates ("January" = 1), unlike raw `Date`. */
+function at(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second = 0,
+  ms = 0,
+): Date {
+  return new Date(year, month - 1, day, hour, minute, second, ms);
+}
+
+function window(overrides: Partial<ScheduleWindow> = {}): ScheduleWindow {
+  return { days: null, startMinute: null, endMinute: null, ...overrides };
+}
+
+describe('isScheduleActiveAt — no schedule fields set = always active', () => {
+  it('is active on a weekday', () => {
+    expect(isScheduleActiveAt(window(), at(2026, 1, 5, 9, 0))).toBe(true); // Mon
+  });
+
+  it('is active on a weekend too', () => {
+    expect(isScheduleActiveAt(window(), at(2026, 1, 10, 23, 59))).toBe(true); // Sat
+  });
+});
+
+describe('isScheduleActiveAt — day-of-week only', () => {
+  const weekdays = window({ days: [1, 2, 3, 4, 5] }); // Mon-Fri
+
+  it('is active on a matching weekday', () => {
+    expect(isScheduleActiveAt(weekdays, at(2026, 1, 5, 10, 0))).toBe(true); // Mon
+  });
+
+  it('is inactive on Saturday', () => {
+    expect(isScheduleActiveAt(weekdays, at(2026, 1, 10, 10, 0))).toBe(false);
+  });
+
+  it('is inactive on Sunday', () => {
+    expect(isScheduleActiveAt(weekdays, at(2026, 1, 11, 14, 0))).toBe(false);
+  });
+
+  it('only-days-set is active all day (midnight) on a matching day', () => {
+    const weekend = window({ days: [6, 7] });
+    expect(isScheduleActiveAt(weekend, at(2026, 1, 10, 0, 0))).toBe(true); // Sat 00:00
+  });
+
+  it('only-days-set is inactive on a non-matching day regardless of time', () => {
+    const weekend = window({ days: [6, 7] });
+    expect(isScheduleActiveAt(weekend, at(2026, 1, 5, 12, 0))).toBe(false); // Mon
+  });
+});
+
+describe('isScheduleActiveAt — normal time range (end EXCLUSIVE)', () => {
+  const nineToFive = window({ startMinute: 540, endMinute: 1020 }); // 09:00-17:00
+
+  it('is active within the range', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 7, 10, 0))).toBe(true); // Wed
+  });
+
+  it('is inactive before the range', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 7, 8, 0))).toBe(false);
+  });
+
+  it('is active at the exact start time', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 7, 9, 0))).toBe(true);
+  });
+
+  it('is inactive at the exact end time (end is exclusive)', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 7, 17, 0))).toBe(false);
+  });
+
+  it('is inactive after the range', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 7, 18, 0))).toBe(false);
+  });
+
+  it('times-only (no days) applies on a weekend day too — every day in the window', () => {
+    expect(isScheduleActiveAt(nineToFive, at(2026, 1, 10, 10, 0))).toBe(true); // Sat
+  });
+});
+
+describe('isScheduleActiveAt — overnight span (end < start)', () => {
+  const overnight = window({ startMinute: 1380, endMinute: 360 }); // 23:00-06:00
+
+  it('is active at 23:30', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 23, 30))).toBe(true); // Fri
+  });
+
+  it('is active at 02:00', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 2, 0))).toBe(true);
+  });
+
+  it('is inactive at 12:00 (noon)', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 12, 0))).toBe(false);
+  });
+
+  it('is inactive at 07:00', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 7, 0))).toBe(false);
+  });
+
+  it('is active exactly at the 23:00 start boundary', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 23, 0))).toBe(true);
+  });
+
+  it('is inactive exactly at the 06:00 end boundary (exclusive, same as the normal-range rule)', () => {
+    expect(isScheduleActiveAt(overnight, at(2026, 1, 9, 6, 0))).toBe(false);
+  });
+});
+
+describe('isScheduleActiveAt — start === end is a window that is NEVER active (deliberate Android parity)', () => {
+  const zeroWidth = window({ startMinute: 600, endMinute: 600 }); // 10:00-10:00
+
+  it('is inactive at the boundary minute itself', () => {
+    expect(isScheduleActiveAt(zeroWidth, at(2026, 1, 7, 10, 0))).toBe(false);
+  });
+
+  it('is inactive at any other time of day', () => {
+    expect(isScheduleActiveAt(zeroWidth, at(2026, 1, 7, 0, 0))).toBe(false);
+    expect(isScheduleActiveAt(zeroWidth, at(2026, 1, 7, 23, 59))).toBe(false);
+  });
+});
+
+describe('isScheduleActiveAt — combined day + time', () => {
+  const weekdayNineToFive = window({ days: [1, 2, 3, 4, 5], startMinute: 540, endMinute: 1020 });
+
+  it('is active on a weekday within the range', () => {
+    expect(isScheduleActiveAt(weekdayNineToFive, at(2026, 1, 7, 10, 0))).toBe(true); // Wed
+  });
+
+  it('is inactive on the weekend even within the time range', () => {
+    expect(isScheduleActiveAt(weekdayNineToFive, at(2026, 1, 10, 10, 0))).toBe(false); // Sat
+  });
+
+  it('is inactive on a weekday outside the time range', () => {
+    expect(isScheduleActiveAt(weekdayNineToFive, at(2026, 1, 5, 8, 0))).toBe(false); // Mon 8am
+  });
+});
+
+describe('isoDayOfWeek', () => {
+  it('maps Sunday to ISO 7', () => {
+    expect(isoDayOfWeek(at(2026, 1, 4, 12, 0))).toBe(7); // 2026-01-04 is a Sunday
+  });
+
+  it('maps Monday to ISO 1', () => {
+    expect(isoDayOfWeek(at(2026, 1, 5, 12, 0))).toBe(1); // 2026-01-05 is a Monday
+  });
+});
+
+describe('minutesSinceMidnight', () => {
+  it('is 0 at local midnight', () => {
+    expect(minutesSinceMidnight(at(2026, 1, 7, 0, 0))).toBe(0);
+  });
+
+  it('counts hours*60 + minutes', () => {
+    expect(minutesSinceMidnight(at(2026, 1, 7, 14, 37))).toBe(14 * 60 + 37);
+  });
+});
+
+describe('msUntilNextLocalMidnight', () => {
+  it('from 23:59:59.000 local it is exactly 1000ms', () => {
+    const now = at(2026, 6, 15, 23, 59, 59, 0);
+    expect(msUntilNextLocalMidnight(now)).toBe(1000);
+  });
+
+  // Sample times spanning ordinary days, month-end/non-leap-Feb rollover, and the two
+  // windows where DST transitions typically fall (late March / late October) in many
+  // regions (EU: last Sunday of March & October; US: second Sunday of March / first of
+  // November; AU: first Sunday of October). The assertions below are self-consistency
+  // checks (re-derive from now+result and confirm it lands exactly on local midnight),
+  // so they hold regardless of whether the machine running the suite actually observes
+  // a DST shift on that date.
+  const sampleTimes: Array<[number, number, number, number, number, number, number]> = [
+    [2026, 1, 1, 0, 0, 0, 0],
+    [2026, 2, 28, 23, 30, 0, 0], // month-end, non-leap Feb (2026 is not a leap year)
+    [2026, 3, 28, 12, 0, 0, 0], // near typical DST transition (late March)
+    [2026, 3, 29, 1, 30, 0, 0],
+    [2026, 3, 31, 23, 59, 59, 999],
+    [2026, 10, 24, 12, 0, 0, 0], // near typical DST transition (late October)
+    [2026, 10, 25, 2, 30, 0, 0],
+    [2026, 10, 31, 23, 0, 0, 0],
+    [2026, 12, 31, 23, 59, 0, 0], // year rollover
+  ];
+
+  it.each(sampleTimes)(
+    'is > 0, <= 25h, and lands exactly on local midnight (from %d-%d-%d %d:%d:%d.%d)',
+    (y, m, d, h, mi, s, ms) => {
+      const now = at(y, m, d, h, mi, s, ms);
+      const result = msUntilNextLocalMidnight(now);
+
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThanOrEqual(25 * 60 * 60 * 1000);
+
+      const landed = new Date(now.getTime() + result);
+      expect(landed.getHours()).toBe(0);
+      expect(landed.getMinutes()).toBe(0);
+      expect(landed.getSeconds()).toBe(0);
+      expect(landed.getMilliseconds()).toBe(0);
+    },
+  );
+});
+
+describe('localDayKey', () => {
+  it('zero-pads single-digit month and day', () => {
+    expect(localDayKey(at(2026, 1, 5, 10, 0))).toBe('2026-01-05');
+  });
+
+  it('does not pad double-digit month/day', () => {
+    expect(localDayKey(at(2026, 12, 25, 0, 0))).toBe('2026-12-25');
+  });
+});

--- a/extension/tests/core/settingsSchema.test.ts
+++ b/extension/tests/core/settingsSchema.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DAILY_LIMIT_MAX_MINUTES,
+  DAILY_LIMIT_MIN_MINUTES,
+  DEFAULT_SETTINGS,
+  DELAY_MAX_SECONDS,
+  DELAY_MIN_SECONDS,
+  migrateSettings,
+  SCHEMA_VERSION,
+  TEMP_ALLOW_MAX_MINUTES,
+  TEMP_ALLOW_MIN_MINUTES,
+} from '../../src/core/settingsSchema';
+
+/**
+ * migrateSettings must be TOTAL (never throws) and LENIENT (corrupt input falls back to
+ * safe defaults) — it sits between chrome.storage and the block path, so a bad read must
+ * never break enforcement. It also always fails toward the SAFE/enforcing direction
+ * (globalEnabled true, strictMode/AIGC-style toggles false unless explicit).
+ */
+
+describe('migrateSettings — totality on garbage top-level input', () => {
+  const garbageInputs: Array<[string, unknown]> = [
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'not settings'],
+    ['a number', 42],
+    ['an empty array', []],
+    ['a non-empty array', [1, 2, 3]],
+  ];
+
+  it.each(garbageInputs)('%s never throws and falls back to valid DEFAULT_SETTINGS', (_label, input) => {
+    expect(() => migrateSettings(input)).not.toThrow();
+    expect(migrateSettings(input)).toEqual(DEFAULT_SETTINGS);
+  });
+});
+
+describe('migrateSettings — rule.mode fallback', () => {
+  it('an unknown/garbage mode falls back to HARD_BLOCK', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com', mode: 'NUKE_FROM_ORBIT' }] });
+    expect(result.rules[0]?.mode).toBe('HARD_BLOCK');
+  });
+});
+
+describe('migrateSettings — clamping to documented ranges', () => {
+  it('clamps delaySeconds below the minimum up to 1', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com', delaySeconds: -50 }] });
+    expect(result.rules[0]?.delaySeconds).toBe(DELAY_MIN_SECONDS);
+  });
+
+  it('clamps delaySeconds above the maximum down to 300', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com', delaySeconds: 99_999 }] });
+    expect(result.rules[0]?.delaySeconds).toBe(DELAY_MAX_SECONDS);
+  });
+
+  it('clamps dailyLimitMinutes below the minimum up to 1', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com', dailyLimitMinutes: -5 }] });
+    expect(result.rules[0]?.dailyLimitMinutes).toBe(DAILY_LIMIT_MIN_MINUTES);
+  });
+
+  it('clamps dailyLimitMinutes above the maximum down to 480', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com', dailyLimitMinutes: 99_999 }] });
+    expect(result.rules[0]?.dailyLimitMinutes).toBe(DAILY_LIMIT_MAX_MINUTES);
+  });
+
+  it('leaves dailyLimitMinutes as null when not a number', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com' }] });
+    expect(result.rules[0]?.dailyLimitMinutes).toBeNull();
+  });
+
+  it('clamps tempAllowMinutes to 1-60', () => {
+    expect(migrateSettings({ tempAllowMinutes: 0 }).tempAllowMinutes).toBe(TEMP_ALLOW_MIN_MINUTES);
+    expect(migrateSettings({ tempAllowMinutes: -5 }).tempAllowMinutes).toBe(TEMP_ALLOW_MIN_MINUTES);
+    expect(migrateSettings({ tempAllowMinutes: 9_999 }).tempAllowMinutes).toBe(TEMP_ALLOW_MAX_MINUTES);
+  });
+});
+
+describe('migrateSettings — rule dropping', () => {
+  it('drops rules with a missing or blank domain instead of keeping them broken', () => {
+    const result = migrateSettings({
+      rules: [
+        { domain: 'good.com' },
+        { domain: '' },
+        { domain: '   ' },
+        { mode: 'HARD_BLOCK' }, // no domain field at all
+        null,
+        'not an object',
+        42,
+      ],
+    });
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0]?.domain).toBe('good.com');
+  });
+
+  it('lowercases and trims domains', () => {
+    const result = migrateSettings({ rules: [{ domain: '  YouTube.COM  ' }] });
+    expect(result.rules[0]?.domain).toBe('youtube.com');
+  });
+});
+
+describe('migrateSettings — globalEnabled fails toward enforcing', () => {
+  it('defaults to true when absent', () => {
+    expect(migrateSettings({}).globalEnabled).toBe(true);
+  });
+
+  it('becomes false only on an explicit boolean false', () => {
+    expect(migrateSettings({ globalEnabled: false }).globalEnabled).toBe(false);
+  });
+
+  it('stays true for any other (non-false) value', () => {
+    expect(migrateSettings({ globalEnabled: 'no' }).globalEnabled).toBe(true);
+    expect(migrateSettings({ globalEnabled: 0 }).globalEnabled).toBe(true);
+    expect(migrateSettings({ globalEnabled: null }).globalEnabled).toBe(true);
+  });
+});
+
+describe('migrateSettings — strictMode.enabled defaults false', () => {
+  it('defaults to false when absent', () => {
+    expect(migrateSettings({}).strictMode.enabled).toBe(false);
+  });
+
+  it('is true only on an explicit boolean true', () => {
+    expect(migrateSettings({ strictMode: { enabled: true } }).strictMode.enabled).toBe(true);
+    expect(migrateSettings({ strictMode: { enabled: 'true' } }).strictMode.enabled).toBe(false);
+    expect(migrateSettings({ strictMode: { enabled: 1 } }).strictMode.enabled).toBe(false);
+  });
+});
+
+describe('migrateSettings — emergencyPass.enabled defaults true', () => {
+  it('defaults to true when absent', () => {
+    expect(migrateSettings({}).emergencyPass.enabled).toBe(true);
+  });
+
+  it('becomes false only on an explicit boolean false', () => {
+    expect(migrateSettings({ emergencyPass: { enabled: false } }).emergencyPass.enabled).toBe(false);
+    expect(migrateSettings({ emergencyPass: { enabled: 'nope' } }).emergencyPass.enabled).toBe(true);
+  });
+});
+
+describe('migrateSettings — schedule sub-object coercion', () => {
+  it('filters invalid day numbers (0, 8, 1.5, "mon"), keeping valid ISO days', () => {
+    const result = migrateSettings({
+      rules: [{ domain: 'x.com', schedule: { days: [0, 8, 1.5, 'mon', 3] } }],
+    });
+    expect(result.rules[0]?.schedule?.days).toEqual([3]);
+  });
+
+  it('an empty resulting day list becomes null, not []', () => {
+    const result = migrateSettings({
+      rules: [{ domain: 'x.com', schedule: { days: [0, 8, 1.5, 'mon'] } }],
+    });
+    expect(result.rules[0]?.schedule?.days).toBeNull();
+  });
+
+  it('clamps startMinute and endMinute to 0-1439', () => {
+    const result = migrateSettings({
+      rules: [{ domain: 'x.com', schedule: { startMinute: -100, endMinute: 5000 } }],
+    });
+    expect(result.rules[0]?.schedule?.startMinute).toBe(0);
+    expect(result.rules[0]?.schedule?.endMinute).toBe(1439);
+  });
+
+  it('a missing schedule stays null', () => {
+    const result = migrateSettings({ rules: [{ domain: 'x.com' }] });
+    expect(result.rules[0]?.schedule).toBeNull();
+  });
+});
+
+describe('migrateSettings — schemaVersion', () => {
+  it('is always stamped to the current SCHEMA_VERSION regardless of input', () => {
+    expect(migrateSettings({ schemaVersion: 999 }).schemaVersion).toBe(SCHEMA_VERSION);
+    expect(migrateSettings({ schemaVersion: 'garbage' }).schemaVersion).toBe(SCHEMA_VERSION);
+    expect(migrateSettings({}).schemaVersion).toBe(SCHEMA_VERSION);
+  });
+});
+
+describe('migrateSettings — idempotence', () => {
+  it('migrating a garbage input twice is stable', () => {
+    const garbage = {
+      rules: 'not an array',
+      globalEnabled: 'nope',
+      strictMode: 42,
+      schedule: { days: [0, 99, 'mon'] },
+    };
+    const once = migrateSettings(garbage);
+    const twice = migrateSettings(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('migrating an already-valid settings object twice is stable', () => {
+    const valid = migrateSettings({
+      rules: [
+        {
+          domain: 'youtube.com',
+          mode: 'DELAY',
+          delaySeconds: 20,
+          dailyLimitMinutes: 45,
+          enabled: true,
+          showTimeRemaining: true,
+          schedule: {
+            enabled: true,
+            days: [1, 2, 3],
+            startMinute: 60,
+            endMinute: 120,
+            mode: 'BREATHING',
+            delaySeconds: 30,
+          },
+        },
+      ],
+      globalEnabled: false,
+      onboardingComplete: true,
+      strictMode: { enabled: true, challengeLength: 12 },
+      emergencyPass: { enabled: false },
+      youtube: { shortsMode: 'DELAY', hideShortsShelf: true, shortsDelaySeconds: 10 },
+      tempAllowMinutes: 5,
+    });
+    const twice = migrateSettings(valid);
+    expect(twice).toEqual(valid);
+  });
+});

--- a/extension/tests/core/stats.test.ts
+++ b/extension/tests/core/stats.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addActiveSeconds,
+  allTimeTotals,
+  calculateStreak,
+  emptyDayUsage,
+  hourlyHeatmap,
+  lastNDayKeys,
+  recordBlocked,
+  recordWalkedAway,
+  topSites,
+  totalActiveSeconds,
+  weeklySeries,
+} from '../../src/core/stats';
+import { localDayKey } from '../../src/core/scheduleEvaluator';
+import type { DayUsage, UsageByDay } from '../../src/core/protocol';
+
+function usageWith(overrides: Partial<DayUsage> = {}): DayUsage {
+  return {
+    activeSec: overrides.activeSec ?? 0,
+    blocked: overrides.blocked ?? 0,
+    walkedAway: overrides.walkedAway ?? 0,
+    hourly: overrides.hourly ?? new Array<number>(24).fill(0),
+  };
+}
+
+function buildDay(entries: Record<string, Partial<DayUsage>>): Record<string, DayUsage> {
+  const result: Record<string, DayUsage> = {};
+  for (const [domain, partial] of Object.entries(entries)) {
+    result[domain] = usageWith(partial);
+  }
+  return result;
+}
+
+/** i days before `now`, as a local calendar day key. Mirrors the streak's own walk-back. */
+function keyForDaysAgo(now: Date, daysAgo: number): string {
+  return localDayKey(new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysAgo));
+}
+
+/** The calendar day immediately after `key`, computed independently of lastNDayKeys. */
+function nextDayKey(key: string): string {
+  const [y, m, d] = key.split('-').map(Number);
+  return localDayKey(new Date(y as number, (m as number) - 1, (d as number) + 1));
+}
+
+describe('emptyDayUsage', () => {
+  it('returns the all-zero shape with a 24-length hourly array', () => {
+    const usage = emptyDayUsage();
+    expect(usage).toEqual({ activeSec: 0, blocked: 0, walkedAway: 0, hourly: new Array(24).fill(0) });
+    expect(usage.hourly).toHaveLength(24);
+  });
+
+  it('returns independent hourly arrays across calls', () => {
+    const a = emptyDayUsage();
+    const b = emptyDayUsage();
+    expect(a.hourly).not.toBe(b.hourly);
+  });
+});
+
+describe('addActiveSeconds', () => {
+  it('adds to activeSec and the given hour bucket without mutating the input', () => {
+    const original = emptyDayUsage();
+    const snapshot = JSON.parse(JSON.stringify(original));
+    const next = addActiveSeconds(original, 30, 9);
+
+    expect(next).not.toBe(original);
+    expect(next.hourly).not.toBe(original.hourly);
+    expect(original).toEqual(snapshot); // input untouched
+
+    expect(next.activeSec).toBe(30);
+    expect(next.hourly[9]).toBe(30);
+    expect(next.hourly.filter((_v, i) => i !== 9).every((v) => v === 0)).toBe(true);
+  });
+
+  it('accumulates across repeated calls', () => {
+    let usage = emptyDayUsage();
+    usage = addActiveSeconds(usage, 10, 5);
+    usage = addActiveSeconds(usage, 20, 5);
+    usage = addActiveSeconds(usage, 5, 6);
+    expect(usage.activeSec).toBe(35);
+    expect(usage.hourly[5]).toBe(30);
+    expect(usage.hourly[6]).toBe(5);
+  });
+
+  it('ignores negative seconds (no-op, but still a fresh object)', () => {
+    const base = addActiveSeconds(emptyDayUsage(), 100, 8);
+    const next = addActiveSeconds(base, -5, 8);
+    expect(next).toEqual(base);
+    expect(next).not.toBe(base);
+  });
+
+  it('ignores non-finite seconds', () => {
+    const original = emptyDayUsage();
+    expect(addActiveSeconds(original, Number.NaN, 5)).toEqual(original);
+    expect(addActiveSeconds(original, Number.POSITIVE_INFINITY, 5)).toEqual(original);
+  });
+
+  it('rejects an out-of-range or non-integer hour', () => {
+    const original = emptyDayUsage();
+    expect(addActiveSeconds(original, 10, -1)).toEqual(original);
+    expect(addActiveSeconds(original, 10, 24)).toEqual(original);
+    expect(addActiveSeconds(original, 10, 3.5)).toEqual(original);
+  });
+
+  it('accepts the boundary hours 0 and 23', () => {
+    expect(addActiveSeconds(emptyDayUsage(), 10, 0).hourly[0]).toBe(10);
+    expect(addActiveSeconds(emptyDayUsage(), 10, 23).hourly[23]).toBe(10);
+  });
+});
+
+describe('recordBlocked / recordWalkedAway', () => {
+  it('recordBlocked increments blocked without mutating the input', () => {
+    const original = emptyDayUsage();
+    const snapshot = JSON.parse(JSON.stringify(original));
+    const next = recordBlocked(original);
+    expect(next).not.toBe(original);
+    expect(original).toEqual(snapshot);
+    expect(next.blocked).toBe(1);
+    expect(next.walkedAway).toBe(0);
+  });
+
+  it('recordWalkedAway increments walkedAway without mutating the input', () => {
+    const original = emptyDayUsage();
+    const snapshot = JSON.parse(JSON.stringify(original));
+    const next = recordWalkedAway(original);
+    expect(next).not.toBe(original);
+    expect(original).toEqual(snapshot);
+    expect(next.walkedAway).toBe(1);
+    expect(next.blocked).toBe(0);
+  });
+
+  it('chains correctly across multiple calls', () => {
+    let usage = emptyDayUsage();
+    usage = recordBlocked(usage);
+    usage = recordBlocked(usage);
+    usage = recordWalkedAway(usage);
+    expect(usage.blocked).toBe(2);
+    expect(usage.walkedAway).toBe(1);
+  });
+});
+
+describe('totalActiveSeconds', () => {
+  it('sums activeSec across every domain', () => {
+    const day = buildDay({ a: { activeSec: 10 }, b: { activeSec: 20 } });
+    expect(totalActiveSeconds(day)).toBe(30);
+  });
+
+  it('is 0 for an empty day', () => {
+    expect(totalActiveSeconds({})).toBe(0);
+  });
+});
+
+describe('topSites', () => {
+  it('ranks domains by activeSec descending', () => {
+    const day = buildDay({ a: { activeSec: 10 }, b: { activeSec: 100 }, c: { activeSec: 50 } });
+    expect(topSites(day).map((s) => s.domain)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('breaks ties alphabetically by domain', () => {
+    const day = buildDay({ zeta: { activeSec: 50 }, alpha: { activeSec: 50 }, mu: { activeSec: 50 } });
+    expect(topSites(day).map((s) => s.domain)).toEqual(['alpha', 'mu', 'zeta']);
+  });
+
+  it('mixes descending activeSec with alphabetical tie-break correctly', () => {
+    const day = buildDay({
+      b: { activeSec: 50 },
+      a: { activeSec: 50 },
+      z: { activeSec: 90 },
+      m: { activeSec: 10 },
+    });
+    expect(topSites(day).map((s) => s.domain)).toEqual(['z', 'a', 'b', 'm']);
+  });
+
+  it('computes each domain\'s proportional fraction of the day total', () => {
+    const day = buildDay({ a: { activeSec: 25 }, b: { activeSec: 75 } });
+    const ranked = topSites(day);
+    const a = ranked.find((s) => s.domain === 'a');
+    const b = ranked.find((s) => s.domain === 'b');
+    expect(a?.fraction).toBeCloseTo(0.25);
+    expect(b?.fraction).toBeCloseTo(0.75);
+  });
+
+  it('is safe when the day total is zero -- fractions read 0, never NaN/Infinity', () => {
+    const day = buildDay({ a: { activeSec: 0 }, b: { activeSec: 0 } });
+    const ranked = topSites(day);
+    expect(ranked.every((s) => s.fraction === 0)).toBe(true);
+    expect(ranked.some((s) => Number.isNaN(s.fraction))).toBe(false);
+  });
+
+  it('respects the limit parameter', () => {
+    const day = buildDay({ a: { activeSec: 30 }, b: { activeSec: 20 }, c: { activeSec: 10 } });
+    expect(topSites(day, 2).map((s) => s.domain)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for an empty day', () => {
+    expect(topSites({})).toEqual([]);
+  });
+});
+
+describe('lastNDayKeys', () => {
+  it('returns n keys, oldest first, ending with today', () => {
+    const now = new Date(2026, 5, 15, 10, 30); // arbitrary local time, no DST edge
+    const keys = lastNDayKeys(now, 5);
+    expect(keys).toHaveLength(5);
+    expect(keys[4]).toBe(localDayKey(now));
+    expect(new Set(keys).size).toBe(5);
+  });
+
+  it('is strictly consecutive with no gaps or repeats', () => {
+    const now = new Date(2026, 5, 15, 10, 30);
+    const keys = lastNDayKeys(now, 10);
+    for (let i = 0; i < keys.length - 1; i++) {
+      expect(nextDayKey(keys[i] as string)).toBe(keys[i + 1]);
+    }
+  });
+
+  it('handles n=1 (just today)', () => {
+    const now = new Date(2026, 5, 15, 10, 30);
+    expect(lastNDayKeys(now, 1)).toEqual([localDayKey(now)]);
+  });
+
+  it('is DST-safe across a late-March window (EU-style spring-forward date)', () => {
+    const now = new Date(2026, 2, 29, 12, 0); // March 29, local noon
+    const keys = lastNDayKeys(now, 7);
+    expect(keys).toHaveLength(7);
+    expect(new Set(keys).size).toBe(7); // 7 DISTINCT calendar days
+    expect(keys[6]).toBe(localDayKey(now));
+    for (let i = 0; i < keys.length - 1; i++) {
+      expect(nextDayKey(keys[i] as string)).toBe(keys[i + 1]);
+    }
+  });
+
+  it('is DST-safe across a late-October window (EU-style fall-back date)', () => {
+    const now = new Date(2026, 9, 30, 12, 0); // October 30, local noon
+    const keys = lastNDayKeys(now, 7);
+    expect(keys).toHaveLength(7);
+    expect(new Set(keys).size).toBe(7); // 7 DISTINCT calendar days
+    expect(keys[6]).toBe(localDayKey(now));
+    for (let i = 0; i < keys.length - 1; i++) {
+      expect(nextDayKey(keys[i] as string)).toBe(keys[i + 1]);
+    }
+  });
+});
+
+describe('weeklySeries', () => {
+  it('zero-fills days with no data', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const keys = lastNDayKeys(now, 3);
+    const usage: UsageByDay = {
+      [keys[2] as string]: buildDay({ a: { activeSec: 60, blocked: 1, walkedAway: 2 } }),
+    };
+    const series = weeklySeries(usage, keys);
+    expect(series).toHaveLength(3);
+    expect(series[0]).toEqual({ day: keys[0], activeSec: 0, blocked: 0, walkedAway: 0 });
+    expect(series[1]).toEqual({ day: keys[1], activeSec: 0, blocked: 0, walkedAway: 0 });
+    expect(series[2]).toEqual({ day: keys[2], activeSec: 60, blocked: 1, walkedAway: 2 });
+  });
+
+  it('sums across multiple domains for the same day', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const key = localDayKey(now);
+    const usage: UsageByDay = {
+      [key]: buildDay({
+        a: { activeSec: 10, blocked: 1, walkedAway: 0 },
+        b: { activeSec: 20, blocked: 0, walkedAway: 3 },
+      }),
+    };
+    const series = weeklySeries(usage, [key]);
+    expect(series[0]).toEqual({ day: key, activeSec: 30, blocked: 1, walkedAway: 3 });
+  });
+
+  it('preserves the order of the given day keys', () => {
+    const usage: UsageByDay = {};
+    const series = weeklySeries(usage, ['2026-01-03', '2026-01-01', '2026-01-02']);
+    expect(series.map((s) => s.day)).toEqual(['2026-01-03', '2026-01-01', '2026-01-02']);
+  });
+});
+
+describe('hourlyHeatmap', () => {
+  it('sums hourly buckets across domains for the given day', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const key = localDayKey(now);
+    const hourlyA = new Array<number>(24).fill(0);
+    hourlyA[3] = 100;
+    const hourlyB = new Array<number>(24).fill(0);
+    hourlyB[3] = 50;
+    hourlyB[10] = 20;
+    const usage: UsageByDay = {
+      [key]: buildDay({ a: { hourly: hourlyA }, b: { hourly: hourlyB } }),
+    };
+    const heatmap = hourlyHeatmap(usage, key);
+    expect(heatmap).toHaveLength(24);
+    expect(heatmap[3]).toBe(150);
+    expect(heatmap[10]).toBe(20);
+    expect(heatmap.filter((_v, i) => i !== 3 && i !== 10).every((v) => v === 0)).toBe(true);
+  });
+
+  it('returns all zeros for a day with no data', () => {
+    const heatmap = hourlyHeatmap({}, '2026-06-15');
+    expect(heatmap).toEqual(new Array(24).fill(0));
+  });
+});
+
+describe('allTimeTotals', () => {
+  it('sums blocked/walkedAway across every day and domain', () => {
+    const usage: UsageByDay = {
+      '2026-01-01': buildDay({ a: { blocked: 2, walkedAway: 1 }, b: { blocked: 1 } }),
+      '2026-01-02': buildDay({ a: { walkedAway: 3 } }),
+    };
+    expect(allTimeTotals(usage)).toEqual({ blocked: 3, walkedAway: 4 });
+  });
+
+  it('is all-zero for empty usage', () => {
+    expect(allTimeTotals({})).toEqual({ blocked: 0, walkedAway: 0 });
+  });
+});
+
+/**
+ * calculateStreak matrix. Mirrors the exact Kotlin walk in
+ * app/src/main/java/com/astraedus/nudge/ui/screens/stats/StatsCalculator.kt:
+ *
+ *   for (i in 0..6) {
+ *       ...
+ *       if (hadWalkedAway || hadBlocked) streak++
+ *       else if (i == 0 && dayEvents.isEmpty()) continue
+ *       else break
+ *   }
+ *
+ * i.e. only TODAY (i=0) gets a free pass when it has zero events of any kind; every other
+ * day that lacks a blocked/walked-away event breaks the walk, whether or not it has other
+ * activity recorded.
+ */
+describe('calculateStreak', () => {
+  it('is 0 with no data at all', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    expect(calculateStreak({}, now)).toBe(0);
+  });
+
+  it('is 1 when only today has a blocked event', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { blocked: 1 } }),
+    };
+    expect(calculateStreak(usage, now)).toBe(1);
+  });
+
+  it('is 1 when only today has a walked-away event (counts the same as blocked)', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { walkedAway: 1 } }),
+    };
+    expect(calculateStreak(usage, now)).toBe(1);
+  });
+
+  it('counts consecutive days with blocked/walked-away events', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { blocked: 1 } }),
+      [keyForDaysAgo(now, 1)]: buildDay({ a: { walkedAway: 2 } }),
+      [keyForDaysAgo(now, 2)]: buildDay({ a: { blocked: 3 } }),
+    };
+    expect(calculateStreak(usage, now)).toBe(3);
+  });
+
+  it('BREAKS on a gap day with no events at all, UNLESS that day is today', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { blocked: 1 } }),
+      // day 1 (yesterday) intentionally absent from the map entirely.
+      [keyForDaysAgo(now, 2)]: buildDay({ a: { blocked: 1 } }),
+    };
+    // Yesterday's total absence breaks the walk before day 2 is ever reached, even though
+    // day 2 itself has a blocked event -- matches the Kotlin `else -> break` for i != 0.
+    expect(calculateStreak(usage, now)).toBe(1);
+  });
+
+  it('skips (does not break) TODAY specifically when today has zero events of any kind', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      // today (i=0) absent entirely -> dayEvents.isEmpty() && i==0 -> `continue`, not break.
+      [keyForDaysAgo(now, 1)]: buildDay({ a: { blocked: 1 } }),
+    };
+    expect(calculateStreak(usage, now)).toBe(1);
+  });
+
+  it('breaks when a day exists in the map but has 0 blocked and 0 walkedAway, even with activeSec > 0', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { activeSec: 300, blocked: 0, walkedAway: 0 } }),
+    };
+    // Today has recorded activity (not "isEmpty()"), so it does NOT get the today-only free
+    // pass -- it must break like any other non-qualifying day.
+    expect(calculateStreak(usage, now)).toBe(0);
+  });
+
+  it('treats a present-but-all-zero day the same as an absent day (today still gets skipped)', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: {} }), // present in the map, but truly all-zero
+      [keyForDaysAgo(now, 1)]: buildDay({ a: { blocked: 1 } }),
+    };
+    expect(calculateStreak(usage, now)).toBe(1);
+  });
+
+  it('does not let a day further back re-extend the streak past an earlier break', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {
+      [keyForDaysAgo(now, 0)]: buildDay({ a: { blocked: 1 } }),
+      [keyForDaysAgo(now, 1)]: buildDay({ a: { blocked: 1 } }),
+      [keyForDaysAgo(now, 2)]: buildDay({ a: { activeSec: 60 } }), // browsed, not blocked -> breaks
+      [keyForDaysAgo(now, 3)]: buildDay({ a: { blocked: 1 } }), // would extend it, but is unreachable
+    };
+    expect(calculateStreak(usage, now)).toBe(2);
+  });
+
+  it('never looks back further than a 7-day window (i in 0..6)', () => {
+    const now = new Date(2026, 5, 15, 9, 0);
+    const usage: UsageByDay = {};
+    for (let i = 0; i <= 9; i++) {
+      usage[keyForDaysAgo(now, i)] = buildDay({ a: { blocked: 1 } });
+    }
+    expect(calculateStreak(usage, now)).toBe(7);
+  });
+});

--- a/extension/tests/core/strictMode.test.ts
+++ b/extension/tests/core/strictMode.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHARSET,
+  DEFAULT_LENGTH,
+  LENGTH_EASY,
+  LENGTH_HARD,
+  LENGTH_MEDIUM,
+  forDisplay,
+  generate,
+  isWeakening,
+  normalize,
+  rawLength,
+  verify,
+} from '../../src/core/strictMode';
+import {
+  DEFAULT_SETTINGS,
+  structuredCloneSettings,
+  type NudgeSettings,
+  type SiteRule,
+} from '../../src/core/settingsSchema';
+
+// Confusable glyphs the charset must never contain, and generate() must never produce.
+const CONFUSABLE = ['0', 'O', '1', 'l', 'I'];
+
+describe('strictMode: constants', () => {
+  it('length presets match the spec', () => {
+    expect(LENGTH_EASY).toBe(12);
+    expect(LENGTH_MEDIUM).toBe(24);
+    expect(LENGTH_HARD).toBe(48);
+    expect(DEFAULT_LENGTH).toBe(LENGTH_MEDIUM);
+  });
+
+  it('charset itself excludes confusable characters (tests the CLASS, not a sample)', () => {
+    for (const forbidden of CONFUSABLE) {
+      expect(CHARSET.includes(forbidden)).toBe(false);
+    }
+  });
+
+  it('charset has no duplicate characters', () => {
+    expect(new Set(CHARSET).size).toBe(CHARSET.length);
+  });
+});
+
+describe('strictMode: generate()', () => {
+  it('returns the requested raw length', () => {
+    expect(generate(12).length).toBe(12);
+    expect(generate(24).length).toBe(24);
+    expect(generate(48).length).toBe(48);
+  });
+
+  it('uses only the unambiguous charset, over a large sample', () => {
+    // Generate a large sample so any forbidden char would almost certainly appear if allowed.
+    let sample = '';
+    for (let i = 0; i < 50; i++) {
+      sample += generate(48);
+    }
+    for (const forbidden of CONFUSABLE) {
+      expect(sample.includes(forbidden)).toBe(false);
+    }
+    for (const ch of sample) {
+      expect(CHARSET.includes(ch)).toBe(true);
+    }
+  });
+
+  it('produces different strings across calls (real crypto randomness)', () => {
+    const a = generate(24);
+    const b = generate(24);
+    const c = generate(24);
+    // Collision of two 24-char strings from a 57-char alphabet is astronomically unlikely.
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+    expect(a).not.toBe(c);
+  });
+
+  it('coerces non-positive length to at least one char', () => {
+    expect(generate(0).length).toBe(1);
+    expect(generate(-5).length).toBe(1);
+  });
+
+  it('coerces a fractional length by truncating', () => {
+    expect(generate(5.9).length).toBe(5);
+  });
+
+  it('is injectable: a deterministic randomInts source produces a deterministic string', () => {
+    // Fixed sequence of indices into CHARSET — proves generate() defers entirely to the
+    // injected source rather than mixing in its own randomness.
+    const indices = [0, 1, 2, CHARSET.length - 1];
+    const fixed = (count: number, maxExclusive: number): number[] => {
+      expect(maxExclusive).toBe(CHARSET.length);
+      expect(count).toBe(indices.length);
+      return indices;
+    };
+    const result = generate(indices.length, fixed);
+    const expected = indices.map((i) => CHARSET.charAt(i)).join('');
+    expect(result).toBe(expected);
+  });
+
+  it('injected randomInts is called with the coerced length, not the raw input', () => {
+    let calledWith: [number, number] | null = null;
+    const spy = (count: number, maxExclusive: number): number[] => {
+      calledWith = [count, maxExclusive];
+      return new Array(count).fill(0);
+    };
+    generate(-5, spy);
+    expect(calledWith).toEqual([1, CHARSET.length]);
+  });
+});
+
+describe('strictMode: forDisplay()', () => {
+  it('groups into dash-separated chunks of five', () => {
+    expect(forDisplay('abcdefghijklmno')).toBe('abcde-fghij-klmno');
+  });
+
+  it('handles a partial final group', () => {
+    expect(forDisplay('abcdefg')).toBe('abcde-fg');
+  });
+
+  it('handles a string shorter than one group', () => {
+    expect(forDisplay('abc')).toBe('abc');
+  });
+
+  it('handles the empty string', () => {
+    expect(forDisplay('')).toBe('');
+  });
+});
+
+describe('strictMode: verify()', () => {
+  it('true on exact match', () => {
+    expect(verify('aB3kP', 'aB3kP')).toBe(true);
+  });
+
+  it('false on wrong character', () => {
+    expect(verify('aB3kQ', 'aB3kP')).toBe(false);
+  });
+
+  it('is case sensitive', () => {
+    expect(verify('ab3kp', 'aB3kP')).toBe(false);
+    expect(verify('AB3KP', 'aB3kP')).toBe(false);
+  });
+
+  it('false on truncated input', () => {
+    expect(verify('aB3k', 'aB3kP')).toBe(false);
+  });
+
+  it('ignores display dashes on either side', () => {
+    // Target shown grouped; user types raw.
+    expect(verify('abcdefghij', 'abcde-fghij')).toBe(true);
+    // User types with the dashes too.
+    expect(verify('abcde-fghij', 'abcde-fghij')).toBe(true);
+    // Both raw.
+    expect(verify('abcdefghij', 'abcdefghij')).toBe(true);
+  });
+
+  it('is dash-insensitive in BOTH directions against a grouped target', () => {
+    // The bug this guards: the target is displayed dash-grouped and the copy no longer
+    // promises "exactly", so typing WITH or WITHOUT dashes must both pass.
+    const raw = 'k7Qm2vX9pLtR';
+    const grouped = forDisplay(raw); // "k7Qm2-vX9pL-tR"
+    // Typed without dashes.
+    expect(verify(raw, grouped)).toBe(true);
+    // Typed with the same dashes shown.
+    expect(verify(grouped, grouped)).toBe(true);
+    // Typed with dashes in different (user-chosen) positions — still passes.
+    expect(verify('k7-Qm2vX9-pLtR', grouped)).toBe(true);
+    // Wrong content with the right dashes must still fail (dashes don't mask a typo).
+    expect(verify('k7Qm2-vX9pL-tX', grouped)).toBe(false);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(verify('  aB3kP  ', 'aB3kP')).toBe(true);
+    expect(verify('\taB3kP\n', 'aB3kP')).toBe(true);
+  });
+
+  it('false when internal whitespace breaks the match', () => {
+    // Internal space is NOT stripped — an accidental mid-string space must fail.
+    expect(verify('aB 3kP', 'aB3kP')).toBe(false);
+  });
+
+  it('false on empty target', () => {
+    expect(verify('', '')).toBe(false);
+    expect(verify('anything', '')).toBe(false);
+  });
+});
+
+describe('strictMode: normalize() / rawLength() — the unit the live counter and verify share', () => {
+  it('normalize strips dashes and surrounding whitespace but keeps case and inner content', () => {
+    expect(normalize('  k7Qm2-vX9pL  ')).toBe('k7Qm2vX9pL');
+    expect(normalize('k7Qm2vX9pL')).toBe('k7Qm2vX9pL');
+  });
+
+  it('normalize does NOT strip internal whitespace', () => {
+    expect(normalize('aB 3kP')).toBe('aB 3kP');
+  });
+
+  it('rawLength counts the same characters with or without dashes', () => {
+    const raw = 'k7Qm2vX9pLtR'; // 12 raw chars
+    expect(rawLength(raw)).toBe(12);
+    expect(rawLength(forDisplay(raw))).toBe(12);
+    expect(rawLength(`  ${raw}  `)).toBe(12);
+    // Partial input progresses in raw units regardless of dashes the user typed.
+    expect(rawLength('k7Qm2-vX')).toBe(7);
+  });
+
+  it('normalize + rawLength agree with verify: equal normalized forms always verify true', () => {
+    const cases = ['abcdefghij', 'abcde-fghij', '  abcde-fghij  ', 'a-b-c-d-e-f-g-h-i-j'];
+    const target = 'abcdefghij';
+    for (const candidate of cases) {
+      expect(normalize(candidate)).toBe(normalize(target));
+      expect(rawLength(candidate)).toBe(rawLength(target));
+      expect(verify(candidate, target)).toBe(true);
+    }
+  });
+
+  it('normalize + rawLength agree with verify: differing normalized forms always verify false', () => {
+    const target = 'abcdefghij';
+    const candidate = 'abcdefghix'; // last char differs
+    expect(normalize(candidate)).not.toBe(normalize(target));
+    expect(verify(candidate, target)).toBe(false);
+  });
+});
+
+// ── isWeakening ──
+
+function baseSettings(overrides: Partial<NudgeSettings> = {}): NudgeSettings {
+  return { ...structuredCloneSettings(DEFAULT_SETTINGS), ...overrides };
+}
+
+function makeRule(overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: 'r1',
+    domain: 'example.com',
+    mode: 'DELAY',
+    delaySeconds: 15,
+    dailyLimitMinutes: null,
+    enabled: true,
+    createdAt: 0,
+    showTimeRemaining: false,
+    schedule: null,
+    ...overrides,
+  };
+}
+
+describe('strictMode: isWeakening() — globalEnabled axis', () => {
+  it('true -> false is weakening', () => {
+    const oldS = baseSettings({ globalEnabled: true });
+    const newS = baseSettings({ globalEnabled: false });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('false -> true is not weakening', () => {
+    const oldS = baseSettings({ globalEnabled: false });
+    const newS = baseSettings({ globalEnabled: true });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('unchanged is not weakening', () => {
+    const oldS = baseSettings({ globalEnabled: true });
+    const newS = baseSettings({ globalEnabled: true });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — strictMode.enabled axis', () => {
+  it('true -> false is weakening', () => {
+    const oldS = baseSettings({ strictMode: { enabled: true, challengeLength: 24 } });
+    const newS = baseSettings({ strictMode: { enabled: false, challengeLength: 24 } });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('false -> true is not weakening', () => {
+    const oldS = baseSettings({ strictMode: { enabled: false, challengeLength: 24 } });
+    const newS = baseSettings({ strictMode: { enabled: true, challengeLength: 24 } });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — rule removed / added axis', () => {
+  it('removing an existing rule is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule()] });
+    const newS = baseSettings({ rules: [] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('adding a brand-new rule is NOT weakening (strengthening)', () => {
+    const oldS = baseSettings({ rules: [] });
+    const newS = baseSettings({ rules: [makeRule()] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('an unchanged rule set is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule()] });
+    const newS = baseSettings({ rules: [makeRule()] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — rule disabled axis', () => {
+  it('disabling a rule is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ enabled: true })] });
+    const newS = baseSettings({ rules: [makeRule({ enabled: false })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('enabling a rule is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ enabled: false })] });
+    const newS = baseSettings({ rules: [makeRule({ enabled: true })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — rule mode axis', () => {
+  it('HARD_BLOCK -> DELAY is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ mode: 'HARD_BLOCK' })] });
+    const newS = baseSettings({ rules: [makeRule({ mode: 'DELAY' })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('DELAY -> HARD_BLOCK is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ mode: 'DELAY' })] });
+    const newS = baseSettings({ rules: [makeRule({ mode: 'HARD_BLOCK' })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('DELAY -> BREATHING is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ mode: 'DELAY' })] });
+    const newS = baseSettings({ rules: [makeRule({ mode: 'BREATHING' })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('BREATHING -> DELAY is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ mode: 'BREATHING' })] });
+    const newS = baseSettings({ rules: [makeRule({ mode: 'DELAY' })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — rule delaySeconds axis', () => {
+  it('shorter delay is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ delaySeconds: 30 })] });
+    const newS = baseSettings({ rules: [makeRule({ delaySeconds: 15 })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('longer delay is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ delaySeconds: 15 })] });
+    const newS = baseSettings({ rules: [makeRule({ delaySeconds: 30 })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — rule dailyLimitMinutes axis', () => {
+  it('lower daily limit is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 60 })] });
+    const newS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 30 })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('higher daily limit is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 30 })] });
+    const newS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 60 })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('removing an existing daily limit is weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 30 })] });
+    const newS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: null })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('adding a daily limit where none existed is not weakening', () => {
+    const oldS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: null })] });
+    const newS = baseSettings({ rules: [makeRule({ dailyLimitMinutes: 30 })] });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — emergencyPass.enabled axis', () => {
+  it('false -> true is weakening (adding an escape hatch)', () => {
+    const oldS = baseSettings({ emergencyPass: { enabled: false } });
+    const newS = baseSettings({ emergencyPass: { enabled: true } });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('true -> false is not weakening', () => {
+    const oldS = baseSettings({ emergencyPass: { enabled: true } });
+    const newS = baseSettings({ emergencyPass: { enabled: false } });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('unchanged is not weakening', () => {
+    const oldS = baseSettings({ emergencyPass: { enabled: true } });
+    const newS = baseSettings({ emergencyPass: { enabled: true } });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — tempAllowMinutes axis', () => {
+  it('increasing is weakening', () => {
+    const oldS = baseSettings({ tempAllowMinutes: 10 });
+    const newS = baseSettings({ tempAllowMinutes: 20 });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('decreasing is not weakening', () => {
+    const oldS = baseSettings({ tempAllowMinutes: 20 });
+    const newS = baseSettings({ tempAllowMinutes: 10 });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+
+  it('unchanged is not weakening', () => {
+    const oldS = baseSettings({ tempAllowMinutes: 10 });
+    const newS = baseSettings({ tempAllowMinutes: 10 });
+    expect(isWeakening(oldS, newS)).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — youtube.shortsMode axis', () => {
+  function withShorts(mode: 'INHERIT' | 'HARD_BLOCK' | 'DELAY' | 'BREATHING'): NudgeSettings {
+    return baseSettings({
+      youtube: { shortsMode: mode, hideShortsShelf: false, shortsDelaySeconds: 15 },
+    });
+  }
+
+  it('HARD_BLOCK -> DELAY is weakening', () => {
+    expect(isWeakening(withShorts('HARD_BLOCK'), withShorts('DELAY'))).toBe(true);
+  });
+
+  it('DELAY -> HARD_BLOCK is not weakening', () => {
+    expect(isWeakening(withShorts('DELAY'), withShorts('HARD_BLOCK'))).toBe(false);
+  });
+
+  it('DELAY -> BREATHING is weakening', () => {
+    expect(isWeakening(withShorts('DELAY'), withShorts('BREATHING'))).toBe(true);
+  });
+
+  it('BREATHING -> DELAY is not weakening', () => {
+    expect(isWeakening(withShorts('BREATHING'), withShorts('DELAY'))).toBe(false);
+  });
+
+  it('DELAY -> INHERIT is weakening (INHERIT is the weakest rung)', () => {
+    expect(isWeakening(withShorts('DELAY'), withShorts('INHERIT'))).toBe(true);
+  });
+
+  it('INHERIT -> DELAY is not weakening', () => {
+    expect(isWeakening(withShorts('INHERIT'), withShorts('DELAY'))).toBe(false);
+  });
+
+  it('INHERIT -> INHERIT is not weakening', () => {
+    expect(isWeakening(withShorts('INHERIT'), withShorts('INHERIT'))).toBe(false);
+  });
+});
+
+describe('strictMode: isWeakening() — identity / mixed', () => {
+  it('two identical, non-trivial settings objects are not weakening', () => {
+    const settings = baseSettings({
+      globalEnabled: true,
+      rules: [makeRule({ id: 'r1' }), makeRule({ id: 'r2', domain: 'other.com' })],
+      strictMode: { enabled: true, challengeLength: 48 },
+      emergencyPass: { enabled: false },
+      tempAllowMinutes: 15,
+    });
+    expect(isWeakening(settings, structuredCloneSettings(settings))).toBe(false);
+  });
+
+  it('weakening on one axis while strengthening another still counts as weakening', () => {
+    // Stronger mode (DELAY -> HARD_BLOCK) but shorter delay (30 -> 5) on the same rule.
+    const oldS = baseSettings({ rules: [makeRule({ mode: 'DELAY', delaySeconds: 30 })] });
+    const newS = baseSettings({ rules: [makeRule({ mode: 'HARD_BLOCK', delaySeconds: 5 })] });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+
+  it('multiple rules: one weakened among several unchanged still counts as weakening', () => {
+    const oldS = baseSettings({
+      rules: [makeRule({ id: 'r1', delaySeconds: 30 }), makeRule({ id: 'r2', delaySeconds: 30 })],
+    });
+    const newS = baseSettings({
+      rules: [makeRule({ id: 'r1', delaySeconds: 30 }), makeRule({ id: 'r2', delaySeconds: 5 })],
+    });
+    expect(isWeakening(oldS, newS)).toBe(true);
+  });
+});

--- a/extension/tests/smoke.test.ts
+++ b/extension/tests/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('toolchain smoke', () => {
+  it('runs vitest', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/extension/tests/ui/blockPage.test.tsx
+++ b/extension/tests/ui/blockPage.test.tsx
@@ -1,0 +1,446 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BlockContext } from '../../src/core/protocol';
+import type { BlockDecision } from '../../src/core/types';
+import { formatNextPass } from '../../src/ui/format';
+import { BlockPage, isNavigableTarget } from '../../src/entrypoints/blocked/BlockPage';
+
+const TARGET = 'https://distracting.example/feed';
+
+function hardBlockDecision(overrides: Partial<Extract<BlockDecision, { type: 'BLOCK' }>> = {}) {
+  return {
+    type: 'BLOCK' as const,
+    mode: 'HARD_BLOCK' as const,
+    delaySeconds: 0,
+    ruleName: 'Focus Time',
+    dailyTimeRemainingMs: null,
+    dailyLimitMinutes: null,
+    limitReached: false,
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<BlockContext> = {}): BlockContext {
+  return {
+    target: TARGET,
+    domain: 'distracting.example',
+    decision: hardBlockDecision(),
+    delayTitle: 'Take a breath',
+    delaySubtitle: 'It will still be here in a few seconds.',
+    hardBlockMessage: 'This site is off-limits right now.',
+    passEnabled: true,
+    passAvailable: true,
+    passNextAvailableMs: 0,
+    strictModeEnabled: false,
+    tempAllowMinutes: 10,
+    ...overrides,
+  };
+}
+
+let sendMessageMock: ReturnType<typeof vi.fn>;
+let replaceMock: ReturnType<typeof vi.fn>;
+
+// jsdom's real `window.location` has a non-configurable, non-writable `replace` method
+// (can't be spied on), so the block page's own navigation calls are verified against a
+// full stand-in object instead. Vitest's jsdom environment defines `location` as a plain
+// accessor on `window`, so whole-object reassignment (not `Object.defineProperty`) is what
+// actually works here.
+/** The extension page the DNR rule redirects to. */
+const BLOCKED_PAGE_URL = 'chrome-extension://nudgeid/blocked.html';
+
+/**
+ * Mirrors production byte-for-byte: the DNR rule appends the ORIGINAL url VERBATIM as the
+ * last thing in the address (`regexSubstitution` cannot percent-encode), so the target
+ * routinely carries its own `?`, `&` and `#`. Encoding it here would have tested a contract
+ * the extension never actually produces.
+ */
+function setTarget(target: string | null) {
+  const suffix = target === null ? '' : `?target=${target}`;
+  (window as unknown as { location: unknown }).location = {
+    href: `${BLOCKED_PAGE_URL}${suffix}`,
+    search: suffix,
+    replace: replaceMock,
+  };
+}
+
+/** Flushes several microtask hops (mocked chrome promise -> rpc's send() -> component .then()),
+ * wrapped in `act` at each hop so any resulting React state updates get committed. */
+async function flush(times = 6) {
+  for (let i = 0; i < times; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  sendMessageMock = vi.fn();
+  replaceMock = vi.fn();
+  vi.stubGlobal('chrome', {
+    runtime: {
+      sendMessage: sendMessageMock,
+      getURL: (path: string) => `chrome-extension://test-id/${path}`,
+    },
+  } as unknown as typeof chrome);
+  setTarget(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('isNavigableTarget', () => {
+  it('accepts http/https URLs', () => {
+    expect(isNavigableTarget('https://example.com')).toBe(true);
+    expect(isNavigableTarget('http://example.com/path?q=1')).toBe(true);
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(isNavigableTarget('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isNavigableTarget('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects chrome-extension: URLs', () => {
+    expect(isNavigableTarget('chrome-extension://other-id/page.html')).toBe(false);
+  });
+
+  it('rejects missing/blank/unparsable input', () => {
+    expect(isNavigableTarget(null)).toBe(false);
+    expect(isNavigableTarget(undefined)).toBe(false);
+    expect(isNavigableTarget('')).toBe(false);
+    expect(isNavigableTarget('not a url')).toBe(false);
+  });
+});
+
+describe('BlockPage — target parsing', () => {
+  // Regression: the target arrives VERBATIM after "?target=" because DNR's regexSubstitution
+  // cannot percent-encode. Parsing it with URLSearchParams truncated the url at its own first
+  // "&", so "watch?v=abc&t=30" came back as "watch?v=abc" — the user would be sent to the
+  // wrong place after completing a pause. Whole class: any target carrying its own query.
+  it('preserves a target that carries its own query string, unsplit at "&"', async () => {
+    const target = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s&list=PL1';
+    sendMessageMock.mockResolvedValue(makeContext({ target, domain: 'youtube.com' }));
+    setTarget(target);
+    render(<BlockPage />);
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'GET_BLOCK_CONTEXT', target }),
+    );
+  });
+
+  it('preserves a target that carries a #fragment', async () => {
+    const target = 'https://example.com/a/b?x=1#section-2';
+    sendMessageMock.mockResolvedValue(makeContext({ target, domain: 'example.com' }));
+    setTarget(target);
+    render(<BlockPage />);
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'GET_BLOCK_CONTEXT', target }),
+    );
+  });
+
+  it('does not percent-decode a target containing a literal %XX sequence', async () => {
+    // Both producers append the url verbatim, so decoding here would corrupt a real url.
+    const target = 'https://example.com/search?q=100%25%20cotton';
+    sendMessageMock.mockResolvedValue(makeContext({ target, domain: 'example.com' }));
+    setTarget(target);
+    render(<BlockPage />);
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'GET_BLOCK_CONTEXT', target }),
+    );
+  });
+});
+
+describe('BlockPage — target guard', () => {
+  it('renders a safe fallback for a javascript: target, never fetches, never navigates', async () => {
+    setTarget('javascript:alert(1)');
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText(/nothing to show here/i)).toBeTruthy();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a safe fallback for a data: target, never fetches, never navigates', async () => {
+    setTarget('data:text/html,<script>alert(1)</script>');
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText(/nothing to show here/i)).toBeTruthy();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a safe fallback when target is missing', async () => {
+    setTarget(null);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText(/nothing to show here/i)).toBeTruthy();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a safe fallback when target is blank', async () => {
+    (window as unknown as { location: unknown }).location = {
+      href: `${BLOCKED_PAGE_URL}?target=`,
+      search: '?target=',
+      replace: replaceMock,
+    };
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText(/nothing to show here/i)).toBeTruthy();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('BlockPage — loading and error', () => {
+  it('renders a neutral loading state before the context resolves — never the wrong mode', () => {
+    setTarget(TARGET);
+    sendMessageMock.mockImplementationOnce(() => new Promise(() => {})); // never resolves
+    render(<BlockPage />);
+
+    expect(screen.getByText('Loading…')).toBeTruthy();
+    expect(screen.queryByText('I changed my mind')).toBeNull();
+    expect(screen.queryByText('Go Back')).toBeNull();
+  });
+
+  it('shows a retry affordance when GET_BLOCK_CONTEXT rejects, and retry recovers', async () => {
+    setTarget(TARGET);
+    sendMessageMock.mockRejectedValueOnce(new Error('receiving end does not exist'));
+    render(<BlockPage />);
+    await flush();
+
+    const retryButton = screen.getByRole('button', { name: /retry/i });
+    expect(retryButton).toBeTruthy();
+    expect(screen.queryByText('Loading…')).toBeNull();
+
+    const context = makeContext({ hardBlockMessage: 'Back to focus.' });
+    sendMessageMock.mockResolvedValueOnce(context);
+    fireEvent.click(retryButton);
+    await flush();
+
+    expect(screen.getByText('Back to focus.')).toBeTruthy();
+  });
+});
+
+describe('Hard Block', () => {
+  it('renders the hard-block message and offers no way through', async () => {
+    setTarget(TARGET);
+    const context = makeContext({ hardBlockMessage: 'Stay focused. Try again later.' });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText('Stay focused. Try again later.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go Back' })).toBeTruthy();
+    expect(screen.queryByText(/open anyway|continue to site|proceed/i)).toBeNull();
+    expect(screen.getByText('Rule: Focus Time')).toBeTruthy();
+  });
+
+  it('shows "Daily limit reached" without duplicating the ruleName suffix', async () => {
+    setTarget(TARGET);
+    const context = makeContext({
+      hardBlockMessage: 'Budget is gone for today.',
+      decision: hardBlockDecision({
+        ruleName: 'Focus Time (limit reached)',
+        dailyTimeRemainingMs: 0,
+        dailyLimitMinutes: 30,
+        limitReached: true,
+      }),
+    });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText('Daily limit reached')).toBeTruthy();
+    // ruleName already carries the suffix from the background — must appear exactly once.
+    expect(screen.getAllByText(/Focus Time \(limit reached\)/)).toHaveLength(1);
+    expect(screen.queryByText('Focus Time (limit reached) (limit reached)')).toBeNull();
+  });
+
+  it('"Go Back" never navigates to the blocked target', async () => {
+    setTarget(TARGET);
+    const historyBackSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+    const context = makeContext();
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go Back' }));
+
+    expect(replaceMock).not.toHaveBeenCalledWith(TARGET);
+    // Either history.back() fired, or (no history) it fell back to a neutral about:blank —
+    // never the blocked site.
+    const wentToTarget = replaceMock.mock.calls.some((call) => call[0] === TARGET);
+    expect(wentToTarget).toBe(false);
+    historyBackSpy.mockRestore();
+  });
+});
+
+describe('Delay', () => {
+  it('renders title/subtitle and, after the delay elapses, completes the pause and navigates', async () => {
+    setTarget(TARGET);
+    const context = makeContext({
+      decision: {
+        type: 'BLOCK',
+        mode: 'DELAY',
+        delaySeconds: 15,
+        ruleName: 'Focus Time',
+        dailyTimeRemainingMs: null,
+        dailyLimitMinutes: null,
+        limitReached: false,
+      },
+    });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText('Take a breath')).toBeTruthy();
+    expect(screen.getByText('It will still be here in a few seconds.')).toBeTruthy();
+
+    sendMessageMock.mockResolvedValueOnce({ ok: true, until: Date.now() + 600_000 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'COMPLETE_PAUSE', target: TARGET });
+    expect(replaceMock).toHaveBeenCalledWith(TARGET);
+  });
+
+  it('"I changed my mind" sends WALKED_AWAY and navigates to the dashboard', async () => {
+    setTarget(TARGET);
+    const context = makeContext({
+      decision: {
+        type: 'BLOCK',
+        mode: 'DELAY',
+        delaySeconds: 15,
+        ruleName: 'Focus Time',
+        dailyTimeRemainingMs: null,
+        dailyLimitMinutes: null,
+        limitReached: false,
+      },
+    });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    sendMessageMock.mockResolvedValueOnce({ ok: true });
+    fireEvent.click(screen.getByRole('button', { name: 'I changed my mind' }));
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'WALKED_AWAY', target: TARGET });
+    expect(replaceMock).toHaveBeenCalledWith('chrome-extension://test-id/dashboard.html');
+  });
+});
+
+describe('Breathing', () => {
+  it('alternates Breathe in/out on the fixed 4s/4s cycle and completes into COMPLETE_PAUSE + navigation', async () => {
+    setTarget(TARGET);
+    const context = makeContext({
+      decision: {
+        type: 'BLOCK',
+        mode: 'BREATHING',
+        delaySeconds: 8,
+        ruleName: 'Focus Time',
+        dailyTimeRemainingMs: null,
+        dailyLimitMinutes: null,
+        limitReached: false,
+      },
+    });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.getByText('Breathe in...')).toBeTruthy();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    await flush();
+    expect(screen.getByText('Breathe out...')).toBeTruthy();
+
+    sendMessageMock.mockResolvedValueOnce({ ok: true, until: Date.now() + 600_000 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'COMPLETE_PAUSE', target: TARGET });
+    expect(replaceMock).toHaveBeenCalledWith(TARGET);
+  });
+});
+
+describe('Escape Hatch', () => {
+  it('shows the available label and, on tap, calls USE_EMERGENCY_PASS then navigates', async () => {
+    setTarget(TARGET);
+    const context = makeContext({ passEnabled: true, passAvailable: true, strictModeEnabled: false });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    const passButton = screen.getByRole('button', { name: 'Use for 2 minutes · once a day' });
+    expect((passButton as HTMLButtonElement).disabled).toBe(false);
+
+    sendMessageMock.mockResolvedValueOnce({ ok: true, until: Date.now() + 120_000 });
+    fireEvent.click(passButton);
+    await flush();
+
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: 'USE_EMERGENCY_PASS', target: TARGET });
+    expect(replaceMock).toHaveBeenCalledWith(TARGET);
+  });
+
+  it('shows the disabled spent label with the correct hours', async () => {
+    setTarget(TARGET);
+    const passNextAvailableMs = 5 * 3_600_000;
+    const context = makeContext({
+      passEnabled: true,
+      passAvailable: false,
+      passNextAvailableMs,
+      strictModeEnabled: false,
+    });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    const label = `Daily pass used · next in ${formatNextPass(passNextAvailableMs)}`;
+    const passButton = screen.getByRole('button', { name: label });
+    expect((passButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('renders nothing under Strict Mode', async () => {
+    setTarget(TARGET);
+    const context = makeContext({ passEnabled: true, passAvailable: true, strictModeEnabled: true });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.queryByText(/use for 2 minutes/i)).toBeNull();
+    expect(screen.queryByText(/daily pass used/i)).toBeNull();
+  });
+
+  it('renders nothing when the pass is disabled entirely', async () => {
+    setTarget(TARGET);
+    const context = makeContext({ passEnabled: false, passAvailable: true, strictModeEnabled: false });
+    sendMessageMock.mockResolvedValueOnce(context);
+    render(<BlockPage />);
+    await flush();
+
+    expect(screen.queryByText(/use for 2 minutes/i)).toBeNull();
+    expect(screen.queryByText(/daily pass used/i)).toBeNull();
+  });
+});

--- a/extension/tests/ui/blockPage.test.tsx
+++ b/extension/tests/ui/blockPage.test.tsx
@@ -41,19 +41,19 @@ function makeContext(overrides: Partial<BlockContext> = {}): BlockContext {
 let sendMessageMock: ReturnType<typeof vi.fn>;
 let replaceMock: ReturnType<typeof vi.fn>;
 
-// jsdom's real `window.location` has a non-configurable, non-writable `replace` method
-// (can't be spied on), so the block page's own navigation calls are verified against a
-// full stand-in object instead. Vitest's jsdom environment defines `location` as a plain
-// accessor on `window`, so whole-object reassignment (not `Object.defineProperty`) is what
-// actually works here.
 /** The extension page the DNR rule redirects to. */
 const BLOCKED_PAGE_URL = 'chrome-extension://nudgeid/blocked.html';
 
 /**
- * Mirrors production byte-for-byte: the DNR rule appends the ORIGINAL url VERBATIM as the
- * last thing in the address (`regexSubstitution` cannot percent-encode), so the target
- * routinely carries its own `?`, `&` and `#`. Encoding it here would have tested a contract
- * the extension never actually produces.
+ * Point the page at `target`, mirroring production byte-for-byte: the DNR rule appends the
+ * ORIGINAL url VERBATIM as the last thing in the address (`regexSubstitution` cannot
+ * percent-encode), so the target routinely carries its own `?`, `&` and `#`. Encoding it
+ * here would test a contract the extension never actually produces.
+ *
+ * jsdom's real `window.location` has a non-configurable, non-writable `replace` method that
+ * cannot be spied on, so navigation is verified against a full stand-in object. Vitest's
+ * jsdom environment defines `location` as a plain accessor on `window`, so whole-object
+ * reassignment (not `Object.defineProperty`) is what actually works.
  */
 function setTarget(target: string | null) {
   const suffix = target === null ? '' : `?target=${target}`;
@@ -68,7 +68,7 @@ function setTarget(target: string | null) {
  * wrapped in `act` at each hop so any resulting React state updates get committed. */
 async function flush(times = 6) {
   for (let i = 0; i < times; i++) {
-    // eslint-disable-next-line no-await-in-loop
+     
     await act(async () => {
       await Promise.resolve();
     });

--- a/extension/tests/ui/dashboard.test.tsx
+++ b/extension/tests/ui/dashboard.test.tsx
@@ -8,6 +8,7 @@ import { forDisplay } from '../../src/core/strictMode';
 import { Dashboard } from '../../src/entrypoints/dashboard/Dashboard';
 import { ChallengeDialog } from '../../src/entrypoints/dashboard/ChallengeDialog';
 import { StatsPanel } from '../../src/entrypoints/dashboard/StatsPanel';
+import { RuleEditor } from '../../src/entrypoints/dashboard/RuleEditor';
 
 let sendMessageMock: ReturnType<typeof vi.fn>;
 
@@ -339,5 +340,46 @@ describe('Dashboard', () => {
     await flush();
 
     expect(screen.getByText('Break the scroll. Take back your time.')).toBeDefined();
+  });
+});
+
+describe('RuleEditor, Daily Time Limit is not offered for Hard Block', () => {
+  /**
+   * Companion to the engine fix: a daily limit is meaningless on a Hard Block (the site is
+   * barred outright, so there is no browsing time to budget). Offering the control invited
+   * the exact combination that used to produce an infinite redirect loop, and still reads to
+   * a user as "blocked, but only after 30 minutes".
+   */
+  const noop = () => {};
+
+  function renderEditor(mode: SiteRule['mode']) {
+    return render(<RuleEditor rule={makeRule({ mode })} onSave={noop} onCancel={noop} />);
+  }
+
+  it('explains why, instead of showing the limit controls, when mode is Hard Block', () => {
+    renderEditor('HARD_BLOCK');
+
+    expect(screen.getByText(/not used with hard block/i)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'No limit' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '30m' })).toBeNull();
+  });
+
+  it('offers the limit controls for Delay', () => {
+    renderEditor('DELAY');
+
+    expect(screen.getByRole('button', { name: 'No limit' })).toBeTruthy();
+    expect(screen.queryByText(/not used with hard block/i)).toBeNull();
+  });
+
+  it('offers the limit controls for Breathing', () => {
+    renderEditor('BREATHING');
+
+    expect(screen.getByRole('button', { name: 'No limit' })).toBeTruthy();
+    expect(screen.queryByText(/not used with hard block/i)).toBeNull();
+  });
+
+  it('keeps the Daily Time Limit section itself present in every mode', () => {
+    renderEditor('HARD_BLOCK');
+    expect(screen.getByText('Daily Time Limit')).toBeTruthy();
   });
 });

--- a/extension/tests/ui/dashboard.test.tsx
+++ b/extension/tests/ui/dashboard.test.tsx
@@ -1,0 +1,343 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardState, DayUsage } from '../../src/core/protocol';
+import { DEFAULT_SETTINGS, structuredCloneSettings } from '../../src/core/settingsSchema';
+import type { NudgeSettings, SiteRule } from '../../src/core/settingsSchema';
+import { forDisplay } from '../../src/core/strictMode';
+import { Dashboard } from '../../src/entrypoints/dashboard/Dashboard';
+import { ChallengeDialog } from '../../src/entrypoints/dashboard/ChallengeDialog';
+import { StatsPanel } from '../../src/entrypoints/dashboard/StatsPanel';
+
+let sendMessageMock: ReturnType<typeof vi.fn>;
+
+function makeDay(overrides: Partial<DayUsage> = {}): DayUsage {
+  return { activeSec: 0, blocked: 0, walkedAway: 0, hourly: new Array<number>(24).fill(0), ...overrides };
+}
+
+function makeRule(overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: 'rule-youtube.com',
+    domain: 'youtube.com',
+    mode: 'DELAY',
+    delaySeconds: 15,
+    dailyLimitMinutes: 30,
+    enabled: true,
+    createdAt: 1700000000000,
+    showTimeRemaining: true,
+    schedule: null,
+    ...overrides,
+  };
+}
+
+function makeSettings(overrides: Partial<NudgeSettings> = {}): NudgeSettings {
+  return { ...structuredCloneSettings(DEFAULT_SETTINGS), ...overrides };
+}
+
+const RECENT_DAYS = [
+  '2026-07-20',
+  '2026-07-21',
+  '2026-07-22',
+  '2026-07-23',
+  '2026-07-24',
+  '2026-07-25',
+  '2026-07-26',
+];
+
+function makeState(overrides: Partial<DashboardState> = {}): DashboardState {
+  const hourly = new Array<number>(24).fill(0);
+  hourly[9] = 1200;
+  hourly[21] = 2400;
+  return {
+    settings: makeSettings({ rules: [makeRule()] }),
+    recentDays: RECENT_DAYS,
+    usage: {
+      '2026-07-25': { 'youtube.com': makeDay({ activeSec: 900, blocked: 2, walkedAway: 1 }) },
+      '2026-07-26': {
+        'youtube.com': makeDay({ activeSec: 3600, blocked: 4, walkedAway: 3, hourly }),
+        'reddit.com': makeDay({ activeSec: 1800, blocked: 1, walkedAway: 0 }),
+      },
+    },
+    allTimeBlocked: 42,
+    allTimeWalkedAway: 17,
+    ...overrides,
+  };
+}
+
+/** An empty-but-valid state: every counter zero, no usage rollups at all. */
+function makeEmptyState(): DashboardState {
+  return {
+    settings: makeSettings(),
+    recentDays: RECENT_DAYS,
+    usage: {},
+    allTimeBlocked: 0,
+    allTimeWalkedAway: 0,
+  };
+}
+
+/** Flush the microtask hops between the mocked chrome promise and the committed React state. */
+async function flush(times = 6) {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+beforeEach(() => {
+  sendMessageMock = vi.fn();
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { sendMessage: sendMessageMock, getURL: (p: string) => `chrome-extension://nudgeid/${p}` },
+    tabs: { create: vi.fn() },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('StatsPanel', () => {
+  it('renders real numbers for today and all-time counters', () => {
+    render(<StatsPanel data={makeState()} />);
+
+    // Today = 3600 + 1800 active seconds across two domains -> "1h 30m".
+    expect(screen.getByText('1h 30m')).toBeDefined();
+    // Blocked today = 4 + 1; Walked Away today = 3 + 0.
+    expect(screen.getByText('5')).toBeDefined();
+    expect(screen.getByText('3')).toBeDefined();
+    expect(screen.getByText(/42 all-time/)).toBeDefined();
+    expect(screen.getByText(/17 all-time/)).toBeDefined();
+  });
+
+  it('uses the exact "Blocked" and "Walked Away" stat labels', () => {
+    render(<StatsPanel data={makeState()} />);
+    expect(screen.getByText('Blocked')).toBeDefined();
+    expect(screen.getByText('Walked Away')).toBeDefined();
+  });
+
+  it('lists top sites with proportional bars', () => {
+    render(<StatsPanel data={makeState()} />);
+    expect(screen.getByText('youtube.com')).toBeDefined();
+    expect(screen.getByText('reddit.com')).toBeDefined();
+  });
+
+  it('survives the all-zero empty state without dividing by zero', () => {
+    const { container } = render(<StatsPanel data={makeEmptyState()} />);
+
+    expect(screen.getByText(/No activity tracked yet/)).toBeDefined();
+    expect(screen.getByText(/Nothing tracked in the last 7 days/)).toBeDefined();
+
+    // No NaN/Infinity anywhere in the rendered markup (the classic /0 leak).
+    expect(container.innerHTML).not.toMatch(/NaN|Infinity/);
+
+    // The 7-day chart still renders 7 bars, each with a finite height.
+    const rects = container.querySelectorAll('rect');
+    expect(rects.length).toBeGreaterThanOrEqual(7);
+    rects.forEach((rect) => {
+      const height = Number(rect.getAttribute('height'));
+      expect(Number.isFinite(height)).toBe(true);
+      expect(height).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it('renders a 24-cell hourly heatmap', () => {
+    const { container } = render(<StatsPanel data={makeState()} />);
+    expect(container.querySelectorAll('[title$=":00 — 0s"], [title*=":00 — "]').length).toBe(24);
+  });
+});
+
+describe('ChallengeDialog', () => {
+  const CHALLENGE = 'abcde12345fghij67890klmn';
+
+  it('renders the challenge dash-grouped and never pre-fills the input', () => {
+    render(<ChallengeDialog challenge={CHALLENGE} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByTestId('challenge-code').textContent).toBe(forDisplay(CHALLENGE));
+    expect((screen.getByLabelText('Unlock code') as HTMLInputElement).value).toBe('');
+  });
+
+  it('BLOCKS paste — the whole point of the friction', () => {
+    render(<ChallengeDialog challenge={CHALLENGE} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    const input = screen.getByLabelText('Unlock code') as HTMLInputElement;
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: { getData: () => CHALLENGE },
+    });
+    fireEvent(input, pasteEvent);
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    expect(input.value).toBe('');
+  });
+
+  it('only enables submit once the typed input matches the challenge length', () => {
+    const onSubmit = vi.fn();
+    render(<ChallengeDialog challenge={CHALLENGE} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    const input = screen.getByLabelText('Unlock code');
+    const submit = screen.getByRole('button', { name: 'Unlock' }) as HTMLButtonElement;
+
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: CHALLENGE.slice(0, 5) } });
+    expect(screen.getByTestId('challenge-progress').textContent).toBe(`5/${CHALLENGE.length}`);
+    expect((screen.getByRole('button', { name: 'Unlock' }) as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: CHALLENGE } });
+    expect(screen.getByTestId('challenge-progress').textContent).toBe(
+      `${CHALLENGE.length}/${CHALLENGE.length}`,
+    );
+    const enabled = screen.getByRole('button', { name: 'Unlock' }) as HTMLButtonElement;
+    expect(enabled.disabled).toBe(false);
+
+    fireEvent.click(enabled);
+    expect(onSubmit).toHaveBeenCalledWith(CHALLENGE);
+  });
+
+  it('counts dashes typed by the user as formatting, not content', () => {
+    render(<ChallengeDialog challenge={CHALLENGE} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('Unlock code'), {
+      target: { value: forDisplay(CHALLENGE) },
+    });
+
+    expect(screen.getByTestId('challenge-progress').textContent).toBe(
+      `${CHALLENGE.length}/${CHALLENGE.length}`,
+    );
+  });
+});
+
+describe('Dashboard', () => {
+  it('shows a retry instead of a dead spinner when the service worker is asleep', async () => {
+    sendMessageMock.mockRejectedValue(new Error('Could not establish connection.'));
+    render(<Dashboard />);
+    await flush();
+
+    expect(screen.getByText(/Could not establish connection/)).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDefined();
+  });
+
+  it('shows the naming-parity strings on the Settings tab', async () => {
+    sendMessageMock.mockResolvedValue(makeState());
+    render(<Dashboard />);
+    await flush();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    for (const label of [
+      'Hard Block',
+      'Delay',
+      'Breathing',
+      'Daily Time Limit',
+      'Commitment Lock',
+      'Escape Hatch',
+    ]) {
+      expect(screen.getAllByText(new RegExp(label)).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('states the Commitment Lock honesty note about chrome://extensions removal', async () => {
+    sendMessageMock.mockResolvedValue(makeState());
+    render(<Dashboard />);
+    await flush();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    expect(screen.getByText(/cannot prevent its own removal/)).toBeDefined();
+    expect(screen.getAllByText(/chrome:\/\/extensions/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/commitment device, not an unbreakable/)).toBeDefined();
+  });
+
+  it('exposes "Scheduled Override" and "Show time remaining" in the rule editor', async () => {
+    sendMessageMock.mockResolvedValue(makeState());
+    render(<Dashboard />);
+    await flush();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByText('Scheduled Override')).toBeDefined();
+    expect(screen.getByText('Show time remaining')).toBeDefined();
+    expect(screen.getByText('Daily Time Limit')).toBeDefined();
+  });
+
+  it('surfaces the challenge when the background rejects a weakening save', async () => {
+    const challenge = 'qwertyuiopas';
+    sendMessageMock.mockImplementation((request: { type: string }) => {
+      if (request.type === 'GET_DASHBOARD_STATE') {
+        return Promise.resolve(makeState({ settings: makeSettings({ rules: [makeRule()] }) }));
+      }
+      return Promise.resolve({ ok: false, challenge, reason: 'challenge-required' });
+    });
+
+    render(<Dashboard />);
+    await flush();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    // Turning the master toggle off is a weakening change.
+    fireEvent.click(screen.getByLabelText('Nudge is on'));
+    await flush();
+
+    expect(screen.getByTestId('challenge-code').textContent).toBe(forDisplay(challenge));
+    expect((screen.getByRole('button', { name: 'Unlock' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('retries the save with the typed challengeResponse and closes on success', async () => {
+    const challenge = 'qwertyuiopas';
+    let saveCalls = 0;
+    sendMessageMock.mockImplementation((request: { type: string; challengeResponse?: string }) => {
+      if (request.type === 'GET_DASHBOARD_STATE') return Promise.resolve(makeState());
+      saveCalls += 1;
+      if (request.challengeResponse === undefined) {
+        return Promise.resolve({ ok: false, challenge, reason: 'challenge-required' });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<Dashboard />);
+    await flush();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    fireEvent.click(screen.getByLabelText('Nudge is on'));
+    await flush();
+
+    fireEvent.change(screen.getByLabelText('Unlock code'), { target: { value: challenge } });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+    await flush();
+
+    expect(saveCalls).toBe(2);
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SAVE_SETTINGS', challengeResponse: challenge }),
+    );
+    expect(screen.queryByTestId('challenge-code')).toBeNull();
+  });
+
+  it('tells the user when the typed code was wrong and keeps the same challenge', async () => {
+    const challenge = 'qwertyuiopas';
+    sendMessageMock.mockImplementation((request: { type: string; challengeResponse?: string }) => {
+      if (request.type === 'GET_DASHBOARD_STATE') return Promise.resolve(makeState());
+      return Promise.resolve({
+        ok: false,
+        challenge,
+        reason: request.challengeResponse === undefined ? 'challenge-required' : 'challenge-incorrect',
+      });
+    });
+
+    render(<Dashboard />);
+    await flush();
+    fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    fireEvent.click(screen.getByLabelText('Nudge is on'));
+    await flush();
+
+    fireEvent.change(screen.getByLabelText('Unlock code'), { target: { value: challenge } });
+    fireEvent.click(screen.getByRole('button', { name: 'Unlock' }));
+    await flush();
+
+    expect(screen.getByText(/doesn't match/)).toBeDefined();
+    expect(screen.getByTestId('challenge-code').textContent).toBe(forDisplay(challenge));
+  });
+
+  it('shows the tagline', async () => {
+    sendMessageMock.mockResolvedValue(makeState());
+    render(<Dashboard />);
+    await flush();
+
+    expect(screen.getByText('Break the scroll. Take back your time.')).toBeDefined();
+  });
+});

--- a/extension/tests/ui/exportImport.test.ts
+++ b/extension/tests/ui/exportImport.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExport,
+  dedupeImportedRules,
+  EXPORT_VERSION,
+  parseImport,
+} from '../../src/ui/exportImport';
+import { DEFAULT_SETTINGS, structuredCloneSettings } from '../../src/core/settingsSchema';
+import type { SiteRule } from '../../src/core/settingsSchema';
+
+function makeRule(overrides: Partial<SiteRule> = {}): SiteRule {
+  return {
+    id: 'rule-youtube.com',
+    domain: 'youtube.com',
+    mode: 'DELAY',
+    delaySeconds: 15,
+    dailyLimitMinutes: 30,
+    enabled: true,
+    createdAt: 1700000000000,
+    showTimeRemaining: true,
+    schedule: null,
+    ...overrides,
+  };
+}
+
+describe('buildExport', () => {
+  it('produces the version:1 / exportedAt / rules envelope', () => {
+    const settings = structuredCloneSettings(DEFAULT_SETTINGS);
+    settings.rules = [makeRule()];
+
+    const exported = buildExport(settings);
+
+    expect(exported.version).toBe(1);
+    expect(exported.version).toBe(EXPORT_VERSION);
+    expect(typeof exported.exportedAt).toBe('string');
+    // Must be a real ISO timestamp, not a placeholder.
+    expect(new Date(exported.exportedAt).toISOString()).toBe(exported.exportedAt);
+    expect(exported.rules).toHaveLength(1);
+    expect(exported.rules[0]!.domain).toBe('youtube.com');
+  });
+
+  it('deep-clones the schedule so mutating the export never touches settings', () => {
+    const settings = structuredCloneSettings(DEFAULT_SETTINGS);
+    settings.rules = [
+      makeRule({
+        schedule: {
+          enabled: true,
+          days: [1, 2, 3],
+          startMinute: 60,
+          endMinute: 120,
+          mode: 'HARD_BLOCK',
+          delaySeconds: 5,
+        },
+      }),
+    ];
+
+    const exported = buildExport(settings);
+    exported.rules[0]!.schedule!.days!.push(7);
+
+    expect(settings.rules[0]!.schedule!.days).toEqual([1, 2, 3]);
+  });
+});
+
+describe('parseImport round trip', () => {
+  it('round-trips a built export back into equivalent rules', () => {
+    const settings = structuredCloneSettings(DEFAULT_SETTINGS);
+    settings.rules = [
+      makeRule({ domain: 'instagram.com', mode: 'BREATHING' }),
+      makeRule({
+        domain: 'x.com',
+        schedule: {
+          enabled: true,
+          days: [6, 7],
+          startMinute: 1380,
+          endMinute: 360,
+          mode: 'HARD_BLOCK',
+          delaySeconds: 30,
+        },
+      }),
+    ];
+
+    const json = JSON.stringify(buildExport(settings));
+    const result = parseImport(json);
+
+    expect(result.ok).toBe(true);
+    expect(result.rules).toHaveLength(2);
+    expect(result.rules?.map((r) => r.domain).sort()).toEqual(['instagram.com', 'x.com']);
+    const overnight = result.rules?.find((r) => r.domain === 'x.com');
+    expect(overnight?.schedule?.startMinute).toBe(1380);
+    expect(overnight?.schedule?.endMinute).toBe(360);
+  });
+});
+
+describe('parseImport validation', () => {
+  it('rejects malformed JSON without throwing', () => {
+    expect(() => parseImport('{not valid json')).not.toThrow();
+    const result = parseImport('{not valid json');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('rejects a non-object root (array) without throwing', () => {
+    const result = parseImport('[1,2,3]');
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('rejects a non-object root (primitive) without throwing', () => {
+    const result = parseImport('"just a string"');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a missing version field', () => {
+    const result = parseImport(JSON.stringify({ exportedAt: new Date().toISOString(), rules: [] }));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/version/i);
+  });
+
+  it('rejects a version newer than supported', () => {
+    const result = parseImport(
+      JSON.stringify({ version: EXPORT_VERSION + 1, exportedAt: new Date().toISOString(), rules: [] }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/newer/i);
+  });
+
+  it('tolerates missing optional fields on a rule (older export)', () => {
+    const result = parseImport(
+      JSON.stringify({
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        rules: [{ domain: 'reddit.com', mode: 'DELAY' }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules?.[0]?.domain).toBe('reddit.com');
+    expect(result.rules?.[0]?.dailyLimitMinutes).toBeNull();
+    expect(result.rules?.[0]?.schedule).toBeNull();
+    expect(result.rules?.[0]?.delaySeconds).toBe(15); // clamped default
+  });
+
+  it('drops garbage entries inside the rules array without throwing or failing the whole import', () => {
+    const result = parseImport(
+      JSON.stringify({
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        rules: [
+          { domain: 'youtube.com', mode: 'DELAY' },
+          null,
+          42,
+          'garbage',
+          { mode: 'HARD_BLOCK' }, // missing domain
+          { domain: '   ' }, // blank domain
+          { domain: 'valid-two.com' },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.rules?.map((r) => r.domain).sort()).toEqual(['valid-two.com', 'youtube.com']);
+  });
+
+  it('clamps an out-of-range delaySeconds/dailyLimitMinutes instead of rejecting the rule', () => {
+    const result = parseImport(
+      JSON.stringify({
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        rules: [{ domain: 'clamp.com', delaySeconds: 99999, dailyLimitMinutes: -5 }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.rules?.[0]?.delaySeconds).toBeLessThanOrEqual(300);
+    expect(result.rules?.[0]?.dailyLimitMinutes).toBeGreaterThanOrEqual(1);
+  });
+
+  it('falls back an unknown mode string to HARD_BLOCK rather than throwing', () => {
+    const result = parseImport(
+      JSON.stringify({
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        rules: [{ domain: 'weird.com', mode: 'NOT_A_REAL_MODE' }],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.rules?.[0]?.mode).toBe('HARD_BLOCK');
+  });
+});
+
+describe('dedupeImportedRules', () => {
+  it('drops imported rules whose domain already exists', () => {
+    const existing = [makeRule({ domain: 'youtube.com' })];
+    const imported = [makeRule({ domain: 'youtube.com', mode: 'HARD_BLOCK' }), makeRule({ domain: 'reddit.com' })];
+
+    const merged = dedupeImportedRules(existing, imported);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.find((r) => r.domain === 'youtube.com')?.mode).toBe('DELAY'); // existing wins
+    expect(merged.some((r) => r.domain === 'reddit.com')).toBe(true);
+  });
+
+  it('de-dupes within the imported batch itself, keeping the first occurrence', () => {
+    const existing: SiteRule[] = [];
+    const imported = [
+      makeRule({ domain: 'dup.com', mode: 'DELAY' }),
+      makeRule({ domain: 'dup.com', mode: 'BREATHING' }),
+    ];
+
+    const merged = dedupeImportedRules(existing, imported);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.mode).toBe('DELAY');
+  });
+
+  it('is a no-op when there is nothing new to import', () => {
+    const existing = [makeRule({ domain: 'a.com' }), makeRule({ domain: 'b.com' })];
+    const merged = dedupeImportedRules(existing, []);
+    expect(merged).toEqual(existing);
+  });
+});

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./.wxt/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "jsx": "react-jsx",
+    "types": ["chrome", "vitest/globals"]
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "e2e/**/*",
+    "*.config.ts",
+    ".wxt/**/*"
+  ],
+  "exclude": ["node_modules", ".output", "dist"]
+}

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { WxtVitest } from 'wxt/testing/vitest-plugin';
+
+export default defineConfig({
+  plugins: [WxtVitest()],
+  test: {
+    globals: true,
+    // Default is node — src/core/ is pure TS. Tests that need a DOM (YouTube
+    // selector fixtures) opt in per file with `// @vitest-environment jsdom`.
+    environment: 'node',
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/core/**/*.ts'],
+    },
+  },
+});

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -31,5 +31,8 @@ export default defineConfig({
     action: {
       default_title: 'Nudge',
     },
+    // The full-tab dashboard IS the options page (PRD item 9), so right-clicking the
+    // toolbar icon -> Options lands on it instead of going nowhere.
+    options_page: 'dashboard.html',
   },
 });

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'wxt';
+
+// Nudge for Chrome — MV3 config.
+// Architecture: ops/routes/nudge/research/ext-08-architecture.md
+// MV3 recipes:  ops/routes/nudge/research/ext-01-mv3-architecture.md
+export default defineConfig({
+  srcDir: 'src',
+  modules: ['@wxt-dev/module-react'],
+  manifest: {
+    name: 'Nudge — Website Blocker, Screen Time & Shorts Blocker',
+    description:
+      'Block distracting sites with friction instead of walls: delay-to-open, breathing pauses, daily time limits and local-only screen time. No account, no telemetry.',
+    permissions: [
+      'declarativeNetRequest',
+      'tabs',
+      'storage',
+      'unlimitedStorage',
+      'alarms',
+      'idle',
+    ],
+    host_permissions: ['<all_urls>'],
+    // A DNR `redirect.extensionPath` target MUST be web-accessible or the redirect
+    // silently fails — even though the extension owns the page.
+    // See ext-01 §1 (w3c/webextensions#604).
+    web_accessible_resources: [
+      {
+        resources: ['blocked.html'],
+        matches: ['<all_urls>'],
+      },
+    ],
+    action: {
+      default_title: 'Nudge',
+    },
+  },
+});

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -6,6 +6,13 @@ import { defineConfig } from 'wxt';
 export default defineConfig({
   srcDir: 'src',
   modules: ['@wxt-dev/module-react'],
+  // Extension pages load from disk, so modulepreload buys nothing — and Chrome logs a
+  // "cross-world extension resource mismatch" warning for every preloaded chunk, ~6 per page.
+  // A clean console is part of a zero-telemetry product's trust story; better to drop the
+  // useless hints than to teach users that warnings here are normal.
+  vite: () => ({
+    build: { modulePreload: false },
+  }),
   manifest: {
     name: 'Nudge — Website Blocker, Screen Time & Shorts Blocker',
     description:


### PR DESCRIPTION
MVP of **Nudge for Chrome**, the MV3 sibling of the Android app. Free, GPL-3.0, no account, **zero telemetry, zero network requests**. Lives in a new `extension/` directory; the Android app is untouched.

Built to `ext-07` (PRD) and `ext-08` (architecture); MV3 recipes from `ext-01`, YouTube from `ext-03`, Android semantics from `ext-05`.

## What's in it

All 12 MVP items: three block modes (**Hard Block / Delay / Breathing**), temporary access after a completed pause, **Daily Time Limit** with midnight reset and a mid-browsing flip, **Scheduled Override** (incl. overnight spans), local-only usage stats, YouTube Shorts rule, **Commitment Lock** (Strict Mode), **Escape Hatch** (daily 2-minute pass), custom block messages, popup + dashboard + block page, onboarding, and JSON export/import.

`src/core/` is pure TypeScript with **zero `chrome.*` imports**, a direct port of the Android pure-Kotlin domain layer *and its test intent* (`BlockEngine`, `ScheduleEvaluator`, `WebDomainMatcher`, `StrictModeChallenge`, `RuleWeakening`, `EmergencyPass`, `StatsCalculator`). That's what keeps the engine exhaustively unit-testable, exactly as on Android.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm test` | **400 passing, 15 files** |
| `npm run build` | loadable `.output/chrome-mv3`, manifest + SW verified |
| `npm run e2e` | **19/19 passing** |

E2E drives a **real Chrome with the extension loaded**. To give it real hostnames with no network, it maps `*.test` onto a local server via `--host-resolver-rules`, so DNR sees ordinary navigations. It covers the block redirect, subdomain matching, master toggle, delay → temp allow → **real alarm expiry** → re-block, breathing, walked-away, budget escalation, the mid-browsing budget flip of an already-open tab, scheduled override (in / out / disabled), Strict Mode gating a weakening change while never gating a strengthening one, and the single-use daily pass.

## Three real bugs caught and fixed

1. **`URLSearchParams` truncated the blocked URL.** `regexSubstitution` cannot percent-encode, so the target arrives verbatim and routinely contains its own `?`/`&`. `watch?v=abc&t=30` was being read as `watch?v=abc`, users would land on the wrong page after completing a pause. Now slices after the marker; regression tests cover the whole class (own query, `#fragment`, literal `%XX`).
2. **React hooks after an early return** in `DelayView`/`BreathingView` (found by `rules-of-hooks`). The fix needed an `enabled` flag on `useCompleteOnZero`, because a disarmed view has a zero-length countdown and `remaining === 0` would otherwise complete the pause instantly and **grant real access**.
3. **`'INHERIT'` isn't a `BlockMode`**, so it couldn't be a `coerceMode` fallback, flagged independently by two test lanes.

## CI

New `extension-ci.yml` (lint → typecheck → unit → build → Playwright under xvfb), scoped `paths: ['extension/**']`.

`release.yml` gains the mirror-image `paths-ignore: ['extension/**']` so extension commits stop rebuilding the Android app. **Verified before touching it:** GitHub does not evaluate path filters for *tag* pushes, so the `v*` Android release flow is unaffected. No `ext-v*` tag has been created.

## Reviewer notes

- **Known gap:** a rule always blocks in *some* mode, there's no "allow by default, block only during the window" schedule. Outside a Scheduled Override the rule's own Default Behavior applies. This is faithful to Android, but "block only during work hours" isn't expressible yet; likely the first follow-up.
- Strict Mode can't stop removal from `chrome://extensions`, and the dashboard **says so plainly** rather than pretending, honesty is the differentiator.
- YouTube fixtures are hand-authored from the ext-03 taxonomy, not live DOM captures; refresh from real DOM when possible.
- `extension/CLAUDE.md` carries dev/build/test commands, load-unpacked steps, the architecture map, release process, and a lessons section.

Draft on purpose, the orchestrator QA-gates the merge.
