### PR TITLE
feat(ext): YouTube channel lists, gray-screen mode, Unhook-parity toggles

### DIFF
--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -94,6 +94,13 @@ unit-testable, exactly as the Android domain layer is.
 - **Channel identification is three-tier** (ext-03 §3): `ytInitialPlayerResponse.videoDetails`
   first, then an `ytInitialData` brace-counting scan, then a DOM selector chain. YouTube
   ships different shapes on different surfaces, so one path is not enough.
+- **THE INLINE TIERS GO STALE ON SPA NAVIGATION.** YouTube does not rewrite
+  `ytInitialPlayerResponse` / `ytInitialData` on a watch -> watch client-side hop, so they
+  keep describing whatever video was last FULL-loaded. The fast tier is therefore the
+  *stalest* one during normal browsing. Both inline tiers must prove they describe the
+  current video (their declared videoId === the URL's `v`); a tier that declares a different
+  id, or none at all, is skipped in favour of the DOM byline, which YouTube really does
+  re-render. Live QA caught this bypassing the whitelist, blacklist AND gray-screen at once.
 - **The decision is pure and separate from the DOM.** `core/channels.ts` answers "what does
   this channel mean" with no DOM at all; `content/channelFilter.ts` only applies the answer.
   That split is what let the full mode x listed x unknown matrix be tested exhaustively.
@@ -105,6 +112,17 @@ unit-testable, exactly as the Android domain layer is.
   unidentified channel never earns colour, because staying gray is harmless.
 - **Feed cards are matched per-card.** The channel chain is run SCOPED to each card; an
   unscoped query returns the first channel on the page for every card.
+- **A selector match that yields nothing is a MISS, not an answer.** `channelFromDom`
+  iterates every rung and every match until one produces an identifier, skipping hrefless
+  placeholder anchors, taking `elements[0]` of the first matching rung let a hidden empty
+  anchor on search results mask the real `/@handle` link and leak the whitelist.
+- **Some selector chains are ladders, some are lists.** A chain is normally alternatives
+  for ONE element (first match wins), but a few surfaces are genuinely several elements
+  shown together, the end-screen grid and the creator end-cards coexist, so those carry
+  `matchAll: true`. Getting this wrong hides one and leaves the other on screen.
+- **The fail-open is observable.** When some cards resolve and others do not, the content
+  script logs a one-shot warning naming the count, so YouTube DOM churn shows up in
+  devtools rather than silently degrading channel filtering into a no-op.
 
 #### Gray-screen: the mechanism and its flash behaviour
 

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -101,6 +101,21 @@ unit-testable, exactly as the Android domain layer is.
   current video (their declared videoId === the URL's `v`); a tier that declares a different
   id, or none at all, is skipped in favour of the DOM byline, which YouTube really does
   re-render. Live QA caught this bypassing the whitelist, blacklist AND gray-screen at once.
+- **THE BYLINE ITSELF LAGS TOO, hence the settle window.** Fixing the permanent bypass left
+  a transient one: `yt-navigate-finish` fires BEFORE YouTube re-renders the owner byline, so
+  for ~1.5-5s even the DOM tier reports the previous video's channel. The forward direction
+  (allowed -> blocked) is a couple of ungated seconds; the REVERSE (blocked -> allowed) was
+  far worse, a channel the user explicitly allowed was accused of being "off your list" for
+  3-5s. Punishing someone for watching what they said they wanted is the most damaging thing
+  this extension can do. `core/channelFreshness.ts` resolves it with a cheap discriminator:
+  staleness only MATTERS while the byline still names the channel from before the hop, so
+  detection is CONFIRMED the moment it differs (or the inline data is authoritative, or a
+  6s backstop elapses) and SETTLING until then. While settling we withhold the interstitial
+  and stay gray, both fail-safe directions.
+- **A debounce can be STARVED.** The corrective re-check was losing to YouTube's
+  post-navigation mutation storm, which kept resetting the 250ms debounce, that starvation
+  is what stretched the window to 5s. Anything that MUST happen after an event needs its own
+  timer that page activity cannot reset (`SETTLE_RECHECK_MS`), not just a debounced observer.
 - **The decision is pure and separate from the DOM.** `core/channels.ts` answers "what does
   this channel mean" with no DOM at all; `content/channelFilter.ts` only applies the answer.
   That split is what let the full mode x listed x unknown matrix be tested exhaustively.

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -55,10 +55,13 @@ src/
     strictMode.ts       <- domain/lock/StrictModeChallenge.kt + RuleWeakening.kt
     emergencyPass.ts    <- domain/emergency/EmergencyPass.kt
     stats.ts            <- ui/screens/stats/StatsCalculator.kt
+    channels.ts         (channel-list decision matrix; pure, no DOM)
     budgets.ts, messages.ts, ruleResolver.ts
   background/   The service worker: dnr, tracker, tempAllow, alarmsHub, badge,
                 messagesRouter, storage.
-  content/      YouTube: selectors.ts (ALL selectors), youtube.ts, youtube.css
+  content/      YouTube: selectors.ts (ALL selectors), youtube.ts, youtube.css,
+                channelDetection.ts (3-tier channel identification), channelFilter.ts
+                (feed filtering + watch gate + colour flip), unhook.ts (hide toggles)
   entrypoints/  WXT entrypoints: background, blocked/, popup/, dashboard/, onboarding/,
                 youtube.content.ts
   ui/           Shared React primitives + design tokens + typed rpc wrapper
@@ -85,6 +88,47 @@ unit-testable, exactly as the Android domain layer is.
 5. YouTube SPA navigation is invisible to DNR, so `content/youtube.ts` handles in-page
    Shorts with 3-layer nav detection (`yt-navigate-finish` + `popstate` + debounced
    observer).
+
+### Channel lists, gray-screen and the hide toggles (v1.1)
+
+- **Channel identification is three-tier** (ext-03 §3): `ytInitialPlayerResponse.videoDetails`
+  first, then an `ytInitialData` brace-counting scan, then a DOM selector chain. YouTube
+  ships different shapes on different surfaces, so one path is not enough.
+- **The decision is pure and separate from the DOM.** `core/channels.ts` answers "what does
+  this channel mean" with no DOM at all; `content/channelFilter.ts` only applies the answer.
+  That split is what let the full mode x listed x unknown matrix be tested exhaustively.
+- **The unknown-channel case FAILS OPEN, deliberately and observably.** If detection fails
+  (YouTube moved its DOM, the page hasn't hydrated), a hard whitelist that failed *shut*
+  would block ALL of YouTube the moment a selector rots. So an unidentified channel is
+  allowed, but with a distinct `reason: 'unknown-channel'`, so "we checked and it's fine" is
+  always distinguishable from "we couldn't tell". Gray-screen takes the OPPOSITE bias: an
+  unidentified channel never earns colour, because staying gray is harmless.
+- **Feed cards are matched per-card.** The channel chain is run SCOPED to each card; an
+  unscoped query returns the first channel on the page for every card.
+
+#### Gray-screen: the mechanism and its flash behaviour
+
+The requirement is contradictory on its face, the CSS must be *gateable* (off when the
+feature is off) AND applied *before first paint* (or the page flashes in full colour, which
+is exactly the hit the feature exists to remove). Neither obvious option delivers both:
+
+| Approach | Gateable? | Flash-free? |
+|---|---|---|
+| Static `content_scripts.css` in the manifest | No, always on | Yes |
+| CSS injected from JS after a storage read | Yes | No, paints in colour first |
+| **Dynamic `chrome.scripting.registerContentScripts` with `css`** | **Yes** | **Yes** |
+
+We use the third. The service worker registers `public/grayscale.css` while the feature is on
+and unregisters it when off; Chrome injects registered CSS "before any DOM is constructed or
+displayed" (verified in the `chrome.scripting` reference). Registration is re-derived from
+settings on every worker wake, because `persistAcrossSessions` defaults to true and a stale
+registration would otherwise outlive the setting that asked for it.
+
+**The one flash that remains, and why it is the right one:** going gray -> COLOUR flickers
+once, after the channel check resolves, on an *allowed* channel. That direction is
+unavoidable (we cannot know the channel before the page exists) and is the correct trade: a
+brief gray frame on a video you're allowed to watch is a far better failure than a colour
+frame on every video you are trying not to be pulled into.
 
 ## Non-negotiables
 
@@ -133,6 +177,20 @@ xvfb), scoped with `paths: ['extension/**']`. The Android workflow carries the m
 - **Return `true` from the `onMessage` listener** to keep the channel open for an async
   response, and always send *something* — otherwise callers hang forever.
 - **Gate settings changes in the WORKER, not the UI.** A gate a page can skip is not a gate.
+- **`chrome.scripting.registerContentScripts` accepts `css` and injects it before first
+  paint.** That is the only way to have CSS that is BOTH runtime-gateable and flash-free;
+  static manifest CSS cannot be turned off and JS-injected CSS is always too late.
+- **A hard whitelist must fail OPEN.** Whatever identifies the thing being filtered can
+  break; if 'unidentified' means 'blocked', one rotted selector blocks the entire site.
+  Fail open, but carry a distinct reason so the fail-open is observable rather than silent.
+- **e2e can drive the YouTube content script with no network**: map `*.youtube.com` onto
+  the local fixture server too. It MUST be served over HTTPS, youtube.com is in Chrome's
+  HSTS preload list, so `http://` is force-upgraded before the resolver rule applies and a
+  plain-HTTP server answers ERR_SSL_PROTOCOL_ERROR. The fixture generates a throwaway
+  self-signed cert per run (never committed) and Chrome runs with --ignore-certificate-errors.
+- **Each hiding feature owns its own CSS class.** Shorts hiding, the Unhook toggles and the
+  channel filter use three different classes: with one shared class, turning any of them
+  off would un-hide the others' elements.
 - **ENGINE INVARIANT: if any rule applies, the verdict is a BLOCK.** ALLOW means "no rule
   applies here" and nothing else. DNR has already redirected by the time the engine runs, so
   an ALLOW while a rule still applies is not a harmless no-op — it bounces the user back to
@@ -180,5 +238,11 @@ xvfb), scoped with `paths: ['extension/**']`. The Android workflow carries the m
   rather than pretending; honesty is the differentiator (ext-02).
 - YouTube fixtures in `tests/content/fixtures/` are hand-authored from the ext-03 taxonomy,
   not live DOM captures. Refresh them from real YouTube DOM when possible.
-- v1.1 scope (channel whitelist/blacklist, gray-screen mode, Instagram/TikTok/X surfaces) is
-  specified in the PRD but not built.
+- Instagram / TikTok / X reel surfaces are specified in the PRD's v1.1 section but NOT built
+, this phase covered the YouTube half only.
+- **Disabling autoplay is best-effort.** There is no API for it, so we click the player's
+  own switch when it reads `aria-checked="true"`. YouTube re-renders the player and can
+  restore its own state, so it is re-applied on every SPA navigation and is not a guarantee.
+  The dashboard says so plainly rather than implying certainty.
+- Channel detection depends on YouTube's `ytInitialPlayerResponse` / `ytInitialData` shapes.
+  Fixture tests cover the documented shapes, but they are hand-authored, not live captures.

--- a/extension/e2e/blocking.spec.ts
+++ b/extension/e2e/blocking.spec.ts
@@ -21,7 +21,7 @@ test.describe('site blocking', () => {
     await page.goto(siteUrl('blocked.test'));
 
     // The DNR redirect must carry the original URL through to the block page.
-    await expect(page).toHaveURL(/blocked\.html\?target=http:\/\/blocked\.test\//);
+    await expect(page).toHaveURL(/blocked\.html\?target=https:\/\/blocked\.test\//);
     await expect(page.getByRole('button', { name: /go back/i })).toBeVisible();
   });
 

--- a/extension/e2e/fixtures.ts
+++ b/extension/e2e/fixtures.ts
@@ -49,18 +49,33 @@ const SETTINGS_KEY = 'nudge:settings';
 function youtubePage(url: URL): string {
   const channelId = url.searchParams.get('channel') ?? '';
   const name = url.searchParams.get('name') ?? 'Test Channel';
+  const videoId = url.searchParams.get('v') ?? '';
+  // `staleVideo` reproduces the SPA case: inline JSON pinned to a DIFFERENT video than the
+  // URL names, which is what YouTube actually serves after a client-side navigation.
+  const inlineVideoId = url.searchParams.get('staleVideo') ?? videoId;
+
   const playerResponse =
     channelId === ''
       ? ''
       : `<script>var ytInitialPlayerResponse = ${JSON.stringify({
-          videoDetails: { channelId, author: name, title: 'A video' },
+          videoDetails: { videoId: inlineVideoId, channelId, author: name, title: 'A video' },
         })};</script>`;
+
+  // A real watch page also carries a channel byline in the DOM, which YouTube re-renders on
+  // every navigation, that is the tier the staleness guard falls through to.
+  const domChannelId = url.searchParams.get('domChannel') ?? channelId;
+  const byline =
+    domChannelId === ''
+      ? ''
+      : `<ytd-channel-name id="channel-name"><a class="yt-formatted-string" ` +
+        `href="/channel/${domChannelId}" aria-label="Go to channel ${name}">${name}</a>` +
+        `</ytd-channel-name>`;
 
   return (
     `<!doctype html><html><head><title>${name} - YouTube</title></head><body>` +
     `<h1 id="host">www.youtube.com</h1><p id="path">${url.pathname}${url.search}</p>` +
     playerResponse +
-    `<ytd-watch-flexy><div id="primary"><video id="player"></video></div>` +
+    `<ytd-watch-flexy><div id="primary"><video id="player"></video>${byline}</div>` +
     `<div id="secondary"><div id="related">recommendations</div></div></ytd-watch-flexy>` +
     `<div id="comments"><div id="contents">comments</div></div>` +
     `</body></html>`
@@ -73,7 +88,7 @@ function youtubePage(url: URL): string {
  * Needed because youtube.com is in Chrome's HSTS PRELOAD list: `http://www.youtube.com/` is
  * force-upgraded to HTTPS before it ever reaches our resolver rule, so a plain-HTTP fixture
  * server answers with ERR_SSL_PROTOCOL_ERROR. Generated per-run into a temp dir rather than
- * committed, a private key in a public repo is a bad habit even when it is worthless, and
+ * committed - a private key in a public repo is a bad habit even when it is worthless - and
  * Chrome is launched with --ignore-certificate-errors so the cert never has to be trusted.
  */
 function generateSelfSignedCert(): { key: Buffer; cert: Buffer } {
@@ -86,7 +101,8 @@ function generateSelfSignedCert(): { key: Buffer; cert: Buffer } {
       '-out', `${dir}/cert.pem`,
       '-days', '1',
       '-subj', '/CN=localhost',
-      '-addext', 'subjectAltName=DNS:localhost,DNS:*.youtube.com,DNS:youtube.com,DNS:*.test,IP:127.0.0.1',
+      '-addext',
+      'subjectAltName=DNS:localhost,DNS:*.youtube.com,DNS:youtube.com,DNS:*.test,IP:127.0.0.1',
     ],
     { stdio: 'ignore' },
   );

--- a/extension/e2e/fixtures.ts
+++ b/extension/e2e/fixtures.ts
@@ -15,7 +15,11 @@
  *    exactly as it would see youtube.com.
  */
 
-import { createServer, type Server } from 'node:http';
+import { execFileSync } from 'node:child_process';
+import type { Server } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import type { AddressInfo } from 'node:net';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,10 +38,73 @@ export const EXTENSION_PATH = path.resolve(here, '../.output/chrome-mv3');
 /** The storage key the extension persists settings under (see background/storage.ts). */
 const SETTINGS_KEY = 'nudge:settings';
 
+/**
+ * A YouTube-shaped page, served for the mapped youtube.com host.
+ *
+ * `?channel=UCxxxx&name=Foo` embeds a real `ytInitialPlayerResponse` so the extension's
+ * own detection runs against the shape it expects, this is what lets the channel features
+ * be tested end to end (real content script, real registered CSS, real service worker) with
+ * no network access at all.
+ */
+function youtubePage(url: URL): string {
+  const channelId = url.searchParams.get('channel') ?? '';
+  const name = url.searchParams.get('name') ?? 'Test Channel';
+  const playerResponse =
+    channelId === ''
+      ? ''
+      : `<script>var ytInitialPlayerResponse = ${JSON.stringify({
+          videoDetails: { channelId, author: name, title: 'A video' },
+        })};</script>`;
+
+  return (
+    `<!doctype html><html><head><title>${name} - YouTube</title></head><body>` +
+    `<h1 id="host">www.youtube.com</h1><p id="path">${url.pathname}${url.search}</p>` +
+    playerResponse +
+    `<ytd-watch-flexy><div id="primary"><video id="player"></video></div>` +
+    `<div id="secondary"><div id="related">recommendations</div></div></ytd-watch-flexy>` +
+    `<div id="comments"><div id="contents">comments</div></div>` +
+    `</body></html>`
+  );
+}
+
+/**
+ * A throwaway self-signed cert for the test server.
+ *
+ * Needed because youtube.com is in Chrome's HSTS PRELOAD list: `http://www.youtube.com/` is
+ * force-upgraded to HTTPS before it ever reaches our resolver rule, so a plain-HTTP fixture
+ * server answers with ERR_SSL_PROTOCOL_ERROR. Generated per-run into a temp dir rather than
+ * committed, a private key in a public repo is a bad habit even when it is worthless, and
+ * Chrome is launched with --ignore-certificate-errors so the cert never has to be trusted.
+ */
+function generateSelfSignedCert(): { key: Buffer; cert: Buffer } {
+  const dir = mkdtempSync(`${tmpdir()}/nudge-e2e-cert-`);
+  execFileSync(
+    'openssl',
+    [
+      'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+      '-keyout', `${dir}/key.pem`,
+      '-out', `${dir}/cert.pem`,
+      '-days', '1',
+      '-subj', '/CN=localhost',
+      '-addext', 'subjectAltName=DNS:localhost,DNS:*.youtube.com,DNS:youtube.com,DNS:*.test,IP:127.0.0.1',
+    ],
+    { stdio: 'ignore' },
+  );
+  return { key: readFileSync(`${dir}/key.pem`), cert: readFileSync(`${dir}/cert.pem`) };
+}
+
 function startTestServer(): Promise<Server> {
-  const server = createServer((req, res) => {
+  const { key, cert } = generateSelfSignedCert();
+  const server = createHttpsServer({ key, cert }, (req, res) => {
     const host = (req.headers.host ?? 'unknown').split(':')[0]!;
+    const url = new URL(req.url ?? '/', `http://${host}`);
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+
+    if (host.endsWith('youtube.com')) {
+      res.end(youtubePage(url));
+      return;
+    }
+
     res.end(
       `<!doctype html><html><head><title>${host}</title></head>` +
         `<body><h1 id="host">${host}</h1><p id="path">${req.url}</p></body></html>`,
@@ -86,7 +153,9 @@ export const test = base.extend<ExtensionFixtures>({
         `--load-extension=${EXTENSION_PATH}`,
         // Any *.test hostname resolves to the local server, so page URLs stay clean
         // (`http://blocked.test/`) and domain matching is realistic.
-        `--host-resolver-rules=MAP *.test 127.0.0.1:${port}`,
+        // youtube.com is mapped too, so the YouTube content script (which only matches
+        // *.youtube.com) runs for real against a YouTube-shaped page, still zero network.
+        `--host-resolver-rules=MAP *.test 127.0.0.1:${port}, MAP *.youtube.com 127.0.0.1:${port}`,
         // Keep each browser's footprint small. The suite launches one persistent context
         // per test, and on a developer machine that is competing with a real browser for
         // memory; a bloated test browser gets OOM-killed and surfaces as the confusing
@@ -97,6 +166,8 @@ export const test = base.extend<ExtensionFixtures>({
         '--disable-features=Translate,MediaRouter,OptimizationHints',
         '--no-first-run',
         '--no-default-browser-check',
+        // The fixture server presents a throwaway self-signed cert (see above).
+        '--ignore-certificate-errors',
       ],
     });
 
@@ -120,7 +191,7 @@ export const test = base.extend<ExtensionFixtures>({
 
   siteUrl: async ({ context }, use) => {
     void context;
-    await use((host: string, pathname = '/') => `http://${host}${pathname}`);
+    await use((host: string, pathname = '/') => `https://${host}${pathname}`);
   },
 
   setSettings: async ({ serviceWorker }, use) => {

--- a/extension/e2e/fixtures.ts
+++ b/extension/e2e/fixtures.ts
@@ -25,6 +25,7 @@ import {
   type BrowserContext,
   type Worker,
 } from '@playwright/test';
+import { DEFAULT_SETTINGS, SCHEMA_VERSION } from '../src/core/settingsSchema';
 import type { NudgeSettings, SiteRule } from '../src/core/settingsSchema';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -252,14 +253,15 @@ export async function sendFromExtensionPage<T>(
 /** A minimal valid settings object for tests to spread over. */
 export function baseSettings(overrides: Partial<NudgeSettings> = {}): Partial<NudgeSettings> {
   return {
-    schemaVersion: 1,
+    schemaVersion: SCHEMA_VERSION,
     globalEnabled: true,
     onboardingComplete: true,
     rules: [],
     messages: { delayTitles: [], delaySubtitles: [], hardBlockMessages: [] },
     strictMode: { enabled: false, challengeLength: 24 },
     emergencyPass: { enabled: true },
-    youtube: { shortsMode: 'INHERIT', hideShortsShelf: false, shortsDelaySeconds: 15 },
+    // Spread the REAL defaults so adding a settings field never breaks the whole suite.
+    youtube: { ...DEFAULT_SETTINGS.youtube },
     tempAllowMinutes: 10,
     ...overrides,
   };

--- a/extension/e2e/redirectLoop.spec.ts
+++ b/extension/e2e/redirectLoop.spec.ts
@@ -43,7 +43,7 @@ test.describe('Hard Block + Daily Time Limit (redirect-loop regression)', () => 
     // Settled: the block page stayed put rather than bouncing back to the site.
     expect(navigations).toBe(afterLoad);
     await expect(page).toHaveURL(/blocked\.html\?target=/);
-    expect(page.url()).not.toMatch(/^http:\/\/blocked\.test/);
+    expect(page.url()).not.toMatch(/^https?:\/\/blocked\.test/);
   });
 
   test('under budget it is a plain Hard Block, not a "limit reached" block', async ({

--- a/extension/e2e/youtubeAdvanced.spec.ts
+++ b/extension/e2e/youtubeAdvanced.spec.ts
@@ -1,0 +1,172 @@
+import { baseSettings, expect, test } from './fixtures';
+import type { ChannelEntry, NudgeSettings } from '../src/core/settingsSchema';
+
+/**
+ * Phase 4 end to end, against a REAL Chrome with the extension loaded.
+ *
+ * `*.youtube.com` is mapped onto the local test server (see fixtures.ts), so the actual
+ * YouTube content script — the one that only matches `*://*.youtube.com/*` — runs against a
+ * YouTube-shaped page carrying a real `ytInitialPlayerResponse`, with no network access.
+ * That means channel detection, the gate, and the dynamically-registered grayscale CSS are
+ * all exercised for real rather than simulated.
+ */
+
+const ALLOWED = 'UCallowedchannel0000001';
+const OTHER = 'UCotherchannel000000002';
+
+function channel(channelId: string, displayName: string): ChannelEntry {
+  return { channelId, handle: null, displayName, addedAt: 0 };
+}
+
+function watchUrl(channelId: string, name: string): string {
+  return `https://www.youtube.com/watch?v=abc&channel=${channelId}&name=${encodeURIComponent(name)}`;
+}
+
+function withYoutube(overrides: Partial<NudgeSettings['youtube']>): Partial<NudgeSettings> {
+  const base = baseSettings();
+  return { ...base, youtube: { ...base.youtube!, ...overrides } };
+}
+
+test.describe('YouTube channel lists', () => {
+  test('a video from a channel that is not on the allow list is interrupted', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(
+      withYoutube({
+        channelMode: 'WHITELIST',
+        channels: [channel(ALLOWED, 'Allowed Channel')],
+        channelBlockMode: 'HARD_BLOCK',
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+
+    await expect(page.getByText('This channel is off your list')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByRole('button', { name: 'I changed my mind' })).toBeVisible();
+  });
+
+  test('a video from a channel on the allow list plays without interruption', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(
+      withYoutube({
+        channelMode: 'WHITELIST',
+        channels: [channel(ALLOWED, 'Allowed Channel')],
+        channelBlockMode: 'HARD_BLOCK',
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(ALLOWED, 'Allowed Channel'));
+    // Give the content script the same window it would have had to interrupt.
+    await page.waitForTimeout(3_000);
+
+    await expect(page.getByText('This channel is off your list')).toHaveCount(0);
+  });
+
+  test('with channel lists off, nothing is interrupted', async ({ context, setSettings }) => {
+    await setSettings(withYoutube({ channelMode: 'OFF' }));
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+    await page.waitForTimeout(3_000);
+
+    await expect(page.getByText('This channel is off your list')).toHaveCount(0);
+  });
+});
+
+test.describe('gray-screen mode', () => {
+  test('turns YouTube grayscale, and only whitelisted channels come back in colour', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(
+      withYoutube({
+        grayScreen: true,
+        channelMode: 'WHITELIST',
+        channels: [channel(ALLOWED, 'Allowed Channel')],
+        // Not blocking, so the page stays readable and we are testing colour alone.
+        channelBlockMode: 'DELAY',
+      }),
+    );
+
+    // A channel NOT on the list stays gray. Assert the COMPUTED style, which is what the
+    // user actually sees — that also proves the dynamically-registered CSS really loaded.
+    const gray = await context.newPage();
+    await gray.goto(watchUrl(OTHER, 'Some Other Channel'));
+    await expect
+      .poll(
+        () => gray.evaluate(() => getComputedStyle(document.documentElement).filter),
+        { timeout: 15_000 },
+      )
+      .toContain('grayscale');
+    await gray.close();
+
+    // A channel ON the list is restored to full colour.
+    const color = await context.newPage();
+    await color.goto(watchUrl(ALLOWED, 'Allowed Channel'));
+    await expect
+      .poll(
+        () => color.evaluate(() => getComputedStyle(document.documentElement).filter),
+        { timeout: 15_000 },
+      )
+      .toBe('none');
+  });
+
+  test('with gray-screen off, YouTube is never greyed', async ({ context, setSettings }) => {
+    await setSettings(withYoutube({ grayScreen: false, channelMode: 'OFF' }));
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+    await page.waitForTimeout(2_000);
+
+    const filter = await page.evaluate(
+      () => getComputedStyle(document.documentElement).filter,
+    );
+    expect(filter).toBe('none');
+  });
+});
+
+test.describe('Unhook-parity hide toggles', () => {
+  test('hiding comments removes them and leaves the recommendations alone', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(withYoutube({ hideComments: true, hideSidebarRecs: false }));
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+
+    await expect(page.locator('#comments #contents')).toBeHidden({ timeout: 15_000 });
+    await expect(page.locator('#related')).toBeVisible();
+  });
+
+  test('hiding recommendations removes them and leaves the comments alone', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(withYoutube({ hideSidebarRecs: true, hideComments: false }));
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+
+    await expect(page.locator('#related')).toBeHidden({ timeout: 15_000 });
+    await expect(page.locator('#comments #contents')).toBeVisible();
+  });
+
+  test('with every toggle off, the page is untouched', async ({ context, setSettings }) => {
+    await setSettings(withYoutube({ hideComments: false, hideSidebarRecs: false }));
+
+    const page = await context.newPage();
+    await page.goto(watchUrl(OTHER, 'Some Other Channel'));
+    await page.waitForTimeout(2_000);
+
+    await expect(page.locator('#comments #contents')).toBeVisible();
+    await expect(page.locator('#related')).toBeVisible();
+  });
+});

--- a/extension/e2e/youtubeAdvanced.spec.ts
+++ b/extension/e2e/youtubeAdvanced.spec.ts
@@ -1,4 +1,5 @@
 import { baseSettings, expect, test } from './fixtures';
+import type { Page } from '@playwright/test';
 import type { ChannelEntry, NudgeSettings } from '../src/core/settingsSchema';
 
 /**
@@ -168,5 +169,105 @@ test.describe('Unhook-parity hide toggles', () => {
 
     await expect(page.locator('#comments #contents')).toBeVisible();
     await expect(page.locator('#related')).toBeVisible();
+  });
+});
+
+test.describe('SPA navigation between videos (staleness regression)', () => {
+  /**
+   * THE EXACT LIVE FAILURE (QA, 2026-07-26). YouTube does not rewrite its inline scripts on
+   * a watch -> watch client-side navigation, so after hopping from an allowed video to a
+   * disallowed one the page still carries JSON describing the ALLOWED one. Trusting it meant
+   * the disallowed video played with no gate and in full colour.
+   *
+   * Reproduced here faithfully: load an allowed video normally, then pushState to a
+   * disallowed video whose inline data is STILL pinned to the first one (`staleVideo`),
+   * re-render the byline the way YouTube does, and fire `yt-navigate-finish`.
+   */
+  const FIRST_VIDEO = 'firstvideo0001';
+  const SECOND_VIDEO = 'secondvideo002';
+
+  async function spaNavigate(
+    page: Page,
+    toUrl: string,
+    freshChannelId: string,
+  ): Promise<void> {
+    await page.evaluate(
+      ([url, channelId]) => {
+        history.pushState({}, '', url);
+        // YouTube re-renders the byline on navigation; the inline <script> is left alone.
+        const anchor = document.querySelector('#channel-name a');
+        if (anchor !== null) anchor.setAttribute('href', `/channel/${channelId}`);
+        document.dispatchEvent(new CustomEvent('yt-navigate-finish'));
+      },
+      [toUrl, freshChannelId] as const,
+    );
+  }
+
+  test('gates the new video even though the inline data still describes the old one', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(
+      withYoutube({
+        channelMode: 'WHITELIST',
+        channels: [channel(ALLOWED, 'Allowed Channel')],
+        channelBlockMode: 'HARD_BLOCK',
+      }),
+    );
+
+    const page = await context.newPage();
+    // Full load of an ALLOWED video, no gate, as established elsewhere.
+    await page.goto(
+      `https://www.youtube.com/watch?v=${FIRST_VIDEO}&channel=${ALLOWED}&name=Allowed%20Channel`,
+    );
+    await page.waitForTimeout(1_500);
+    await expect(page.getByText('This channel is off your list')).toHaveCount(0);
+
+    // SPA-hop to a DISALLOWED video whose inline JSON is still pinned to the first video.
+    await spaNavigate(
+      page,
+      `/watch?v=${SECOND_VIDEO}&channel=${ALLOWED}&name=Allowed%20Channel&staleVideo=${FIRST_VIDEO}&domChannel=${OTHER}`,
+      OTHER,
+    );
+
+    await expect(page.getByText('This channel is off your list')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('does not grant colour to the new video on the strength of the old one', async ({
+    context,
+    setSettings,
+  }) => {
+    await setSettings(
+      withYoutube({
+        grayScreen: true,
+        channelMode: 'WHITELIST',
+        channels: [channel(ALLOWED, 'Allowed Channel')],
+        channelBlockMode: 'DELAY',
+      }),
+    );
+
+    const page = await context.newPage();
+    await page.goto(
+      `https://www.youtube.com/watch?v=${FIRST_VIDEO}&channel=${ALLOWED}&name=Allowed%20Channel`,
+    );
+    await expect
+      .poll(() => page.evaluate(() => getComputedStyle(document.documentElement).filter), {
+        timeout: 15_000,
+      })
+      .toBe('none');
+
+    await spaNavigate(
+      page,
+      `/watch?v=${SECOND_VIDEO}&channel=${ALLOWED}&name=Allowed%20Channel&staleVideo=${FIRST_VIDEO}&domChannel=${OTHER}`,
+      OTHER,
+    );
+
+    await expect
+      .poll(() => page.evaluate(() => getComputedStyle(document.documentElement).filter), {
+        timeout: 15_000,
+      })
+      .toContain('grayscale');
   });
 });

--- a/extension/eslint.config.js
+++ b/extension/eslint.config.js
@@ -12,6 +12,9 @@ export default tseslint.config(
       'coverage/**',
       'playwright-report/**',
       'test-results/**',
+      // Scratch tooling the QA agent drops into this directory during live runs.
+      // Untracked and never shipped, but it would otherwise fail the local lint gate.
+      '.qa-*',
     ],
   },
   js.configs.recommended,

--- a/extension/public/grayscale.css
+++ b/extension/public/grayscale.css
@@ -1,0 +1,27 @@
+/*
+ * Gray-screen mode.
+ *
+ * NOT listed in the manifest. The service worker registers this file as a DYNAMIC content
+ * script (chrome.scripting.registerContentScripts) only while the feature is on, and
+ * unregisters it when off. That is what makes the feature gateable with ZERO colour flash:
+ * the docs guarantee registered CSS is injected "before any DOM is constructed or displayed",
+ * whereas a manifest entry is static (always on) and anything JS-driven has to wait for an
+ * async storage read and therefore paints in colour first.
+ *
+ * See src/background/grayscale.ts and the CLAUDE.md note on the flash tradeoff.
+ */
+
+html {
+  filter: grayscale(1) !important;
+}
+
+/*
+ * The colour reward. src/content/youtube.ts adds this class once it has confirmed the
+ * current channel is one the user allowed. Going gray -> colour therefore flashes once,
+ * after the channel check resolves; that direction is unavoidable and deliberate — a brief
+ * gray frame on an allowed video is a far better failure than a colour frame on every
+ * video the user is trying not to be pulled into.
+ */
+html.nudge-color {
+  filter: none !important;
+}

--- a/extension/src/background/grayscale.ts
+++ b/extension/src/background/grayscale.ts
@@ -1,0 +1,65 @@
+/**
+ * Gray-screen mode's registration side.
+ *
+ * The problem: static manifest CSS cannot be turned off, and CSS injected from JS cannot be
+ * applied before the page paints (it has to await a storage read first), so a JS-gated
+ * grayscale flashes the page in full colour on every load — exactly the dopamine hit the
+ * feature exists to remove.
+ *
+ * The solution: register `grayscale.css` as a DYNAMIC content script while the feature is
+ * on and unregister it when off. Chrome injects registered CSS "before any DOM is
+ * constructed or displayed" (chrome.scripting docs), so there is no colour frame at all.
+ *
+ * Registration is derived from settings on every worker wake rather than toggled
+ * incrementally: `persistAcrossSessions` defaults to true, so a stale registration would
+ * otherwise outlive the setting that asked for it and grey YouTube out for a user who had
+ * turned the feature off.
+ */
+
+export const GRAYSCALE_SCRIPT_ID = 'nudge-grayscale';
+const GRAYSCALE_CSS = 'grayscale.css';
+const YOUTUBE_MATCHES = ['*://*.youtube.com/*'];
+
+async function isRegistered(): Promise<boolean> {
+  try {
+    const existing = await chrome.scripting.getRegisteredContentScripts({
+      ids: [GRAYSCALE_SCRIPT_ID],
+    });
+    return existing.length > 0;
+  } catch {
+    // A filter for an unknown id throws on some Chrome versions rather than returning [].
+    return false;
+  }
+}
+
+/**
+ * Make the registration match `enabled`. Idempotent, so it is safe to call on every worker
+ * wake and on every settings change.
+ */
+export async function applyGrayscale(enabled: boolean): Promise<void> {
+  const registered = await isRegistered();
+
+  try {
+    if (enabled && !registered) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: GRAYSCALE_SCRIPT_ID,
+          matches: YOUTUBE_MATCHES,
+          css: [GRAYSCALE_CSS],
+          // The whole point: before the first paint.
+          runAt: 'document_start',
+          allFrames: false,
+          persistAcrossSessions: true,
+        },
+      ]);
+      return;
+    }
+    if (!enabled && registered) {
+      await chrome.scripting.unregisterContentScripts({ ids: [GRAYSCALE_SCRIPT_ID] });
+    }
+  } catch (error) {
+    // Gray-screen is a cosmetic intervention; a registration failure must never take down
+    // the blocking path that shares this worker.
+    console.error('[nudge] gray-screen registration failed', error);
+  }
+}

--- a/extension/src/background/messagesRouter.ts
+++ b/extension/src/background/messagesRouter.ts
@@ -266,14 +266,49 @@ async function addSite(
   return { ok: true };
 }
 
+/**
+ * The v1.1 YouTube feature fields, passed through verbatim.
+ *
+ * Kept as one helper so the "globally disabled" branch and the live branch can never drift
+ * apart — a field added to one and forgotten in the other is exactly how a toggle ends up
+ * silently dead on one path.
+ */
+function youtubeFeatureFields(
+  settings: NudgeSettings,
+): Omit<YoutubeConfig, 'enabled' | 'hideShortsShelf' | 'shortsMode' | 'shortsDelaySeconds'> {
+  const yt = settings.youtube;
+  return {
+    channelMode: yt.channelMode,
+    channels: yt.channels,
+    channelBlockMode: yt.channelBlockMode,
+    channelDelaySeconds: yt.channelDelaySeconds,
+    grayScreen: yt.grayScreen,
+    hideHomeFeed: yt.hideHomeFeed,
+    hideSidebarRecs: yt.hideSidebarRecs,
+    hideEndScreen: yt.hideEndScreen,
+    hideComments: yt.hideComments,
+    disableAutoplay: yt.disableAutoplay,
+  };
+}
+
 async function buildYoutubeConfig(now: Date): Promise<YoutubeConfig> {
   const settings = await loadSettings();
   if (!settings.globalEnabled) {
+    // The master toggle means "behave as if uninstalled": every feature off, not just
+    // blocking. Otherwise a disabled Nudge would still be greying YouTube out.
     return {
       enabled: false,
       hideShortsShelf: false,
       shortsMode: 'ALLOW',
       shortsDelaySeconds: settings.youtube.shortsDelaySeconds,
+      ...youtubeFeatureFields(settings),
+      channelMode: 'OFF',
+      grayScreen: false,
+      hideHomeFeed: false,
+      hideSidebarRecs: false,
+      hideEndScreen: false,
+      hideComments: false,
+      disableAutoplay: false,
     };
   }
 
@@ -296,6 +331,7 @@ async function buildYoutubeConfig(now: Date): Promise<YoutubeConfig> {
     hideShortsShelf: settings.youtube.hideShortsShelf,
     shortsMode,
     shortsDelaySeconds: settings.youtube.shortsDelaySeconds,
+    ...youtubeFeatureFields(settings),
   };
 }
 

--- a/extension/src/content/channelDetection.ts
+++ b/extension/src/content/channelDetection.ts
@@ -1,0 +1,432 @@
+/**
+ * Channel detection for YouTube watch pages and feed cards (ext-03 §3).
+ *
+ * WHY three tiers: YouTube ships the uploader's identity in a different shape depending on
+ * the surface, and reshuffles those shapes on its own schedule. A watch page embeds two
+ * separate inline JSON blobs (`ytInitialPlayerResponse` and `ytInitialData`) that both
+ * carry the channel, in different places, with different reliability:
+ *
+ *   1. `channelFromPlayerResponse` — PRIMARY. `ytInitialPlayerResponse.videoDetails` is the
+ *      flattest, most stable shape: `channelId` and `author` sit directly on one object.
+ *   2. `channelFromInitialData` — FALLBACK. `ytInitialData` carries the same information
+ *      nested inside the page's render tree (`videoSecondaryInfoRenderer.owner
+ *      .videoOwnerRenderer`), several renderer wrappers deep. Those wrapper names are
+ *      exactly what YouTube's A/B tests and redesigns rename, so this path is read with a
+ *      generic tree search rather than a fixed property path (`findRenderer` below) — it
+ *      only needs the ONE key name `videoSecondaryInfoRenderer` to still exist somewhere in
+ *      the tree, not for its ancestors to be unchanged.
+ *   3. `channelFromDom` — LAST RESORT. If neither script is present or parseable, fall back
+ *      to `CHANNEL_ELEMENTS` (selectors.ts), a chain of DOM selectors ordered specific to
+ *      generic so a wrapper rename degrades to the bare `a[href^="/@"]` rung instead of
+ *      finding nothing.
+ *
+ * `detectWatchChannel` runs all three in order and returns the first one that actually
+ * identifies the channel (a channel id or a handle — a bare display name is not enough to
+ * call it "found"). `detectCardChannel` runs the same DOM chain (tier 3 only — feed cards
+ * don't carry their own inline JSON) SCOPED to one feed card, which is what makes per-card
+ * channel filtering possible at all: an unscoped query would return the first channel
+ * anywhere on the page for every card.
+ *
+ * THE BRACE-COUNTING SCANNER (`scanBalancedJson`): a naive extraction — split the script's
+ * text on a fixed delimiter like `'};</script>'` and glue a `}` back on — breaks the moment
+ * YouTube changes what follows the object literal (ext-03 §3). This module never does that;
+ * it locates the `=` that starts the assignment, then walks forward character by character
+ * counting `{`/`}` depth, correctly stepping over string literals (so a `{` or `}` INSIDE a
+ * quoted string, or an escaped quote/backslash, never perturbs the count) until depth
+ * returns to zero. No `eval`/`new Function` anywhere — MV3's CSP forbids both outright, and
+ * a hand-rolled scanner plus `JSON.parse` on the extracted slice is the only compliant way
+ * to pull structured data out of inline script text.
+ *
+ * Every exported function takes its document/element as an argument, so all of this is
+ * testable in jsdom with zero browser and zero network. Every function is also built to
+ * NEVER THROW: a missing script, truncated JSON, an unexpected shape, or an empty DOM all
+ * resolve to `null` rather than an exception — a page mid-render (YouTube's SPA constantly
+ * is) must not turn a channel-detection miss into a crash.
+ *
+ * `DetectedChannel` is deliberately NOT imported from `../core/channels.ts` (a sibling
+ * module under concurrent development) even though the shapes overlap — this file has no
+ * dependency on it, by design, so the two can be built and tested independently and bridged
+ * later by whoever wires channel detection into the block engine.
+ */
+
+import {
+  CHANNEL_ELEMENTS,
+  CHANNEL_NAME_NOISE,
+  VIDEO_RENDERER_SELECTOR,
+  queryWithFallback,
+} from './selectors';
+
+/** What this module knows about a channel. Any field may be unavailable on a given page. */
+export interface DetectedChannel {
+  /** The canonical `UCxxxxxxxxxxxxxxxxxxxxxx` id, or null if not found. */
+  channelId: string | null;
+  /** The `@handle` form, INCLUDING the leading `@`, never a URL path. Null if not found. */
+  handle: string | null;
+  /** Human-readable channel name, noise-stripped. Purely cosmetic — never an identifier. */
+  displayName: string | null;
+}
+
+/* ------------------------------------------------------------ shared JSON extraction */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Find the index of the `{` that opens the object assigned to `varName` in `text`.
+ *
+ * Handles the assignment forms YouTube actually ships: `var X = {`, bare `X = {`, and the
+ * bracket form `window["X"] = {` / `window['X'] = {`. Deliberately does NOT try to parse
+ * full JS grammar — it only needs to find one `=` that plausibly belongs to this variable
+ * name and the first `{` after it, then hands off to the brace scanner.
+ */
+function findObjectStart(text: string, varName: string): number | null {
+  let searchFrom = 0;
+
+  for (;;) {
+    const nameIndex = text.indexOf(varName, searchFrom);
+    if (nameIndex === -1) return null;
+
+    const afterName = nameIndex + varName.length;
+    const eqIndex = text.indexOf('=', afterName);
+    if (eqIndex === -1) {
+      searchFrom = afterName;
+      continue;
+    }
+
+    // Only whitespace / quotes / a closing bracket may sit between the name and its `=`
+    // (covers `var x = `, `x=`, `window["x"] = `, `window['x']=`). Anything else means this
+    // occurrence of the name isn't the assignment we're after (e.g. it's inside a longer
+    // identifier or a string).
+    const between = text.slice(afterName, eqIndex);
+    if (!/^["'\]\s]*$/.test(between)) {
+      searchFrom = afterName;
+      continue;
+    }
+    // Don't mistake `==`/`===` for an assignment operator.
+    if (text.charAt(eqIndex + 1) === '=') {
+      searchFrom = eqIndex + 1;
+      continue;
+    }
+
+    let i = eqIndex + 1;
+    while (i < text.length && /\s/.test(text.charAt(i))) i += 1;
+    if (text.charAt(i) === '{') return i;
+
+    searchFrom = afterName;
+  }
+}
+
+/**
+ * From `start` (which must point at a `{`), walk forward tracking brace depth while
+ * correctly skipping over string contents — including escaped quotes and escaped
+ * backslashes — and return the source slice through the matching closing brace. Returns
+ * null if the braces never balance (truncated input) or `start` isn't a `{`.
+ */
+function scanBalancedJson(text: string, start: number): string | null {
+  if (text.charAt(start) !== '{') return null;
+
+  let depth = 0;
+  let inString = false;
+  let quote = '';
+  let escaped = false;
+
+  for (let i = start; i < text.length; i += 1) {
+    const ch = text.charAt(i);
+
+    if (inString) {
+      if (escaped) {
+        // Whatever this character is, it was escaped — consume it as literal string
+        // content and nothing else, whether it's a quote, a backslash, or anything else.
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Scan every `<script>` on the page for an assignment to `varName`, extract the object
+ * literal with the brace scanner, and `JSON.parse` it. Tries every script (not just the
+ * first that mentions the name) and keeps going past a malformed candidate, so one broken
+ * or unrelated script can't hide a good one elsewhere on the page.
+ */
+function findAssignedObject(doc: Document, varName: string): Record<string, unknown> | null {
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    const text = script.textContent ?? '';
+    if (!text.includes(varName)) continue;
+
+    const start = findObjectStart(text, varName);
+    if (start === null) continue;
+
+    const slice = scanBalancedJson(text, start);
+    if (slice === null) continue;
+
+    try {
+      const parsed: unknown = JSON.parse(slice);
+      if (isRecord(parsed)) return parsed;
+    } catch {
+      // Malformed JSON in this script — keep looking rather than giving up on the page.
+    }
+  }
+  return null;
+}
+
+/**
+ * Breadth-first search for the first object anywhere in `root`'s tree that owns `key` as
+ * its own property, returning that property's value. This is how `channelFromInitialData`
+ * survives YouTube renaming/reshuffling the renderer wrappers ABOVE
+ * `videoSecondaryInfoRenderer` — it never assumes a fixed path down to it.
+ */
+function findRenderer(root: unknown, key: string): unknown {
+  const queue: unknown[] = [root];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+
+    if (isRecord(current)) {
+      if (key in current) return current[key];
+      for (const value of Object.values(current)) {
+        if (isRecord(value) || Array.isArray(value)) queue.push(value);
+      }
+    } else if (Array.isArray(current)) {
+      for (const value of current) {
+        if (isRecord(value) || Array.isArray(value)) queue.push(value);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/* ------------------------------------------------------------------------- tier 1 & 2 */
+
+/** Never throws: wraps a tier lookup so a shape surprise resolves to null, not a crash. */
+function safeCall(fn: () => DetectedChannel | null): DetectedChannel | null {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * PRIMARY path. Reads `ytInitialPlayerResponse.videoDetails.{channelId,author}` out of an
+ * inline `<script>`. This is the flattest, most stable shape YouTube ships (ext-03 §3).
+ */
+export function channelFromPlayerResponse(doc: Document): DetectedChannel | null {
+  return safeCall(() => {
+    const data = findAssignedObject(doc, 'ytInitialPlayerResponse');
+    if (!data) return null;
+
+    const videoDetails = data.videoDetails;
+    if (!isRecord(videoDetails)) return null;
+
+    const channelId = typeof videoDetails.channelId === 'string' ? videoDetails.channelId : null;
+    const displayName = typeof videoDetails.author === 'string' ? videoDetails.author : null;
+    if (channelId === null && displayName === null) return null;
+
+    return { channelId, handle: null, displayName };
+  });
+}
+
+/**
+ * FALLBACK path. Reads `ytInitialData` and walks to
+ * `videoSecondaryInfoRenderer.owner.videoOwnerRenderer` (found anywhere in the tree, see
+ * `findRenderer`) for the channel id, handle and display name.
+ */
+export function channelFromInitialData(doc: Document): DetectedChannel | null {
+  return safeCall(() => {
+    const data = findAssignedObject(doc, 'ytInitialData');
+    if (!data) return null;
+
+    const secondary = findRenderer(data, 'videoSecondaryInfoRenderer');
+    if (!isRecord(secondary)) return null;
+
+    const owner = secondary.owner;
+    if (!isRecord(owner)) return null;
+
+    const videoOwnerRenderer = owner.videoOwnerRenderer;
+    if (!isRecord(videoOwnerRenderer)) return null;
+
+    let channelId: string | null = null;
+    let displayName: string | null = null;
+
+    const title = videoOwnerRenderer.title;
+    if (isRecord(title) && Array.isArray(title.runs)) {
+      const firstRun = title.runs[0];
+      if (isRecord(firstRun)) {
+        displayName = typeof firstRun.text === 'string' ? firstRun.text : null;
+
+        const runNav = firstRun.navigationEndpoint;
+        if (isRecord(runNav)) {
+          const runBrowse = runNav.browseEndpoint;
+          if (isRecord(runBrowse) && typeof runBrowse.browseId === 'string') {
+            channelId = runBrowse.browseId;
+          }
+        }
+      }
+    }
+
+    let handle: string | null = null;
+    const ownerNav = videoOwnerRenderer.navigationEndpoint;
+    if (isRecord(ownerNav)) {
+      const ownerBrowse = ownerNav.browseEndpoint;
+      if (isRecord(ownerBrowse) && typeof ownerBrowse.canonicalBaseUrl === 'string') {
+        handle = handleFromCanonicalPath(ownerBrowse.canonicalBaseUrl);
+      }
+    }
+
+    if (channelId === null && handle === null && displayName === null) return null;
+    return { channelId, handle, displayName };
+  });
+}
+
+/* ------------------------------------------------------------------------------ tier 3 */
+
+/** The first path segment: stops at `/`, `?` or `#`. `''` if `text` starts with one. */
+function firstSegment(text: string): string {
+  const match = /^[^/?#]+/.exec(text);
+  return match ? match[0] : '';
+}
+
+/** `/@handle`, `@handle` or `/@handle/videos` -> `@handle`. Anything else -> null. */
+function handleFromCanonicalPath(path: string): string | null {
+  const withoutSlash = path.startsWith('/') ? path.slice(1) : path;
+  if (!withoutSlash.startsWith('@')) return null;
+  const segment = firstSegment(withoutSlash);
+  return segment.length > 0 ? segment : null;
+}
+
+/**
+ * Classify a channel anchor's `href`: `/channel/UC…` -> channelId, `/@name` -> handle,
+ * `/c/…` or `/user/…` -> a handle-ish name (the best identifier a legacy custom-URL link
+ * gives us — not a real handle, but stored in the same field since it plays the same role).
+ */
+function classifyHref(href: string): { channelId: string | null; handle: string | null } {
+  if (href.startsWith('/channel/')) {
+    const id = firstSegment(href.slice('/channel/'.length));
+    return { channelId: id.length > 0 ? id : null, handle: null };
+  }
+
+  const handle = handleFromCanonicalPath(href);
+  if (handle !== null) return { channelId: null, handle };
+
+  if (href.startsWith('/c/')) {
+    const name = firstSegment(href.slice('/c/'.length));
+    return { channelId: null, handle: name.length > 0 ? name : null };
+  }
+  if (href.startsWith('/user/')) {
+    const name = firstSegment(href.slice('/user/'.length));
+    return { channelId: null, handle: name.length > 0 ? name : null };
+  }
+
+  return { channelId: null, handle: null };
+}
+
+/**
+ * Display name from a channel anchor: `aria-label` FIRST (ext-03 §3: more reliable than
+ * text content), falling back to `textContent`, then stripping the decorative noise
+ * patterns YouTube wraps around the accessible name (`CHANNEL_NAME_NOISE`).
+ */
+function displayNameFrom(el: Element): string | null {
+  const ariaLabel = el.getAttribute('aria-label');
+  const source = ariaLabel !== null && ariaLabel.trim().length > 0 ? ariaLabel : (el.textContent ?? '');
+
+  let cleaned = source.trim();
+  for (const pattern of CHANNEL_NAME_NOISE) {
+    cleaned = cleaned.replace(pattern, '').trim();
+  }
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+/**
+ * LAST RESORT. Runs the `CHANNEL_ELEMENTS` chain (selectors.ts) against `root` and reads
+ * the channel off the first matching anchor. `root` is whatever scope the caller wants —
+ * a whole document for a watch page, or a single feed card for `detectCardChannel` — the
+ * scoping is entirely the caller's choice, this function never reaches outside `root`.
+ */
+export function channelFromDom(root: ParentNode): DetectedChannel | null {
+  return safeCall(() => {
+    const { elements } = queryWithFallback(root, CHANNEL_ELEMENTS, {
+      surfaceId: 'channel-dom',
+      // CHANNEL_ELEMENTS carries no `fallback: true` rung (its generic href^= members are
+      // normal, stable ways to link a channel — see selectors.ts) — this never fires, but
+      // an explicit no-op keeps channel identification from ever depending on the Shorts
+      // degraded-mode warning sink.
+      warn: () => {},
+    });
+
+    const anchor = elements[0];
+    if (!anchor) return null;
+
+    const href = anchor.getAttribute('href') ?? '';
+    const { channelId, handle } = classifyHref(href);
+    const displayName = displayNameFrom(anchor);
+
+    if (channelId === null && handle === null && displayName === null) return null;
+    return { channelId, handle, displayName };
+  });
+}
+
+/* ------------------------------------------------------------------------- composite */
+
+/** True when a result actually identifies a channel (an id or a handle) — a bare name does not. */
+function hasIdentifier(result: DetectedChannel | null): result is DetectedChannel {
+  return result !== null && (result.channelId !== null || result.handle !== null);
+}
+
+/**
+ * The ordered composite for a watch page: player response -> initial data -> DOM. Returns
+ * the first tier that yields at least one identifier (a channel id or a handle).
+ */
+export function detectWatchChannel(doc: Document): DetectedChannel | null {
+  const fromPlayerResponse = channelFromPlayerResponse(doc);
+  if (hasIdentifier(fromPlayerResponse)) return fromPlayerResponse;
+
+  const fromInitialData = channelFromInitialData(doc);
+  if (hasIdentifier(fromInitialData)) return fromInitialData;
+
+  const fromDom = channelFromDom(doc);
+  if (hasIdentifier(fromDom)) return fromDom;
+
+  return null;
+}
+
+/**
+ * Identify the channel for ONE feed card, scoped to it. Feed cards carry no inline JSON of
+ * their own, so this is the DOM chain only — but run against `card`, never the document, so
+ * every card in a feed resolves to its own uploader instead of all collapsing to whichever
+ * channel link happens to be first on the page.
+ */
+export function detectCardChannel(card: Element): DetectedChannel | null {
+  return channelFromDom(card);
+}
+
+/** Every feed-card wrapper on the page (`VIDEO_RENDERERS`, selectors.ts), in document order. */
+export function feedCards(root: ParentNode): Element[] {
+  try {
+    return Array.from(root.querySelectorAll(VIDEO_RENDERER_SELECTOR));
+  } catch {
+    return [];
+  }
+}

--- a/extension/src/content/channelDetection.ts
+++ b/extension/src/content/channelDetection.ts
@@ -53,7 +53,6 @@ import {
   CHANNEL_ELEMENTS,
   CHANNEL_NAME_NOISE,
   VIDEO_RENDERER_SELECTOR,
-  queryWithFallback,
 } from './selectors';
 
 /** What this module knows about a channel. Any field may be unavailable on a given page. */
@@ -221,7 +220,7 @@ function findRenderer(root: unknown, key: string): unknown {
 /* ------------------------------------------------------------------------- tier 1 & 2 */
 
 /** Never throws: wraps a tier lookup so a shape surprise resolves to null, not a crash. */
-function safeCall(fn: () => DetectedChannel | null): DetectedChannel | null {
+function safeCall<T>(fn: () => T | null): T | null {
   try {
     return fn();
   } catch {
@@ -367,24 +366,46 @@ function displayNameFrom(el: Element): string | null {
  */
 export function channelFromDom(root: ParentNode): DetectedChannel | null {
   return safeCall(() => {
-    const { elements } = queryWithFallback(root, CHANNEL_ELEMENTS, {
-      surfaceId: 'channel-dom',
-      // CHANNEL_ELEMENTS carries no `fallback: true` rung (its generic href^= members are
-      // normal, stable ways to link a channel — see selectors.ts) — this never fires, but
-      // an explicit no-op keeps channel identification from ever depending on the Shorts
-      // degraded-mode warning sink.
-      warn: () => {},
-    });
+    // Try EVERY rung, and every element each rung matches, until one actually yields an
+    // identifier.
+    //
+    // Taking only `elements[0]` of the first matching rung leaked the whitelist (live QA,
+    // 2026-07-26): YouTube search results carry a hidden placeholder `ytd-channel-name`
+    // anchor with an EMPTY href, which wins the first rung, classifies to nothing, and makes
+    // the card look unidentifiable - even though a perfectly good `/@handle` anchor exists
+    // further down the same card. An element that yields no identifier is not an answer, it
+    // is a miss, so keep looking.
+    let fallbackName: string | null = null;
 
-    const anchor = elements[0];
-    if (!anchor) return null;
+    for (const rule of CHANNEL_ELEMENTS) {
+      let matches: Element[];
+      try {
+        matches = Array.from(root.querySelectorAll(rule.selector));
+      } catch {
+        continue;
+      }
 
-    const href = anchor.getAttribute('href') ?? '';
-    const { channelId, handle } = classifyHref(href);
-    const displayName = displayNameFrom(anchor);
+      for (const anchor of matches) {
+        const href = anchor.getAttribute('href') ?? '';
+        // A hrefless anchor is a placeholder, never a channel link.
+        if (href.trim() === '') {
+          fallbackName ??= displayNameFrom(anchor);
+          continue;
+        }
+        const { channelId, handle } = classifyHref(href);
+        if (channelId === null && handle === null) {
+          fallbackName ??= displayNameFrom(anchor);
+          continue;
+        }
+        return { channelId, handle, displayName: displayNameFrom(anchor) ?? fallbackName };
+      }
+    }
 
-    if (channelId === null && handle === null && displayName === null) return null;
-    return { channelId, handle, displayName };
+    // Nothing identifying anywhere. A bare name is not an identifier (see `hasIdentifier`),
+    // but returning it keeps the display useful for a caller that only wants a label.
+    return fallbackName === null
+      ? null
+      : { channelId: null, handle: null, displayName: fallbackName };
   });
 }
 
@@ -395,17 +416,81 @@ function hasIdentifier(result: DetectedChannel | null): result is DetectedChanne
   return result !== null && (result.channelId !== null || result.handle !== null);
 }
 
+/** The video id a watch/shorts URL refers to, or null when the URL names no video. */
+export function videoIdFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const fromQuery = parsed.searchParams.get('v');
+    if (fromQuery !== null && fromQuery !== '') return fromQuery;
+    const shorts = /^\/shorts\/([^/?#]+)/.exec(parsed.pathname);
+    return shorts?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** The video id the inline `ytInitialPlayerResponse` describes, if it says. */
+function playerResponseVideoId(doc: Document): string | null {
+  return safeCall(() => {
+    const data = findAssignedObject(doc, 'ytInitialPlayerResponse');
+    if (!data || !isRecord(data.videoDetails)) return null;
+    const id = data.videoDetails.videoId;
+    return typeof id === 'string' && id !== '' ? id : null;
+  });
+}
+
+/** The video id the inline `ytInitialData` describes, if it says. */
+function initialDataVideoId(doc: Document): string | null {
+  return safeCall(() => {
+    const data = findAssignedObject(doc, 'ytInitialData');
+    if (!data) return null;
+    const endpoint = findRenderer(data, 'watchEndpoint');
+    const id = isRecord(endpoint) ? endpoint.videoId : null;
+    return typeof id === 'string' && id !== '' ? id : null;
+  });
+}
+
 /**
- * The ordered composite for a watch page: player response -> initial data -> DOM. Returns
- * the first tier that yields at least one identifier (a channel id or a handle).
+ * The ordered composite for a watch page: player response -> initial data -> DOM.
+ *
+ * STALENESS IS THE WHOLE PROBLEM HERE (live QA, 2026-07-26). YouTube is a SPA, and on a
+ * watch -> watch client-side navigation the inline `ytInitialPlayerResponse` and
+ * `ytInitialData` scripts are NOT rewritten, they stay pinned to whatever video was loaded
+ * by the last FULL page load. Tier 1 therefore returns a perfectly well-formed channel that
+ * simply belongs to the wrong video, short-circuits the chain, and the fresh DOM byline is
+ * never consulted. Observed live: a whitelisted channel full-loaded, then an SPA hop to a
+ * non-whitelisted video played in full colour with no gate at all, defeating the whitelist,
+ * the blacklist and gray-screen during exactly the browsing pattern people actually use.
+ *
+ * So the inline tiers must PROVE they are describing the current video: when the URL names a
+ * video, a script tier is used only if it declares the SAME video id. A tier that declares a
+ * different id is stale, and a tier that declares none cannot be verified, both are skipped
+ * in favour of the DOM, which YouTube genuinely re-renders on navigation.
  */
-export function detectWatchChannel(doc: Document): DetectedChannel | null {
-  const fromPlayerResponse = channelFromPlayerResponse(doc);
-  if (hasIdentifier(fromPlayerResponse)) return fromPlayerResponse;
+export function detectWatchChannel(
+  doc: Document,
+  options: { url?: string } = {},
+): DetectedChannel | null {
+  const expectedVideoId = videoIdFromUrl(options.url ?? doc.location?.href ?? '');
 
-  const fromInitialData = channelFromInitialData(doc);
-  if (hasIdentifier(fromInitialData)) return fromInitialData;
+  /** Can this inline tier be trusted to describe the video the URL names? */
+  function inlineTierIsCurrent(tierVideoId: string | null): boolean {
+    // No video in the URL (a channel page, say), there is nothing to contradict.
+    if (expectedVideoId === null) return true;
+    return tierVideoId === expectedVideoId;
+  }
 
+  if (inlineTierIsCurrent(playerResponseVideoId(doc))) {
+    const fromPlayerResponse = channelFromPlayerResponse(doc);
+    if (hasIdentifier(fromPlayerResponse)) return fromPlayerResponse;
+  }
+
+  if (inlineTierIsCurrent(initialDataVideoId(doc))) {
+    const fromInitialData = channelFromInitialData(doc);
+    if (hasIdentifier(fromInitialData)) return fromInitialData;
+  }
+
+  // Always fresh: YouTube re-renders the byline on every navigation.
   const fromDom = channelFromDom(doc);
   if (hasIdentifier(fromDom)) return fromDom;
 

--- a/extension/src/content/channelDetection.ts
+++ b/extension/src/content/channelDetection.ts
@@ -430,7 +430,7 @@ export function videoIdFromUrl(url: string): string | null {
 }
 
 /** The video id the inline `ytInitialPlayerResponse` describes, if it says. */
-function playerResponseVideoId(doc: Document): string | null {
+export function playerResponseVideoId(doc: Document): string | null {
   return safeCall(() => {
     const data = findAssignedObject(doc, 'ytInitialPlayerResponse');
     if (!data || !isRecord(data.videoDetails)) return null;
@@ -440,7 +440,7 @@ function playerResponseVideoId(doc: Document): string | null {
 }
 
 /** The video id the inline `ytInitialData` describes, if it says. */
-function initialDataVideoId(doc: Document): string | null {
+export function initialDataVideoId(doc: Document): string | null {
   return safeCall(() => {
     const data = findAssignedObject(doc, 'ytInitialData');
     if (!data) return null;
@@ -514,4 +514,14 @@ export function feedCards(root: ParentNode): Element[] {
   } catch {
     return [];
   }
+}
+
+/**
+ * The video id the page's inline data claims to describe, from whichever tier says.
+ *
+ * Exposed so the settle-window check can ask "is the inline data authoritative for the video
+ * in the address bar?" without re-parsing the page itself.
+ */
+export function inlineVideoId(doc: Document): string | null {
+  return playerResponseVideoId(doc) ?? initialDataVideoId(doc);
 }

--- a/extension/src/content/channelFilter.ts
+++ b/extension/src/content/channelFilter.ts
@@ -1,0 +1,153 @@
+/**
+ * Channel lists applied to the page: feed composition, the watch-page verdict, and the
+ * gray-screen colour flip.
+ *
+ * Split from youtube.ts so all three are testable in jsdom without the SPA controller:
+ * every function takes its root and config as arguments and touches nothing global.
+ *
+ * The DECISION lives in core/channels.ts (pure, exhaustively tested); this module only
+ * finds the channel (content/channelDetection.ts) and applies the answer to the DOM. Keeping
+ * "what does this mean" and "what does the page look like" apart is what let the decision
+ * matrix — including the fail-open unknown-channel case — be tested without any DOM at all.
+ */
+
+import { decideChannel, shouldShowInColor, type ChannelProbe } from '../core/channels';
+import type { YoutubeConfig } from '../core/protocol';
+import { detectCardChannel, detectWatchChannel, feedCards } from './channelDetection';
+import { CHANNEL_HIDDEN_CLASS, COLOR_CLASS, NUDGE_OVERLAY_ID, pageTypeFor } from './selectors';
+
+/** The slice of config this module needs. */
+export type ChannelConfig = Pick<
+  YoutubeConfig,
+  'enabled' | 'channelMode' | 'channels' | 'channelBlockMode' | 'grayScreen'
+>;
+
+export interface ChannelFilterResult {
+  /** Cards newly hidden this pass. */
+  hidden: number;
+  /** Cards newly revealed this pass. */
+  revealed: number;
+  /** Cards whose channel could not be identified at all. */
+  unidentified: number;
+}
+
+function probeOf(detected: { channelId: string | null; handle: string | null } | null): ChannelProbe {
+  return { channelId: detected?.channelId ?? null, handle: detected?.handle ?? null };
+}
+
+/**
+ * Hide feed cards whose channel the list disallows.
+ *
+ * Reconcile-and-diff, like the other appliers: compute the set that SHOULD be hidden right
+ * now, then reveal anything currently hidden that is not in it. That is what makes flipping
+ * the feature off restore the feed without a reload.
+ *
+ * Not page-type scoped: feed cards appear on the home feed, subscriptions, search results
+ * and the watch sidebar alike, and a card is a card wherever it shows up.
+ *
+ * A card whose channel cannot be identified is LEFT VISIBLE, matching `decideChannel`'s
+ * documented fail-open: a detection failure must degrade to "YouTube looks normal", never to
+ * "the feed is empty and the extension looks broken".
+ */
+export function applyChannelFilter(
+  root: Document | Element,
+  config: ChannelConfig,
+): ChannelFilterResult {
+  const result: ChannelFilterResult = { hidden: 0, revealed: 0, unidentified: 0 };
+  const active = config.enabled && config.channelMode !== 'OFF';
+
+  const shouldHide = new Set<Element>();
+  if (active) {
+    for (const card of feedCards(root)) {
+      if (card.id === NUDGE_OVERLAY_ID || card.closest(`#${NUDGE_OVERLAY_ID}`)) continue;
+      const detected = detectCardChannel(card);
+      if (detected === null) {
+        result.unidentified += 1;
+        continue;
+      }
+      const verdict = decideChannel({
+        mode: config.channelMode,
+        channels: config.channels,
+        probe: probeOf(detected),
+        blockMode: config.channelBlockMode,
+      });
+      if (verdict.action === 'BLOCK') shouldHide.add(card);
+    }
+  }
+
+  for (const card of shouldHide) {
+    if (card.classList.contains(CHANNEL_HIDDEN_CLASS)) continue;
+    card.classList.add(CHANNEL_HIDDEN_CLASS);
+    result.hidden += 1;
+  }
+
+  for (const hiddenCard of Array.from(root.querySelectorAll(`.${CHANNEL_HIDDEN_CLASS}`))) {
+    if (shouldHide.has(hiddenCard)) continue;
+    hiddenCard.classList.remove(CHANNEL_HIDDEN_CLASS);
+    result.revealed += 1;
+  }
+
+  return result;
+}
+
+/**
+ * The channel verdict for the CURRENT watch page, or null when channel lists are off or
+ * this is not a watch page.
+ */
+export function watchChannelVerdict(
+  doc: Document,
+  config: ChannelConfig,
+  options: { url?: string } = {},
+): ReturnType<typeof decideChannel> | null {
+  if (!config.enabled || config.channelMode === 'OFF') return null;
+  const url = options.url ?? doc.location?.href ?? '';
+  if (pageTypeFor(url) !== 'watch') return null;
+
+  return decideChannel({
+    mode: config.channelMode,
+    channels: config.channels,
+    probe: probeOf(detectWatchChannel(doc)),
+    blockMode: config.channelBlockMode,
+  });
+}
+
+/**
+ * Flip <html> between grayscale and colour.
+ *
+ * The grayscale itself comes from grayscale.css, registered by the service worker only while
+ * the feature is on (see background/grayscale.ts) — so when gray-screen is off this function
+ * only has to make sure it isn't leaving a stale colour class behind.
+ *
+ * Colour is a REWARD for a positively-identified allowed channel. An unidentified channel
+ * stays gray, which is the opposite bias to blocking: failing toward gray is harmless, while
+ * failing toward blocked would break YouTube.
+ */
+export function applyGrayColor(
+  doc: Document,
+  config: ChannelConfig,
+  options: { url?: string } = {},
+): boolean {
+  const root = doc.documentElement;
+  if (root === null) return false;
+
+  if (!config.enabled || !config.grayScreen) {
+    root.classList.remove(COLOR_CLASS);
+    return false;
+  }
+
+  const url = options.url ?? doc.location?.href ?? '';
+  const pageType = pageTypeFor(url);
+  // Only a watch or channel page has a single channel whose identity could earn colour.
+  // A feed is a mix of many, so it stays gray.
+  const detected =
+    pageType === 'watch' || pageType === 'channel' ? detectWatchChannel(doc) : null;
+
+  const inColor = shouldShowInColor({
+    mode: config.channelMode,
+    channels: config.channels,
+    probe: probeOf(detected),
+  });
+
+  root.classList.toggle(COLOR_CLASS, inColor);
+  return inColor;
+}

--- a/extension/src/content/channelFilter.ts
+++ b/extension/src/content/channelFilter.ts
@@ -12,8 +12,15 @@
  */
 
 import { decideChannel, shouldShowInColor, type ChannelProbe } from '../core/channels';
+import { channelFreshness, channelKey } from '../core/channelFreshness';
 import type { YoutubeConfig } from '../core/protocol';
-import { detectCardChannel, detectWatchChannel, feedCards } from './channelDetection';
+import {
+  detectCardChannel,
+  detectWatchChannel,
+  feedCards,
+  inlineVideoId,
+  videoIdFromUrl,
+} from './channelDetection';
 import { CHANNEL_HIDDEN_CLASS, COLOR_CLASS, NUDGE_OVERLAY_ID, pageTypeFor } from './selectors';
 
 /** The slice of config this module needs. */
@@ -142,16 +149,31 @@ function warnIfDetectionDegraded(
 export function watchChannelVerdict(
   doc: Document,
   config: ChannelConfig,
-  options: { url?: string } = {},
+  options: { url?: string; previousKey?: string | null; msSinceNav?: number } = {},
 ): ReturnType<typeof decideChannel> | null {
   if (!config.enabled || config.channelMode === 'OFF') return null;
   const url = options.url ?? doc.location?.href ?? '';
   if (pageTypeFor(url) !== 'watch') return null;
 
+  const detected = detectWatchChannel(doc, { url });
+
+  // Hold fire while the byline may still describe the PREVIOUS video. Returning null means
+  // "no interstitial yet", NOT "allowed" - the caller simply does not gate, which is the same
+  // fail-open we already take for an unidentifiable channel, and it is what stops an allowed
+  // channel being accused for several seconds after a navigation.
+  const freshness = channelFreshness({
+    videoId: videoIdFromUrl(url),
+    inlineVideoId: inlineVideoId(doc),
+    detectedKey: channelKey(detected),
+    previousKey: options.previousKey ?? null,
+    msSinceNav: options.msSinceNav ?? Number.POSITIVE_INFINITY,
+  });
+  if (freshness === 'SETTLING') return null;
+
   return decideChannel({
     mode: config.channelMode,
     channels: config.channels,
-    probe: probeOf(detectWatchChannel(doc, { url })),
+    probe: probeOf(detected),
     blockMode: config.channelBlockMode,
   });
 }
@@ -170,7 +192,7 @@ export function watchChannelVerdict(
 export function applyGrayColor(
   doc: Document,
   config: ChannelConfig,
-  options: { url?: string } = {},
+  options: { url?: string; previousKey?: string | null; msSinceNav?: number } = {},
 ): boolean {
   const root = doc.documentElement;
   if (root === null) return false;
@@ -187,11 +209,25 @@ export function applyGrayColor(
   const detected =
     pageType === 'watch' || pageType === 'channel' ? detectWatchChannel(doc, { url }) : null;
 
-  const inColor = shouldShowInColor({
-    mode: config.channelMode,
-    channels: config.channels,
-    probe: probeOf(detected),
-  });
+  // Staying gray through the settle window is the safe half of the tradeoff: an extra second
+  // of grayscale on an allowed video is unnoticeable, whereas flashing COLOUR onto a channel
+  // the user is avoiding hands them exactly the hit the feature exists to remove.
+  const settling =
+    channelFreshness({
+      videoId: videoIdFromUrl(url),
+      inlineVideoId: inlineVideoId(doc),
+      detectedKey: channelKey(detected),
+      previousKey: options.previousKey ?? null,
+      msSinceNav: options.msSinceNav ?? Number.POSITIVE_INFINITY,
+    }) === 'SETTLING';
+
+  const inColor =
+    !settling &&
+    shouldShowInColor({
+      mode: config.channelMode,
+      channels: config.channels,
+      probe: probeOf(detected),
+    });
 
   root.classList.toggle(COLOR_CLASS, inColor);
   return inColor;

--- a/extension/src/content/channelFilter.ts
+++ b/extension/src/content/channelFilter.ts
@@ -52,6 +52,7 @@ function probeOf(detected: { channelId: string | null; handle: string | null } |
 export function applyChannelFilter(
   root: Document | Element,
   config: ChannelConfig,
+  options: { warn?: (message: string) => void } = {},
 ): ChannelFilterResult {
   const result: ChannelFilterResult = { hidden: 0, revealed: 0, unidentified: 0 };
   const active = config.enabled && config.channelMode !== 'OFF';
@@ -87,7 +88,51 @@ export function applyChannelFilter(
     result.revealed += 1;
   }
 
+  if (active) warnIfDetectionDegraded(result, options.warn ?? defaultDetectionWarn);
+
   return result;
+}
+
+/** One warning per page load; the observer re-runs this constantly. */
+let warnedAboutDetection = false;
+
+/** Test/reset seam for the dedupe flag. */
+export function resetDetectionWarning(): void {
+  warnedAboutDetection = false;
+}
+
+const defaultDetectionWarn: (message: string) => void = (message) => {
+  if (warnedAboutDetection) return;
+  warnedAboutDetection = true;
+  console.warn(message);
+};
+
+/**
+ * Make the fail-open OBSERVABLE.
+ *
+ * An unidentifiable channel is deliberately allowed through (see `decideChannel`), which is
+ * the right call, but with no signal at all, YouTube changing its DOM would degrade the
+ * channel filter into a no-op that looks exactly like "the user has nothing on their list".
+ * A cheap console canary means selector rot shows up the first time anyone opens devtools,
+ * rather than only when a user notices their whitelist quietly stopped working.
+ *
+ * Only fires when SOME cards resolved and others did not: a page where nothing resolved is
+ * usually just a page with no feed cards on it, and a canary that cries wolf gets ignored.
+ */
+function warnIfDetectionDegraded(
+  result: ChannelFilterResult,
+  warn: (message: string) => void,
+): void {
+  const identified = result.hidden + result.revealed;
+  if (result.unidentified === 0) return;
+  if (identified === 0) return;
+
+  warn(
+    `[nudge] Channel filtering is degraded: ${result.unidentified} video card(s) on this ` +
+      `page had no identifiable channel, so they were left visible rather than filtered. ` +
+      `This usually means YouTube changed its DOM. Please report it at ` +
+      `https://github.com/astraedus/nudge/issues so the selectors can be updated.`,
+  );
 }
 
 /**
@@ -106,7 +151,7 @@ export function watchChannelVerdict(
   return decideChannel({
     mode: config.channelMode,
     channels: config.channels,
-    probe: probeOf(detectWatchChannel(doc)),
+    probe: probeOf(detectWatchChannel(doc, { url })),
     blockMode: config.channelBlockMode,
   });
 }
@@ -140,7 +185,7 @@ export function applyGrayColor(
   // Only a watch or channel page has a single channel whose identity could earn colour.
   // A feed is a mix of many, so it stays gray.
   const detected =
-    pageType === 'watch' || pageType === 'channel' ? detectWatchChannel(doc) : null;
+    pageType === 'watch' || pageType === 'channel' ? detectWatchChannel(doc, { url }) : null;
 
   const inColor = shouldShowInColor({
     mode: config.channelMode,

--- a/extension/src/content/selectors.ts
+++ b/extension/src/content/selectors.ts
@@ -129,15 +129,25 @@ const NAV_SURFACE: ShortsSurface = {
   id: 'shorts-nav',
   description: 'Shorts entry in the left navigation rail',
   chain: [
+    // Refreshed 2026-07-26: on live DOM the two `href='/shorts/'` rungs below stopped
+    // matching (YouTube now renders the entry with a trailing-slash-free href and an
+    // aria-label), and only the generic catch-all fired, our own degraded-mode canary
+    // caught it, which is exactly what it is for. The `:has()`-free attribute rungs are
+    // first now because they are the ones that actually match today.
     {
-      selector: "ytd-mini-guide-entry-renderer>a[href='/shorts/']",
-      note: 'Collapsed mini-guide Shorts tab (Vulpelo).',
+      selector: 'ytd-mini-guide-entry-renderer a[href^="/shorts"]',
+      note: 'Collapsed mini-guide Shorts tab (current DOM).',
     },
     {
-      selector: 'ytd-guide-entry-renderer:has(>a[href="/shorts/"])',
-      note: 'Expanded guide Shorts tab.',
+      selector: 'ytd-guide-entry-renderer:has(a[href^="/shorts"])',
+      note: 'Expanded guide Shorts tab (current DOM).',
     },
     { selector: 'a[title="Shorts"]', note: 'Title-anchored nav link (FocusTube).' },
+    { selector: 'a[aria-label="Shorts"]', note: 'Aria-anchored nav link.' },
+    {
+      selector: "ytd-mini-guide-entry-renderer>a[href='/shorts/']",
+      note: 'Legacy exact-href mini-guide tab (Vulpelo); kept for older DOM.',
+    },
   ],
 };
 
@@ -376,9 +386,19 @@ export interface HideSurface {
   id: string;
   /** The settings flag that turns this surface off. */
   toggle: HideToggle;
-  /** Page types the surface exists on, elsewhere we don't even look for it. */
+  /** Page types the surface exists on; elsewhere we don't even look for it. */
   pages: YoutubePageType[];
   chain: SelectorRule[];
+  /**
+   * Hide EVERY rung that matches, instead of stopping at the first.
+   *
+   * Default (false) means the chain is a fallback ladder: rungs are alternative ways to find
+   * the SAME thing, so the most specific match wins. Some surfaces are not like that, their
+   * rungs are genuinely different elements that appear TOGETHER, and stopping at the first
+   * leaves the others on screen (live QA, 2026-07-26: the end-screen grid and the creator
+   * end-cards coexist, so hiding only the grid left the cards showing).
+   */
+  matchAll?: boolean;
 }
 
 /**
@@ -412,10 +432,13 @@ export const HIDE_SURFACES: HideSurface[] = [
     id: 'end-screen',
     toggle: 'hideEndScreen',
     pages: ['watch', 'shorts'],
+    // These are DIFFERENT elements shown at the same time, not alternatives: the grid of
+    // suggested videos AND the creator's own end-cards. First-match-wins left the cards
+    // on screen (live QA, 2026-07-26).
+    matchAll: true,
     chain: [
       { selector: '.ytp-endscreen-content', note: 'End-of-video suggestion grid (DF Tube).' },
-      { selector: '.ytp-ce-video', note: 'In-player card suggestions.' },
-      { selector: '.ytp-ce-element' },
+      { selector: '.ytp-ce-element', note: 'Creator end-cards; coexists with the grid.' },
     ],
   },
   {
@@ -423,9 +446,14 @@ export const HIDE_SURFACES: HideSurface[] = [
     toggle: 'hideComments',
     pages: ['watch', 'shorts'],
     chain: [
-      { selector: '#comments #contents', note: 'Comment list (sanersocialmedia).' },
-      { selector: '#comments' },
+      {
+        selector: '#comments',
+        note:
+          'The WHOLE section. Targeting only `#comments #contents` left the "N Comments / ' +
+          'Sort by" header behind as ~109px of dead chrome (live QA, 2026-07-26).',
+      },
       { selector: '#watch-discussion', note: 'DF Tube hide_comments.css target.' },
+      { selector: '#comments #contents', note: 'Last resort: the list without its header.' },
     ],
   },
 ];

--- a/extension/src/content/selectors.ts
+++ b/extension/src/content/selectors.ts
@@ -308,3 +308,140 @@ export function pageTypeFor(url: string): YoutubePageType {
   if (CHANNEL_PATH.test(parsed.pathname) || parsed.pathname.startsWith('/@')) return 'channel';
   return 'other';
 }
+
+/* ============================================================ v1.1: channels */
+
+/**
+ * Channel-name/link elements, tried in order (ext-03 §3, from
+ * `allenlsy/yt-channels-chrome-extension`'s CHANNEL_ELEMENTS).
+ *
+ * Scoped to a feed card this identifies the card's channel; unscoped on a watch page it
+ * identifies the video's uploader. The `href^=` rungs are last because they are the most
+ * generic, but they are NOT marked `fallback`: on YouTube a bare `/@handle` link is a
+ * perfectly normal, stable way to express a channel, so matching one is not evidence that
+ * the DOM moved. Reserving the fallback warning for genuine churn keeps it meaningful.
+ */
+export const CHANNEL_ELEMENTS: SelectorRule[] = [
+  { selector: 'ytd-channel-name a.yt-formatted-string', note: 'Standard channel-name link.' },
+  { selector: '#channel-name a.yt-formatted-string', note: 'Id-anchored variant.' },
+  { selector: 'a.ytd-channel-name' },
+  { selector: 'a[href^="/channel/"]', note: 'Canonical /channel/UCxxxx link.' },
+  { selector: 'a[href^="/@"]', note: 'Handle link.' },
+  { selector: 'a[href^="/c/"]', note: 'Legacy custom-URL link.' },
+  { selector: 'a[href^="/user/"]', note: 'Legacy /user/ link.' },
+];
+
+/**
+ * Feed-card wrappers (ext-03 §3 VIDEO_RENDERERS). Each is one video in a feed, and the
+ * channel chain above is run SCOPED TO IT, that scoping is the whole feed-composition
+ * mechanism, because an unscoped query would return the first channel on the page for
+ * every card.
+ */
+export const VIDEO_RENDERERS: string[] = [
+  'ytd-video-renderer',
+  'ytd-rich-item-renderer',
+  'ytd-grid-video-renderer',
+  'ytd-compact-video-renderer',
+  'ytd-playlist-video-renderer',
+  'ytd-channel-video-renderer',
+  'ytd-reel-item-renderer',
+];
+
+/** One selector matching every feed card on the page. */
+export const VIDEO_RENDERER_SELECTOR = VIDEO_RENDERERS.join(', ');
+
+/**
+ * Decorations YouTube wraps around an accessible channel name, stripped before display.
+ * `aria-label` is preferred over `textContent` (ext-03 §3: more reliable) but it is phrased
+ * for screen readers, so it arrives as "Go to channel Foo" rather than "Foo".
+ */
+export const CHANNEL_NAME_NOISE: RegExp[] = [/^go to channel\s*/i, /\s*-\s*channel$/i];
+
+/** The class flipped onto <html> when the current channel is allowed to be in colour. */
+export const COLOR_CLASS = 'nudge-color';
+
+/** Marks a feed card the channel filter has hidden, distinct from Shorts hiding. */
+export const CHANNEL_HIDDEN_CLASS = 'nudge-channel-hidden';
+
+/* ====================================================== v1.1: hide toggles */
+
+/** The independent Unhook-parity toggles (settings keys, so they can be looked up directly). */
+export type HideToggle =
+  | 'hideHomeFeed'
+  | 'hideSidebarRecs'
+  | 'hideEndScreen'
+  | 'hideComments';
+
+export interface HideSurface {
+  id: string;
+  /** The settings flag that turns this surface off. */
+  toggle: HideToggle;
+  /** Page types the surface exists on, elsewhere we don't even look for it. */
+  pages: YoutubePageType[];
+  chain: SelectorRule[];
+}
+
+/**
+ * Selector sets from ext-03 §5 (`tobiasdalhof/sanersocialmedia` + DF Tube), per page type
+ * so one breaking upstream doesn't take the others with it.
+ */
+export const HIDE_SURFACES: HideSurface[] = [
+  {
+    id: 'home-feed',
+    toggle: 'hideHomeFeed',
+    pages: ['home'],
+    chain: [
+      {
+        selector: 'ytd-browse[page-subtype="home"] #contents',
+        note: 'Home feed contents (sanersocialmedia).',
+      },
+      { selector: 'ytd-browse[page-subtype="home"] #primary' },
+      { selector: '#feed', note: 'DF Tube hide_feed.css target.' },
+    ],
+  },
+  {
+    id: 'sidebar-recs',
+    toggle: 'hideSidebarRecs',
+    pages: ['watch'],
+    chain: [
+      { selector: '#secondary #related', note: 'Watch-page sidebar recommendations.' },
+      { selector: '#related' },
+    ],
+  },
+  {
+    id: 'end-screen',
+    toggle: 'hideEndScreen',
+    pages: ['watch', 'shorts'],
+    chain: [
+      { selector: '.ytp-endscreen-content', note: 'End-of-video suggestion grid (DF Tube).' },
+      { selector: '.ytp-ce-video', note: 'In-player card suggestions.' },
+      { selector: '.ytp-ce-element' },
+    ],
+  },
+  {
+    id: 'comments',
+    toggle: 'hideComments',
+    pages: ['watch', 'shorts'],
+    chain: [
+      { selector: '#comments #contents', note: 'Comment list (sanersocialmedia).' },
+      { selector: '#comments' },
+      { selector: '#watch-discussion', note: 'DF Tube hide_comments.css target.' },
+    ],
+  },
+];
+
+/**
+ * The player's autoplay switch.
+ *
+ * This one is a genuine DOM INTERACTION rather than a hide: there is no supported API to
+ * turn autoplay off, so we click the control when `aria-checked="true"`. That makes it
+ * best-effort, YouTube re-renders the player on navigation and can restore its own state,
+ * so we re-check on every SPA nav and the click is idempotent by construction (we only ever
+ * click a switch that is currently ON, so we can never toggle it back on).
+ */
+export const AUTOPLAY_TOGGLE: SelectorRule[] = [
+  { selector: '.ytp-autonav-toggle-button[aria-checked="true"]', note: 'Autoplay switch, on.' },
+  {
+    selector: 'button[data-tooltip-target-id="ytp-autonav-toggle-button"][aria-checked="true"]',
+  },
+];

--- a/extension/src/content/unhook.ts
+++ b/extension/src/content/unhook.ts
@@ -1,0 +1,165 @@
+/**
+ * "Unhook parity" — the independent YouTube hide toggles (ext-03 §5): Home Feed, Sidebar
+ * Recommendations, End Screen, Comments, plus best-effort Autoplay-off. Sibling module to
+ * `youtube.ts`'s Shorts hiding, same conventions: pure functions over `root`/`config` so
+ * this is unit-testable without a browser, class-toggle hiding (never node removal) so a
+ * settings flip restores the page instantly, and we never touch our own overlay.
+ *
+ * Kept as its OWN module rather than folded into `youtube.ts` because these toggles are
+ * independent of Shorts hiding and of each other — they can be reasoned about, tested and
+ * (eventually) wired into the content script separately from the Shorts gate/hide logic.
+ */
+
+import type { YoutubeConfig } from '../core/protocol';
+import {
+  AUTOPLAY_TOGGLE,
+  NUDGE_OVERLAY_ID,
+  defaultWarn,
+  pageTypeFor,
+  queryWithFallback,
+  HIDE_SURFACES,
+  type WarnFn,
+  type YoutubePageType,
+} from './selectors';
+
+/**
+ * The class `applyHideToggles` toggles. DELIBERATELY DISTINCT from `HIDDEN_CLASS`
+ * (selectors.ts), which Shorts hiding owns.
+ *
+ * If both features shared one class, they would clobber each other's state: sweeping
+ * "everything with the shared class" when Shorts hiding turns off would also un-hide
+ * comments/end-screen/etc. that this module hid for an unrelated reason (and vice versa).
+ * Two features, two classes, two independent on/off lifecycles.
+ */
+export const UNHOOK_HIDDEN_CLASS = 'nudge-unhook-hidden';
+
+export interface HideResult {
+  /** Elements newly given the hidden class this pass. */
+  hidden: number;
+  /** Elements whose hidden class was removed this pass. */
+  revealed: number;
+  /** Surfaces that only matched via their generic fallback selector. */
+  degradedSurfaces: string[];
+}
+
+/** The four independent hide toggles, plus the master switch. */
+type HideToggleConfig = Pick<
+  YoutubeConfig,
+  'enabled' | 'hideHomeFeed' | 'hideSidebarRecs' | 'hideEndScreen' | 'hideComments'
+>;
+
+/** The URL of whatever document `root` belongs to. Mirrors youtube.ts's private helper. */
+function documentUrl(root: Document | Element): string {
+  const doc = root.ownerDocument ?? (root as Document);
+  return doc.location?.href ?? '';
+}
+
+/**
+ * Add/remove `UNHOOK_HIDDEN_CLASS` across every enabled, page-applicable hide surface.
+ *
+ * Reversible and independent by construction: each pass computes the FULL desired set of
+ * "should be hidden right now" elements (only surfaces whose `pages` include the current
+ * page type AND whose toggle is on in `config`), applies the class to that set, then sweeps
+ * every element currently wearing the class and removes it from anything NOT in the desired
+ * set. That sweep is what makes "flip a toggle off" and "enabled: false" both self-correcting
+ * without needing to remember what was hidden last time — a surface that is off (or off the
+ * current page, or globally disabled) simply never enters the desired set, so anything it
+ * previously hid gets revealed on the very next pass.
+ */
+export function applyHideToggles(
+  root: Document | Element,
+  config: HideToggleConfig,
+  options: { pageType?: YoutubePageType; url?: string; warn?: WarnFn } = {},
+): HideResult {
+  const { warn = defaultWarn } = options;
+  const result: HideResult = { hidden: 0, revealed: 0, degradedSurfaces: [] };
+  const pageType = options.pageType ?? pageTypeFor(options.url ?? documentUrl(root));
+
+  const shouldHide = new Set<Element>();
+
+  if (config.enabled) {
+    for (const surface of HIDE_SURFACES) {
+      // Page-type scoping: don't even query a surface that doesn't live on this page —
+      // a watch-only surface (sidebar recs, comments, end screen) must never be considered
+      // on home/search/etc., whatever a selector might coincidentally match there.
+      if (!surface.pages.includes(pageType)) continue;
+      if (!config[surface.toggle]) continue;
+
+      const { elements, usedFallback } = queryWithFallback(root, surface.chain, {
+        surfaceId: surface.id,
+        warn,
+      });
+      if (usedFallback) result.degradedSurfaces.push(surface.id);
+
+      for (const element of elements) {
+        // Never hide our own overlay, whatever a selector claims — either because a
+        // selector matched the overlay itself, or because it matched something the
+        // overlay happens to contain.
+        if (element.id === NUDGE_OVERLAY_ID || element.closest(`#${NUDGE_OVERLAY_ID}`)) {
+          continue;
+        }
+        shouldHide.add(element);
+      }
+    }
+  }
+
+  for (const element of shouldHide) {
+    if (!element.classList.contains(UNHOOK_HIDDEN_CLASS)) {
+      element.classList.add(UNHOOK_HIDDEN_CLASS);
+      result.hidden += 1;
+    }
+  }
+
+  for (const element of Array.from(root.querySelectorAll(`.${UNHOOK_HIDDEN_CLASS}`))) {
+    if (!shouldHide.has(element)) {
+      element.classList.remove(UNHOOK_HIDDEN_CLASS);
+      result.revealed += 1;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Click the player's autoplay switch off, if it is currently on.
+ *
+ * UNLIKE `applyHideToggles`, this is a genuine DOM INTERACTION, not a hide: there is no
+ * supported API to disable autoplay, so we simulate a click on the switch — and only when
+ * `AUTOPLAY_TOGGLE` finds one with `aria-checked="true"` (see the chain's own doc comment in
+ * selectors.ts). That asymmetry is what makes the operation idempotent by construction: we
+ * only ever act on a switch that is currently ON, so a call can turn autoplay off but can
+ * never turn it back on — there is no code path here that clicks an OFF switch.
+ *
+ * BEST-EFFORT, NOT A GUARANTEE: YouTube re-renders the player (SPA nav, ad breaks, etc.) and
+ * can silently restore its own autoplay state at any time. This function does not track or
+ * fight that — callers are expected to re-run it on every SPA navigation (the same
+ * `yt-navigate-finish`/`popstate`/observer cadence `youtube.ts` already drives Shorts hiding
+ * with), so a re-enabled switch just gets clicked off again on the next pass.
+ *
+ * Never throws: a missing switch is a no-op (returns `false`), and `click()` itself is
+ * guarded — jsdom and YouTube's own custom-element upgrade races can both throw on a click
+ * in odd cases, and that must never take down the caller.
+ */
+export function applyAutoplayOff(
+  root: Document | Element,
+  config: Pick<YoutubeConfig, 'enabled' | 'disableAutoplay'>,
+  options: { warn?: WarnFn } = {},
+): boolean {
+  if (!config.enabled || !config.disableAutoplay) return false;
+
+  const { warn = defaultWarn } = options;
+  const { elements } = queryWithFallback(root, AUTOPLAY_TOGGLE, {
+    surfaceId: 'autoplay-toggle',
+    warn,
+  });
+
+  const toggle = elements[0];
+  if (!toggle) return false;
+
+  try {
+    (toggle as HTMLElement).click();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/extension/src/content/unhook.ts
+++ b/extension/src/content/unhook.ts
@@ -85,10 +85,24 @@ export function applyHideToggles(
       if (!surface.pages.includes(pageType)) continue;
       if (!config[surface.toggle]) continue;
 
-      const { elements, usedFallback } = queryWithFallback(root, surface.chain, {
-        surfaceId: surface.id,
-        warn,
-      });
+      // `matchAll` surfaces are made of DIFFERENT elements that appear together (the
+      // end-screen grid AND the creator's end-cards), so every rung has to be collected.
+      // The default first-match-wins is for chains whose rungs are alternative ways to find
+      // the same element.
+      let elements: Element[];
+      let usedFallback = false;
+      if (surface.matchAll === true) {
+        elements = [];
+        for (const rule of surface.chain) {
+          const rung = queryWithFallback(root, [rule], { surfaceId: surface.id, warn });
+          elements.push(...rung.elements);
+          usedFallback ||= rung.usedFallback;
+        }
+      } else {
+        const found = queryWithFallback(root, surface.chain, { surfaceId: surface.id, warn });
+        elements = found.elements;
+        usedFallback = found.usedFallback;
+      }
       if (usedFallback) result.degradedSurfaces.push(surface.id);
 
       for (const element of elements) {

--- a/extension/src/content/youtube.css
+++ b/extension/src/content/youtube.css
@@ -170,3 +170,25 @@
     transition: none;
   }
 }
+
+/*
+ * Unhook-parity hiding (src/content/unhook.ts).
+ *
+ * A DISTINCT class from `.nudge-hidden`: Shorts hiding and the Unhook toggles are
+ * independent features, and sharing one class would mean turning Shorts hiding off also
+ * un-hid your comments.
+ */
+.nudge-unhook-hidden {
+  display: none !important;
+}
+
+/*
+ * Feed cards removed by the channel filter (src/content/channelFilter.ts).
+ *
+ * Its own class again, for the same reason: a card can be hidden because it is a Short OR
+ * because its channel is not allowed, and turning either feature off must only reveal the
+ * cards that feature was responsible for.
+ */
+.nudge-channel-hidden {
+  display: none !important;
+}

--- a/extension/src/content/youtube.ts
+++ b/extension/src/content/youtube.ts
@@ -24,6 +24,8 @@
 import type { YoutubeConfig } from '../core/protocol';
 import { MODE_LABELS } from '../core/types';
 import { send } from '../ui/rpc';
+import { applyChannelFilter, applyGrayColor, watchChannelVerdict } from './channelFilter';
+import { applyAutoplayOff, applyHideToggles } from './unhook';
 import {
   HIDDEN_CLASS,
   NUDGE_OVERLAY_ID,
@@ -190,9 +192,19 @@ export function createShortsOverlay(
   doc: Document,
   config: Pick<YoutubeConfig, 'shortsMode' | 'shortsDelaySeconds'>,
   handlers: { onComplete: () => void; onBail: () => void },
+  /**
+   * Overrides for a gate that is not about Shorts. The channel gate is the same
+   * interstitial with different words, so it reuses this rather than growing a second
+   * near-identical overlay implementation that could drift.
+   */
+  override: { title?: string; subtitle?: string; ruleLabel?: string } = {},
 ): OverlayHandle {
   const mode = config.shortsMode === 'ALLOW' ? 'HARD_BLOCK' : config.shortsMode;
-  const copy = gateCopy(mode);
+  const base = gateCopy(mode);
+  const copy = {
+    title: override.title ?? base.title,
+    subtitle: override.subtitle ?? base.subtitle,
+  };
   const timers: number[] = [];
 
   const overlay = doc.createElement('div');
@@ -282,7 +294,7 @@ export function createShortsOverlay(
 
   const footer = doc.createElement('p');
   footer.className = 'nudge-overlay__footer';
-  footer.textContent = `Rule: YouTube Shorts · ${MODE_LABELS[mode]}`;
+  footer.textContent = `Rule: ${override.ruleLabel ?? 'YouTube Shorts'} · ${MODE_LABELS[mode]}`;
   card.append(footer);
 
   overlay.append(card);
@@ -372,6 +384,8 @@ export function initYoutubeContentScript(
   let overlay: OverlayHandle | null = null;
   /** Set once a pause is completed; cleared as soon as we leave the Shorts surface. */
   let gateSatisfied = false;
+  /** The watch URL whose channel gate the user has already completed, if any. */
+  let channelGateSatisfiedFor: string | null = null;
   let lastUrl = doc.location?.href ?? '';
   let debounceTimer: number | undefined;
   let stopped = false;
@@ -391,13 +405,29 @@ export function initYoutubeContentScript(
     const url = currentHref();
     if (url !== lastUrl) {
       lastUrl = url;
-      // Leaving Shorts resets the grant — coming back should cost you the pause again.
+      // Leaving Shorts resets the grant - coming back should cost you the pause again.
       if (pageTypeFor(url) !== 'shorts') gateSatisfied = false;
     }
 
+    // The passive layers run on EVERY pass, before and independently of any gate: hiding,
+    // feed filtering and the colour flip must be correct even while an interstitial is up,
+    // and must keep reconciling as YouTube lazy-loads more cards in.
     applyShortsHiding(doc, config, { url });
+    applyHideToggles(doc, config, { url });
+    applyChannelFilter(doc, config);
+    applyGrayColor(doc, config, { url });
+    if (config.disableAutoplay) applyAutoplayOff(doc, config);
 
-    if (!shouldGateShorts(url, config) || gateSatisfied) {
+    const shortsGated = shouldGateShorts(url, config) && !gateSatisfied;
+
+    // The channel gate is scoped to the exact URL that satisfied it, so completing a pause
+    // on one video does not buy access to the next. (Shorts keeps its own coarser grant:
+    // swiping within Shorts is one continuous session, not a fresh decision each time.)
+    const channelVerdict =
+      channelGateSatisfiedFor === url ? null : watchChannelVerdict(doc, config, { url });
+    const channelGate = channelVerdict?.action === 'BLOCK' ? channelVerdict : null;
+
+    if (!shortsGated && channelGate === null) {
       teardownOverlay();
       return;
     }
@@ -405,17 +435,45 @@ export function initYoutubeContentScript(
 
     teardownOverlay();
     pauseMedia(doc);
-    overlay = createShortsOverlay(doc, config, {
-      onComplete: () => {
-        gateSatisfied = true;
-        teardownOverlay();
-      },
-      onBail: () => {
-        teardownOverlay();
-        doc.location.assign(BAIL_URL);
-      },
-    });
-    overlayHost(doc).append(overlay.element);
+
+    if (shortsGated) {
+      overlay = createShortsOverlay(doc, config, {
+        onComplete: () => {
+          gateSatisfied = true;
+          teardownOverlay();
+        },
+        onBail: () => {
+          teardownOverlay();
+          doc.location.assign(BAIL_URL);
+        },
+      });
+    } else if (channelGate !== null) {
+      const gatedUrl = url;
+      overlay = createShortsOverlay(
+        doc,
+        { shortsMode: channelGate.mode, shortsDelaySeconds: config.channelDelaySeconds },
+        {
+          onComplete: () => {
+            channelGateSatisfiedFor = gatedUrl;
+            teardownOverlay();
+          },
+          onBail: () => {
+            teardownOverlay();
+            doc.location.assign(BAIL_URL);
+          },
+        },
+        {
+          title: 'This channel is off your list',
+          subtitle:
+            config.channelMode === 'WHITELIST'
+              ? 'You chose to watch only channels you picked. Still want this one?'
+              : 'You asked Nudge to keep you away from this channel.',
+          ruleLabel: 'YouTube channels',
+        },
+      );
+    }
+
+    if (overlay !== null) overlayHost(doc).append(overlay.element);
   }
 
   function scheduleRefresh(): void {

--- a/extension/src/content/youtube.ts
+++ b/extension/src/content/youtube.ts
@@ -332,11 +332,22 @@ export interface YoutubeController {
   stop: () => void;
 }
 
+/** Everything off. What the script assumes until the worker answers. */
 const IDLE_CONFIG: YoutubeConfig = {
   enabled: false,
   hideShortsShelf: false,
   shortsMode: 'ALLOW',
   shortsDelaySeconds: 15,
+  channelMode: 'OFF',
+  channels: [],
+  channelBlockMode: 'DELAY',
+  channelDelaySeconds: 15,
+  grayScreen: false,
+  hideHomeFeed: false,
+  hideSidebarRecs: false,
+  hideEndScreen: false,
+  hideComments: false,
+  disableAutoplay: false,
 };
 
 /**

--- a/extension/src/content/youtube.ts
+++ b/extension/src/content/youtube.ts
@@ -25,6 +25,8 @@ import type { YoutubeConfig } from '../core/protocol';
 import { MODE_LABELS } from '../core/types';
 import { send } from '../ui/rpc';
 import { applyChannelFilter, applyGrayColor, watchChannelVerdict } from './channelFilter';
+import { channelKey, SETTLE_RECHECK_MS } from '../core/channelFreshness';
+import { detectWatchChannel } from './channelDetection';
 import { applyAutoplayOff, applyHideToggles } from './unhook';
 import {
   HIDDEN_CLASS,
@@ -386,6 +388,12 @@ export function initYoutubeContentScript(
   let gateSatisfied = false;
   /** The watch URL whose channel gate the user has already completed, if any. */
   let channelGateSatisfiedFor: string | null = null;
+  /** Identity of the channel confirmed for the video BEFORE the latest navigation. */
+  let previousChannelKey: string | null = null;
+  /** When the latest navigation happened, for the settle window. */
+  let navAt = 0;
+  /** Storm-proof re-checks scheduled after a navigation. */
+  const settleTimers: number[] = [];
   let lastUrl = doc.location?.href ?? '';
   let debounceTimer: number | undefined;
   let stopped = false;
@@ -404,10 +412,17 @@ export function initYoutubeContentScript(
 
     const url = currentHref();
     if (url !== lastUrl) {
+      // Remember what we were confident about BEFORE the hop: while the new page's byline
+      // still reports that same channel we cannot tell "stale" from "same channel again",
+      // so the verdict is withheld (core/channelFreshness.ts).
+      previousChannelKey = channelKey(detectWatchChannel(doc, { url: lastUrl }));
       lastUrl = url;
+      navAt = Date.now();
+      scheduleSettleChecks();
       // Leaving Shorts resets the grant - coming back should cost you the pause again.
       if (pageTypeFor(url) !== 'shorts') gateSatisfied = false;
     }
+    const msSinceNav = navAt === 0 ? Number.POSITIVE_INFINITY : Date.now() - navAt;
 
     // The passive layers run on EVERY pass, before and independently of any gate: hiding,
     // feed filtering and the colour flip must be correct even while an interstitial is up,
@@ -415,7 +430,7 @@ export function initYoutubeContentScript(
     applyShortsHiding(doc, config, { url });
     applyHideToggles(doc, config, { url });
     applyChannelFilter(doc, config);
-    applyGrayColor(doc, config, { url });
+    applyGrayColor(doc, config, { url, previousKey: previousChannelKey, msSinceNav });
     if (config.disableAutoplay) applyAutoplayOff(doc, config);
 
     const shortsGated = shouldGateShorts(url, config) && !gateSatisfied;
@@ -424,7 +439,13 @@ export function initYoutubeContentScript(
     // on one video does not buy access to the next. (Shorts keeps its own coarser grant:
     // swiping within Shorts is one continuous session, not a fresh decision each time.)
     const channelVerdict =
-      channelGateSatisfiedFor === url ? null : watchChannelVerdict(doc, config, { url });
+      channelGateSatisfiedFor === url
+        ? null
+        : watchChannelVerdict(doc, config, {
+            url,
+            previousKey: previousChannelKey,
+            msSinceNav,
+          });
     const channelGate = channelVerdict?.action === 'BLOCK' ? channelVerdict : null;
 
     if (!shortsGated && channelGate === null) {
@@ -476,6 +497,22 @@ export function initYoutubeContentScript(
     if (overlay !== null) overlayHost(doc).append(overlay.element);
   }
 
+  /**
+   * Re-check on our OWN timers after a navigation.
+   *
+   * The debounced observer alone is not enough: YouTube's post-navigation mutation storm
+   * keeps resetting the 250ms debounce, so the corrective pass can be starved for seconds, 
+   * that starvation is what stretched the settle window out to ~5s in live QA. These fire
+   * regardless of page mutation, so the verdict is always re-evaluated on schedule.
+   */
+  function scheduleSettleChecks(): void {
+    if (!view) return;
+    for (const id of settleTimers.splice(0)) view.clearTimeout(id);
+    for (const delay of SETTLE_RECHECK_MS) {
+      settleTimers.push(view.setTimeout(() => refresh(), delay));
+    }
+  }
+
   function scheduleRefresh(): void {
     if (stopped || !view) return;
     if (debounceTimer !== undefined) view.clearTimeout(debounceTimer);
@@ -525,6 +562,7 @@ export function initYoutubeContentScript(
       observer?.disconnect();
       if (safetyNet !== undefined) view?.clearInterval(safetyNet);
       if (debounceTimer !== undefined) view?.clearTimeout(debounceTimer);
+      for (const id of settleTimers.splice(0)) view?.clearTimeout(id);
       chromeApi?.storage?.onChanged?.removeListener(onStorageChanged);
       teardownOverlay();
     },

--- a/extension/src/core/channelFreshness.ts
+++ b/extension/src/core/channelFreshness.ts
@@ -1,0 +1,92 @@
+/**
+ * Is the channel we just detected actually describing the video on screen YET? PURE.
+ *
+ * THE SETTLE WINDOW (live QA, 2026-07-26). Fixing the permanent SPA-staleness bypass left a
+ * transient one. On a watch -> watch client-side navigation YouTube fires `yt-navigate-finish`
+ * BEFORE it re-renders the owner byline (ext-03 §2 warns metadata lags the event), so for
+ * ~1.5-5s the DOM tier still reports the PREVIOUS video's channel. Two bad outcomes:
+ *
+ *   forward  (allowed -> blocked): a couple of seconds ungated. Mild — it is the fail-open
+ *            we already chose deliberately.
+ *   reverse  (blocked -> allowed): the WORSE one. A channel the user explicitly allowed
+ *            flashes "This channel is off your list" and goes gray for 3-5s. Punishing
+ *            someone for watching what they said they wanted is the most damaging thing
+ *            this extension can do, and it teaches them to distrust the gate.
+ *
+ * The discriminator is cheap: staleness only MATTERS when the byline still shows the channel
+ * from before the navigation. If what we detect now differs from what we detected then, the
+ * byline has demonstrably re-rendered and can be trusted immediately. If it is the same, we
+ * genuinely cannot distinguish "stale" from "two videos by the same channel" — so we wait,
+ * and while waiting we withhold the interstitial rather than risk a false accusation.
+ *
+ * Waiting is safe in one direction only, which is why gray-screen is handled separately:
+ * staying GRAY during the window costs nothing, so colour is withheld too.
+ */
+
+/** A comparable identity for a detected channel. Null when nothing was identified. */
+export function channelKey(
+  detected: { channelId?: string | null; handle?: string | null } | null,
+): string | null {
+  const id = detected?.channelId ?? null;
+  const handle = detected?.handle ?? null;
+  if (id === null && handle === null) return null;
+  return `${id ?? ''}|${(handle ?? '').toLowerCase()}`;
+}
+
+/**
+ * How long to keep waiting before accepting the byline anyway.
+ *
+ * Generous on purpose. It only bites when the detected channel never changes across the
+ * navigation — which is either a genuine same-channel hop (where the verdict is identical
+ * and the delay costs nothing) or a byline that lagged unusually long. In the common
+ * different-channel case confirmation arrives the moment the byline re-renders, typically
+ * well under 2s, so a long backstop buys safety without adding latency.
+ */
+export const SETTLE_MS = 6_000;
+
+export type Freshness = 'CONFIRMED' | 'SETTLING';
+
+export interface FreshnessInput {
+  /** The video id in the address bar, or null when this page names no video. */
+  videoId: string | null;
+  /** The video id the inline page data declares, if any. */
+  inlineVideoId: string | null;
+  /** Identity of the channel detected right now. */
+  detectedKey: string | null;
+  /** Identity confirmed for the PREVIOUS video, or null if there was none. */
+  previousKey: string | null;
+  /** Time since the navigation to the current video. */
+  msSinceNav: number;
+  settleMs?: number;
+}
+
+/**
+ * Whether the current detection can be acted on, or is still settling after a navigation.
+ *
+ * CONFIRMED as soon as ANY of these hold, cheapest first:
+ *  - the inline data declares the video the URL names (authoritative; a full page load)
+ *  - there is no previous channel to be stale from (first view of the session)
+ *  - what we detect now differs from before the nav (the byline demonstrably re-rendered)
+ *  - the backstop elapsed (accept it rather than wait forever)
+ */
+export function channelFreshness(input: FreshnessInput): Freshness {
+  const { videoId, inlineVideoId, detectedKey, previousKey, msSinceNav } = input;
+  const settleMs = input.settleMs ?? SETTLE_MS;
+
+  if (videoId !== null && inlineVideoId === videoId) return 'CONFIRMED';
+  if (previousKey === null) return 'CONFIRMED';
+  if (detectedKey !== previousKey) return 'CONFIRMED';
+  if (msSinceNav >= settleMs) return 'CONFIRMED';
+
+  return 'SETTLING';
+}
+
+/**
+ * Extra re-check times after a navigation, in ms.
+ *
+ * The debounced observer alone is not enough: YouTube's post-navigation mutation storm keeps
+ * resetting the debounce, so the corrective pass can be starved for seconds — that starvation
+ * is what stretched the window to 5s. These fire on their own timers and cannot be reset by
+ * page mutation, guaranteeing the verdict is re-evaluated whether or not the storm ever calms.
+ */
+export const SETTLE_RECHECK_MS: readonly number[] = [400, 900, 1_800, 3_200, SETTLE_MS + 100];

--- a/extension/src/core/channels.ts
+++ b/extension/src/core/channels.ts
@@ -1,0 +1,369 @@
+/**
+ * YouTube channel whitelist/blacklist logic. PURE — no chrome.* imports, no DOM access.
+ *
+ * Three jobs live here: turning whatever a user typed/pasted into a storable
+ * `ChannelEntry` (`parseChannelInput`), matching a channel the content script observed
+ * against the stored list (`findChannel`/`isChannelListed`/`sameChannel`), and the actual
+ * ALLOW/BLOCK decision for a channel-mode rule (`decideChannel`) plus its gray-screen
+ * cousin (`shouldShowInColor`). Spec: ext-03-youtube-techniques.md §3 (channel detection)
+ * and §4 (whitelist/blacklist modes).
+ */
+
+import type { BlockMode } from './types';
+import type { ChannelEntry, ChannelListMode } from './settingsSchema';
+
+// ---------------------------------------------------------------------------------------
+// parseChannelInput
+// ---------------------------------------------------------------------------------------
+
+/** Exact channel-id shape: "UC" + 22 more characters, always this length. */
+const CHANNEL_ID_RE = /^UC[A-Za-z0-9_-]{22}$/;
+
+/**
+ * Loose "this was clearly an attempt at a channel id" detector — deliberately wider than
+ * `CHANNEL_ID_RE` so a typo'd or truncated id (one char short, one char extra, a bad
+ * character) is REJECTED outright instead of silently being filed as a handle literally
+ * called "UCxxxx…". Nobody's real handle starts with "UC" followed by 15+ more characters.
+ * A wrong id that fails loudly is recoverable; one that quietly becomes an unrelated
+ * "handle" is not.
+ */
+const CHANNEL_ID_NEAR_MISS_RE = /^UC[A-Za-z0-9_-]{15,35}$/;
+
+/** Permissive handle/vanity-name charset. Real YouTube handles are narrower, but this
+ * module only needs to reject obvious garbage (spaces, punctuation, empty). */
+const HANDLE_CHARS_RE = /^[A-Za-z0-9._-]{1,30}$/;
+
+function isValidChannelId(value: string): boolean {
+  return CHANNEL_ID_RE.test(value);
+}
+
+function pathSegments(path: string): string[] {
+  return path.split('/').filter((segment) => segment.length > 0);
+}
+
+/**
+ * Locate "youtube.com" as an actual HOST inside `lower`, not merely as a substring —
+ * guards the same superstring trap `domainMatcher.ts` guards against ("notyoutube.com"
+ * contains "youtube.com" starting at index 3, but is not YouTube). A match must be
+ * preceded by a host/scheme boundary (start, '.', '/', ':') and followed by a path/port
+ * boundary (end, '/', ':', '?', '#').
+ */
+function findYoutubeHostIndex(lower: string): number {
+  const marker = 'youtube.com';
+  let from = 0;
+  for (;;) {
+    const idx = lower.indexOf(marker, from);
+    if (idx === -1) return -1;
+    const before = idx === 0 ? '' : lower[idx - 1]!;
+    const afterIdx = idx + marker.length;
+    const after = afterIdx >= lower.length ? '' : lower[afterIdx]!;
+    const boundaryBefore = before === '' || before === '.' || before === '/' || before === ':';
+    const boundaryAfter =
+      after === '' || after === '/' || after === ':' || after === '?' || after === '#';
+    if (boundaryBefore && boundaryAfter) return idx;
+    from = idx + 1;
+  }
+}
+
+/** Returns the path after "youtube.com" (query/fragment stripped), or null when `trimmed`
+ * is not a YouTube URL at all — in which case the caller treats it as a bare token. */
+function extractYoutubePath(trimmed: string): string | null {
+  const lower = trimmed.toLowerCase();
+  const idx = findYoutubeHostIndex(lower);
+  if (idx === -1) return null;
+
+  let rest = trimmed.slice(idx + 'youtube.com'.length);
+  if (rest.startsWith(':')) {
+    // A port, e.g. "youtube.com:443/@x" — skip to the next path separator.
+    const slash = rest.indexOf('/');
+    rest = slash === -1 ? '' : rest.slice(slash);
+  }
+  return rest.split('?')[0]!.split('#')[0]!;
+}
+
+function buildHandleEntry(handleRaw: string, now: number): ChannelEntry {
+  const handle = handleRaw.toLowerCase();
+  return { channelId: null, handle, displayName: `@${handle}`, addedAt: now };
+}
+
+function buildIdEntry(id: string, now: number): ChannelEntry {
+  // Ids are case-SENSITIVE and kept exactly as given — no displayName candidate better
+  // than the id itself is available from a URL/id alone.
+  return { channelId: id, handle: null, displayName: id, addedAt: now };
+}
+
+function buildLegacyEntry(nameRaw: string, now: number): ChannelEntry {
+  // Legacy "/c/Name" and "/user/name" URLs. The original-case segment IS the nicest human
+  // form we have — it's the "given name" the displayName rule prefers — while the stored
+  // `handle` is lowercased for matching, same as a real handle.
+  return { channelId: null, handle: nameRaw.toLowerCase(), displayName: nameRaw, addedAt: now };
+}
+
+function parseHandleToken(handleRaw: string, now: number): ChannelEntry | null {
+  if (!HANDLE_CHARS_RE.test(handleRaw)) return null;
+  return buildHandleEntry(handleRaw, now);
+}
+
+function parseYoutubePath(path: string, now: number): ChannelEntry | null {
+  const segments = pathSegments(path);
+  if (segments.length === 0) return null; // bare "youtube.com" or "youtube.com/" — no channel
+  const first = segments[0]!;
+  const second = segments[1];
+
+  if (first.startsWith('@')) {
+    return parseHandleToken(first.slice(1), now);
+  }
+
+  if (first === 'channel') {
+    // Near-misses are rejected the same as a strict-id mismatch anywhere else — there is
+    // no ambiguity to fall back to here, the URL explicitly says "channel".
+    return second !== undefined && isValidChannelId(second) ? buildIdEntry(second, now) : null;
+  }
+
+  if (first === 'c' || first === 'user') {
+    // Legacy custom/vanity URLs ("/c/Veritasium", "/user/1veritasium"). These are NOT
+    // ids and NOT real handles — the vanity-name -> handle mapping only exists
+    // server-side on YouTube, and this module is pure (no network), so it cannot be
+    // resolved here. Best effort: store the path segment itself as the `handle`, since
+    // it is the only identifier the URL gives us and it lets a later probe carrying the
+    // channel's REAL handle or id still reconcile with this entry via `sameChannel`.
+    // This is a documented approximation, not a guarantee: if the vanity name and the
+    // real handle diverge, matching by handle alone will miss until an id is learned.
+    return second !== undefined && HANDLE_CHARS_RE.test(second)
+      ? buildLegacyEntry(second, now)
+      : null;
+  }
+
+  // Any other first segment ("watch", "shorts", "results", "feed", "playlist", "embed",
+  // ...) names something other than a channel.
+  return null;
+}
+
+function parseBareToken(trimmed: string, now: number): ChannelEntry | null {
+  if (trimmed.startsWith('@')) {
+    return parseHandleToken(trimmed.slice(1), now);
+  }
+  if (CHANNEL_ID_RE.test(trimmed)) {
+    return buildIdEntry(trimmed, now);
+  }
+  if (CHANNEL_ID_NEAR_MISS_RE.test(trimmed)) {
+    return null; // rejected near-miss id — see CHANNEL_ID_NEAR_MISS_RE
+  }
+  return parseHandleToken(trimmed, now);
+}
+
+/**
+ * Turn whatever a user typed or pasted into a `ChannelEntry`, or null when it doesn't
+ * name a channel at all (a watch URL, garbage text, blank input).
+ *
+ * Accepts: a bare handle ("@veritasium", "veritasium"), a handle URL
+ * ("https://www.youtube.com/@veritasium", "youtube.com/@veritasium/videos"), a canonical
+ * id URL ("https://www.youtube.com/channel/UCxxxx…"), a bare id ("UCxxxx…"), and legacy
+ * custom URLs ("youtube.com/c/Veritasium", "youtube.com/user/1veritasium" — see the
+ * comment in `parseYoutubePath` for how those are handled).
+ *
+ * `now` is injectable (defaults to `Date.now()`) so callers/tests get a deterministic
+ * `addedAt`.
+ */
+export function parseChannelInput(raw: string, now: number = Date.now()): ChannelEntry | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+
+  const youtubePath = extractYoutubePath(trimmed);
+  if (youtubePath !== null) {
+    return parseYoutubePath(youtubePath, now);
+  }
+  return parseBareToken(trimmed, now);
+}
+
+// ---------------------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------------------
+
+/**
+ * True when `a` and `b` describe the same channel — sharing EITHER identifier is enough,
+ * because a single entry frequently only has one (captured from wherever the user added
+ * it). Ids compare case-SENSITIVELY (YouTube ids are case-sensitive); handles compare
+ * case-INSENSITIVELY regardless of how they happen to be cased on either side.
+ */
+export function sameChannel(a: ChannelEntry, b: ChannelEntry): boolean {
+  const idMatch = a.channelId !== null && b.channelId !== null && a.channelId === b.channelId;
+  const handleMatch =
+    a.handle !== null && b.handle !== null && a.handle.toLowerCase() === b.handle.toLowerCase();
+  return idMatch || handleMatch;
+}
+
+/**
+ * What the content script actually has when it wants to check a channel against the
+ * list. It may carry only ONE of the two — a feed card usually exposes just a handle,
+ * a watch page's player response usually gives just the canonical id — or, when
+ * detection fails outright, NEITHER (see `decideChannel`'s unknown-channel handling).
+ */
+export interface ChannelProbe {
+  channelId?: string | null;
+  handle?: string | null;
+}
+
+function normalizeProbeHandle(handle: string | null | undefined): string | null {
+  if (handle === null || handle === undefined) return null;
+  return handle.replace(/^@/, '').toLowerCase();
+}
+
+/** Find the stored entry matching `probe` by EITHER identifier — the whole point of
+ * storing both. Returns null when the probe carries no identifier, or none match. */
+export function findChannel(
+  list: readonly ChannelEntry[],
+  probe: ChannelProbe,
+): ChannelEntry | null {
+  const probeId = probe.channelId ?? null;
+  const probeHandle = normalizeProbeHandle(probe.handle);
+  if (probeId === null && probeHandle === null) return null;
+
+  for (const entry of list) {
+    const idMatch = probeId !== null && entry.channelId !== null && entry.channelId === probeId;
+    const handleMatch =
+      probeHandle !== null && entry.handle !== null && entry.handle === probeHandle;
+    if (idMatch || handleMatch) return entry;
+  }
+  return null;
+}
+
+export function isChannelListed(list: readonly ChannelEntry[], probe: ChannelProbe): boolean {
+  return findChannel(list, probe) !== null;
+}
+
+// ---------------------------------------------------------------------------------------
+// Decision
+// ---------------------------------------------------------------------------------------
+
+export type ChannelVerdict =
+  | { action: 'ALLOW'; reason: 'mode-off' | 'not-listed' | 'listed' | 'unknown-channel' }
+  | { action: 'BLOCK'; mode: BlockMode };
+
+/** Shape shared by `decideChannel` and `shouldShowInColor` — both are "given the current
+ * channel-list mode and a probe, what do we know about this channel". */
+export interface ChannelDecisionInput {
+  mode: ChannelListMode;
+  channels: readonly ChannelEntry[];
+  probe: ChannelProbe;
+}
+
+function probeHasIdentifier(probe: ChannelProbe): boolean {
+  return (probe.channelId ?? null) !== null || (probe.handle ?? null) !== null;
+}
+
+/**
+ * The core channel-list decision.
+ *
+ *   - mode 'OFF'        -> always ALLOW (reason 'mode-off'); the feature isn't in use.
+ *   - mode 'BLACKLIST'  -> listed channels BLOCK (in `blockMode`); everything else ALLOWs.
+ *   - mode 'WHITELIST'  -> listed channels ALLOW; everything else BLOCKs. A HARD whitelist.
+ *
+ * THE UNKNOWN-CHANNEL CASE is load-bearing. When `probe` carries NEITHER `channelId` nor
+ * `handle` — channel detection failed, e.g. YouTube changed its DOM or the page hasn't
+ * hydrated yet — what should happen?
+ *
+ *   - BLACKLIST: an unknown channel cannot be proven to be ON the list, so it must ALLOW.
+ *     Blocking here would mean a single detection miss blocks ALL of YouTube, not just the
+ *     channel that should have matched — worse than the blacklist doing nothing.
+ *   - WHITELIST: an unknown channel cannot be proven to be ALLOWED either, and here both
+ *     choices are bad in a different way: BLOCKing turns a detection failure into "all of
+ *     YouTube is now broken" (a hard whitelist becomes a hard "block everything" the
+ *     moment a selector rots), while ALLOWing silently defeats the whitelist's entire
+ *     purpose for exactly the videos it failed to identify.
+ *
+ * We choose ALLOW for the unknown case in BOTH modes — fail OPEN, never fail shut on a
+ * browser-wide surface — but make the choice OBSERVABLE rather than silent: `reason:
+ * 'unknown-channel'` is a distinct value from `'not-listed'` / `'listed'` / `'mode-off'`,
+ * so a caller (and eventually a "channel detection degraded" UI hint) can tell "we let
+ * this through because we checked and it's fine" from "we let this through because we
+ * genuinely could not tell". A silent fail-open is a bug; a documented, observable one is
+ * a design decision.
+ */
+export function decideChannel(
+  params: ChannelDecisionInput & { blockMode: BlockMode },
+): ChannelVerdict {
+  const { mode, channels, probe, blockMode } = params;
+
+  if (mode === 'OFF') {
+    return { action: 'ALLOW', reason: 'mode-off' };
+  }
+
+  if (!probeHasIdentifier(probe)) {
+    return { action: 'ALLOW', reason: 'unknown-channel' };
+  }
+
+  const listed = isChannelListed(channels, probe);
+
+  if (mode === 'BLACKLIST') {
+    return listed
+      ? { action: 'BLOCK', mode: blockMode }
+      : { action: 'ALLOW', reason: 'not-listed' };
+  }
+
+  // mode === 'WHITELIST'
+  return listed ? { action: 'ALLOW', reason: 'listed' } : { action: 'BLOCK', mode: blockMode };
+}
+
+/**
+ * Gray-screen mode: true ONLY when the channel is positively identified AND either the
+ * list is a WHITELIST that includes it, or a BLACKLIST that excludes it — i.e. exactly
+ * the channels `decideChannel` would ALLOW *because it checked*, never because it
+ * couldn't. An unknown channel is NEVER shown in colour: unlike blocking, staying gray
+ * is harmless (the content is still reachable, just desaturated), so there is no
+ * fail-open pressure here — gray is simply the safe default whenever we can't identify
+ * the channel, and it also stays the default when `mode` is 'OFF' (no list to check a
+ * channel against yet).
+ */
+export function shouldShowInColor(params: ChannelDecisionInput): boolean {
+  const { mode, channels, probe } = params;
+  if (!probeHasIdentifier(probe)) return false;
+
+  const listed = isChannelListed(channels, probe);
+  if (mode === 'WHITELIST') return listed;
+  if (mode === 'BLACKLIST') return !listed;
+  return false; // mode === 'OFF'
+}
+
+// ---------------------------------------------------------------------------------------
+// List mutation
+// ---------------------------------------------------------------------------------------
+
+/**
+ * Add `entry` to `list`, merging into an existing entry that describes the same channel
+ * (via `sameChannel`) rather than creating a duplicate row. Mirrors
+ * `settingsSchema.ts`'s `dedupeChannels` merge behaviour: a missing identifier on the
+ * existing row is filled in from the incoming one, and a bare "@handle" displayName
+ * yields to a nicer name once one is known. Pure — always returns a NEW array, never
+ * mutates `list` or its entries.
+ */
+export function addChannel(list: readonly ChannelEntry[], entry: ChannelEntry): ChannelEntry[] {
+  const idx = list.findIndex((existing) => sameChannel(existing, entry));
+  if (idx === -1) {
+    return [...list, entry];
+  }
+
+  const existing = list[idx]!;
+  const merged: ChannelEntry = {
+    channelId: existing.channelId ?? entry.channelId,
+    handle: existing.handle ?? entry.handle,
+    displayName:
+      existing.displayName.startsWith('@') && !entry.displayName.startsWith('@')
+        ? entry.displayName
+        : existing.displayName,
+    addedAt: existing.addedAt,
+  };
+
+  const next = [...list];
+  next[idx] = merged;
+  return next;
+}
+
+/** Remove every entry describing the same channel as `entry` (via `sameChannel`). Pure —
+ * returns a NEW array, never mutates `list`. */
+export function removeChannel(
+  list: readonly ChannelEntry[],
+  entry: ChannelEntry,
+): ChannelEntry[] {
+  return list.filter((existing) => !sameChannel(existing, entry));
+}

--- a/extension/src/core/protocol.ts
+++ b/extension/src/core/protocol.ts
@@ -8,7 +8,12 @@
  */
 
 import type { BlockDecision, BlockMode } from './types';
-import type { NudgeSettings, SiteRule } from './settingsSchema';
+import type {
+  ChannelEntry,
+  ChannelListMode,
+  NudgeSettings,
+  SiteRule,
+} from './settingsSchema';
 
 /** Everything the block page needs to render, fetched in one round trip. */
 export interface BlockContext {
@@ -98,6 +103,22 @@ export interface YoutubeConfig {
   /** The resolved mode for /shorts/*, already accounting for INHERIT. */
   shortsMode: BlockMode | 'ALLOW';
   shortsDelaySeconds: number;
+
+  // --- v1.1 ---
+  /** How `channels` is interpreted: off / listed-are-blocked / only-listed-are-allowed. */
+  channelMode: ChannelListMode;
+  /** The list itself. BOTH identifiers travel so the page can match on either. */
+  channels: ChannelEntry[];
+  /** Mode applied to a channel the list disallows. */
+  channelBlockMode: BlockMode;
+  channelDelaySeconds: number;
+  /** Grayscale all of YouTube; allowed channels flip back to colour. */
+  grayScreen: boolean;
+  hideHomeFeed: boolean;
+  hideSidebarRecs: boolean;
+  hideEndScreen: boolean;
+  hideComments: boolean;
+  disableAutoplay: boolean;
 }
 
 export interface ResponseMap {

--- a/extension/src/core/settingsSchema.ts
+++ b/extension/src/core/settingsSchema.ts
@@ -10,7 +10,16 @@
 
 import type { BlockMode } from './types';
 
-export const SCHEMA_VERSION = 1;
+/**
+ * 1 -> 2 (Phase 4): YouTube channel lists, gray-screen mode, and the Unhook-parity hide
+ * toggles.
+ *
+ * Purely ADDITIVE, and every new default is "off", so a v1 user's protection is neither
+ * weakened nor silently strengthened by the upgrade. `migrateSettings` is the ONLY migration
+ * path and is already total — it rebuilds every field from whatever it is handed — so there
+ * is no per-version branch to keep in sync as the schema grows.
+ */
+export const SCHEMA_VERSION = 2;
 
 /** Delay presets, seconds (Android parity). Custom range 1–300. */
 export const DELAY_PRESETS = [5, 15, 30, 60] as const;
@@ -87,13 +96,59 @@ export interface EmergencyPassSettings {
   enabled: boolean;
 }
 
-/** YouTube feature rule — the Android "Feature Rules" analog. */
+/**
+ * How the channel list is interpreted. The list itself is one array either way — the mode
+ * decides whether being ON it means "block this" or "this is the only thing allowed".
+ */
+export type ChannelListMode = 'OFF' | 'BLACKLIST' | 'WHITELIST';
+
+/**
+ * One channel in the list.
+ *
+ * BOTH identifiers are stored and EITHER matches. They are captured from different places
+ * and neither is always available: a feed card usually exposes only `/@handle`, while the
+ * watch page's player response gives the canonical `UCxxxx` id. Storing one and hoping is
+ * how a whitelist silently fails to recognise a channel the user added.
+ */
+export interface ChannelEntry {
+  /** Canonical channel id, `UCxxxx…`. null when the user supplied only a handle. */
+  channelId: string | null;
+  /** Handle WITHOUT the leading '@', lowercased. null when only an id is known. */
+  handle: string | null;
+  /** What the UI shows. Falls back to the handle or id when YouTube never told us a name. */
+  displayName: string;
+  addedAt: number;
+}
+
+/** YouTube feature rules — the Android "Feature Rules" analog, plus the v1.1 additions. */
 export interface YoutubeSettings {
   /** 'INHERIT' defers to the site rule for youtube.com (if any). */
   shortsMode: 'INHERIT' | BlockMode;
   /** Hide the Shorts shelf/tab/cards across YouTube surfaces. */
   hideShortsShelf: boolean;
   shortsDelaySeconds: number;
+
+  // --- v1.1: channel lists ---
+  channelMode: ChannelListMode;
+  channels: ChannelEntry[];
+  /** The block mode applied to a channel the list disallows. */
+  channelBlockMode: BlockMode;
+  channelDelaySeconds: number;
+
+  // --- v1.1: gray-screen mode ---
+  /**
+   * Grayscale ALL of YouTube; whitelisted channels come back in colour. Nobody else ships
+   * this (ext-02), and it is the softest possible intervention: the content is still there,
+   * it just stops being candy.
+   */
+  grayScreen: boolean;
+
+  // --- v1.1: Unhook-parity hide toggles, each independent, all default off ---
+  hideHomeFeed: boolean;
+  hideSidebarRecs: boolean;
+  hideEndScreen: boolean;
+  hideComments: boolean;
+  disableAutoplay: boolean;
 }
 
 export interface NudgeSettings {
@@ -121,6 +176,16 @@ export const DEFAULT_SETTINGS: NudgeSettings = {
     shortsMode: 'INHERIT',
     hideShortsShelf: false,
     shortsDelaySeconds: DEFAULT_DELAY_SECONDS,
+    channelMode: 'OFF',
+    channels: [],
+    channelBlockMode: 'DELAY',
+    channelDelaySeconds: DEFAULT_DELAY_SECONDS,
+    grayScreen: false,
+    hideHomeFeed: false,
+    hideSidebarRecs: false,
+    hideEndScreen: false,
+    hideComments: false,
+    disableAutoplay: false,
   },
   tempAllowMinutes: DEFAULT_TEMP_ALLOW_MINUTES,
 };
@@ -144,6 +209,76 @@ function coerceMode(value: unknown, fallback: BlockMode): BlockMode {
 function coerceShortsMode(value: unknown): 'INHERIT' | BlockMode {
   if (value === 'INHERIT') return 'INHERIT';
   return VALID_MODES.includes(value as BlockMode) ? (value as BlockMode) : 'INHERIT';
+}
+
+const VALID_CHANNEL_MODES: readonly ChannelListMode[] = ['OFF', 'BLACKLIST', 'WHITELIST'];
+
+function coerceChannelMode(value: unknown): ChannelListMode {
+  return VALID_CHANNEL_MODES.includes(value as ChannelListMode)
+    ? (value as ChannelListMode)
+    : 'OFF';
+}
+
+/**
+ * Normalize one stored channel entry.
+ *
+ * An entry with NEITHER identifier is dropped: it could never match anything, so keeping it
+ * would only show the user a list row that silently does nothing.
+ */
+function coerceChannel(value: unknown): ChannelEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Partial<ChannelEntry>;
+
+  const channelId =
+    typeof raw.channelId === 'string' && raw.channelId.trim() !== ''
+      ? raw.channelId.trim()
+      : null;
+  const handle =
+    typeof raw.handle === 'string' && raw.handle.trim() !== ''
+      ? raw.handle.trim().replace(/^@/, '').toLowerCase()
+      : null;
+  if (channelId === null && handle === null) return null;
+
+  const displayName =
+    typeof raw.displayName === 'string' && raw.displayName.trim() !== ''
+      ? raw.displayName.trim()
+      : (handle !== null ? `@${handle}` : (channelId ?? ''));
+
+  return {
+    channelId,
+    handle,
+    displayName,
+    addedAt: typeof raw.addedAt === 'number' ? raw.addedAt : 0,
+  };
+}
+
+/**
+ * De-duplicate a channel list, merging entries that describe the same channel.
+ *
+ * The same channel can be added twice by different routes (once by handle from a feed card,
+ * once by id from a watch page). Left un-merged, a whitelist would show it twice and a
+ * blacklist would look inconsistent, so entries that share EITHER identifier are folded
+ * together — which also fills in the identifier the other copy was missing.
+ */
+function dedupeChannels(entries: readonly ChannelEntry[]): ChannelEntry[] {
+  const merged: ChannelEntry[] = [];
+  for (const entry of entries) {
+    const existing = merged.find(
+      (candidate) =>
+        (entry.channelId !== null && candidate.channelId === entry.channelId) ||
+        (entry.handle !== null && candidate.handle === entry.handle),
+    );
+    if (existing === undefined) {
+      merged.push(entry);
+      continue;
+    }
+    existing.channelId ??= entry.channelId;
+    existing.handle ??= entry.handle;
+    if (existing.displayName.startsWith('@') && !entry.displayName.startsWith('@')) {
+      existing.displayName = entry.displayName;
+    }
+  }
+  return merged;
 }
 
 function coerceStringArray(value: unknown): string[] {
@@ -247,6 +382,28 @@ export function migrateSettings(raw: unknown): NudgeSettings {
         DELAY_MIN_SECONDS,
         DELAY_MAX_SECONDS,
       ),
+      // v2 fields. A v1 settings object has none of these, so each falls back to its
+      // default — all "off", so upgrading never changes what a user is protected from.
+      channelMode: coerceChannelMode(yt.channelMode),
+      channels: dedupeChannels(
+        Array.isArray(yt.channels)
+          ? yt.channels.map(coerceChannel).filter((c): c is ChannelEntry => c !== null)
+          : [],
+      ),
+      channelBlockMode: coerceMode(yt.channelBlockMode, 'DELAY'),
+      channelDelaySeconds: clamp(
+        typeof yt.channelDelaySeconds === 'number'
+          ? yt.channelDelaySeconds
+          : DEFAULT_DELAY_SECONDS,
+        DELAY_MIN_SECONDS,
+        DELAY_MAX_SECONDS,
+      ),
+      grayScreen: yt.grayScreen === true,
+      hideHomeFeed: yt.hideHomeFeed === true,
+      hideSidebarRecs: yt.hideSidebarRecs === true,
+      hideEndScreen: yt.hideEndScreen === true,
+      hideComments: yt.hideComments === true,
+      disableAutoplay: yt.disableAutoplay === true,
     },
     tempAllowMinutes: clamp(
       typeof input.tempAllowMinutes === 'number'

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -1,5 +1,6 @@
 import { ensureAlarms, handleAlarm } from '../background/alarmsHub';
 import { applyRules } from '../background/dnr';
+import { applyGrayscale } from '../background/grayscale';
 import { registerMessageRouter } from '../background/messagesRouter';
 import { loadSettings } from '../background/storage';
 import { IDLE_DETECTION_SECONDS, onActivityEvent } from '../background/tracker';
@@ -21,7 +22,12 @@ export default defineBackground(() => {
   async function bootstrap(): Promise<void> {
     try {
       await chrome.idle.setDetectionInterval(IDLE_DETECTION_SECONDS);
-      await applyRules(await loadSettings());
+      const settings = await loadSettings();
+      await applyRules(settings);
+      // Gray-screen's content-script registration persists across sessions, so it is
+      // re-derived from settings here rather than only on change, otherwise a stale
+      // registration could outlive the setting that asked for it.
+      await applyGrayscale(settings.globalEnabled && settings.youtube.grayScreen);
       await ensureAlarms();
       await onActivityEvent();
     } catch (error) {
@@ -55,7 +61,10 @@ export default defineBackground(() => {
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'session') return;
     if (Object.keys(changes).some((key) => key === 'nudge:settings')) {
-      void loadSettings().then(applyRules);
+      void loadSettings().then(async (settings) => {
+        await applyRules(settings);
+        await applyGrayscale(settings.globalEnabled && settings.youtube.grayScreen);
+      });
     }
   });
 

--- a/extension/src/entrypoints/dashboard/SettingsPanel.tsx
+++ b/extension/src/entrypoints/dashboard/SettingsPanel.tsx
@@ -20,14 +20,12 @@ import {
   TEMP_ALLOW_MIN_MINUTES,
 } from '../../core/settingsSchema';
 import type { NudgeSettings, SiteRule } from '../../core/settingsSchema';
-import type { BlockMode } from '../../core/types';
 import { MODE_LABELS } from '../../core/types';
 import { buildExport, dedupeImportedRules, parseImport } from '../../ui/exportImport';
 import { formatMinuteOfDay } from '../../ui/format';
 import { Button, Card, Toggle } from '../../ui/components';
 import { RuleEditor } from './RuleEditor';
-
-const MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+import { YoutubePanel } from './YoutubePanel';
 
 const DIFFICULTIES: { label: string; length: number }[] = [
   { label: 'Easy', length: CHALLENGE_LENGTH_EASY },
@@ -455,75 +453,7 @@ export function SettingsPanel({
         </p>
       </Card>
 
-      <Card title="YouTube Shorts">
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 14 }}>
-          <Chip
-            label="Inherit"
-            active={settings.youtube.shortsMode === 'INHERIT'}
-            onClick={() => patch({ youtube: { ...settings.youtube, shortsMode: 'INHERIT' } })}
-          />
-          {MODES.map((m) => (
-            <Chip
-              key={m}
-              label={MODE_LABELS[m]}
-              active={settings.youtube.shortsMode === m}
-              onClick={() => patch({ youtube: { ...settings.youtube, shortsMode: m } })}
-            />
-          ))}
-        </div>
-        <p style={{ margin: '0 0 14px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
-          "Inherit" follows whatever rule you set for youtube.com.
-        </p>
-
-        {settings.youtube.shortsMode !== 'INHERIT' && settings.youtube.shortsMode !== 'HARD_BLOCK' && (
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center', marginBottom: 14 }}>
-            {DELAY_PRESETS.map((preset) => (
-              <Chip
-                key={preset}
-                label={`${preset}s`}
-                active={settings.youtube.shortsDelaySeconds === preset}
-                onClick={() => patch({ youtube: { ...settings.youtube, shortsDelaySeconds: preset } })}
-              />
-            ))}
-            <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
-              Custom
-              <input
-                type="number"
-                aria-label="Shorts custom delay seconds"
-                min={DELAY_MIN_SECONDS}
-                max={DELAY_MAX_SECONDS}
-                value={settings.youtube.shortsDelaySeconds}
-                onChange={(e) => {
-                  const parsed = Number(e.target.value);
-                  if (e.target.value !== '' && Number.isFinite(parsed)) {
-                    patch({
-                      youtube: {
-                        ...settings.youtube,
-                        shortsDelaySeconds: clamp(parsed, DELAY_MIN_SECONDS, DELAY_MAX_SECONDS),
-                      },
-                    });
-                  }
-                }}
-                style={{
-                  width: 64,
-                  marginLeft: 6,
-                  padding: '6px 8px',
-                  borderRadius: 8,
-                  border: '1px solid var(--nudge-outline)',
-                  background: 'var(--nudge-background)',
-                  color: 'var(--nudge-on-surface)',
-                }}
-              />
-            </label>
-          </div>
-        )}
-
-        <Toggle
-          checked={settings.youtube.hideShortsShelf}
-          onChange={(hideShortsShelf) => patch({ youtube: { ...settings.youtube, hideShortsShelf } })}
-          label="Hide Shorts shelf"
-        />
-      </Card>
+      <YoutubePanel settings={settings.youtube} onChange={(youtube) => patch({ youtube })} />
 
       <Card title="Escape Hatch">
         <Toggle

--- a/extension/src/entrypoints/dashboard/YoutubePanel.tsx
+++ b/extension/src/entrypoints/dashboard/YoutubePanel.tsx
@@ -1,0 +1,465 @@
+import { useState } from 'react';
+import { addChannel, parseChannelInput, removeChannel } from '../../core/channels';
+import {
+  DELAY_MAX_SECONDS,
+  DELAY_MIN_SECONDS,
+  DELAY_PRESETS,
+} from '../../core/settingsSchema';
+import type { ChannelEntry, ChannelListMode, YoutubeSettings } from '../../core/settingsSchema';
+import type { BlockMode } from '../../core/types';
+import { MODE_LABELS } from '../../core/types';
+import { Button, Card, Toggle } from '../../ui/components';
+
+const SHORTS_MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+const CHANNEL_BLOCK_MODES: BlockMode[] = ['HARD_BLOCK', 'DELAY', 'BREATHING'];
+
+const CHANNEL_MODE_OPTIONS: { mode: ChannelListMode; label: string; description: string }[] = [
+  {
+    mode: 'OFF',
+    label: 'Off',
+    description: "Every channel plays as normal — Nudge doesn't filter by channel.",
+  },
+  {
+    mode: 'BLACKLIST',
+    label: 'Block these channels',
+    description: 'Videos from the channels you list below are blocked. Everything else plays as normal.',
+  },
+  {
+    mode: 'WHITELIST',
+    label: 'Only allow these channels',
+    description:
+      'Only videos from the channels you list below are allowed. Everything else on YouTube gets blocked.',
+  },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+/** House chip pattern (mirrors SettingsPanel's local `Chip`) — no shared export exists yet. */
+function Chip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        padding: '6px 14px',
+        borderRadius: 999,
+        border: '1px solid var(--nudge-outline)',
+        background: active ? 'var(--nudge-primary)' : 'transparent',
+        color: active ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+        fontSize: 13,
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** Preset chips + a custom field, mirroring RuleEditor's `delayPicker` visual pattern. */
+function DelayPicker({
+  value,
+  onChange,
+  idPrefix,
+}: {
+  value: number;
+  onChange: (seconds: number) => void;
+  idPrefix: string;
+}) {
+  const isPreset = (DELAY_PRESETS as readonly number[]).includes(value);
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+      {DELAY_PRESETS.map((preset) => (
+        <button
+          key={preset}
+          type="button"
+          onClick={() => onChange(preset)}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 999,
+            border: '1px solid var(--nudge-outline)',
+            background: value === preset ? 'var(--nudge-primary)' : 'transparent',
+            color: value === preset ? 'var(--nudge-on-primary)' : 'var(--nudge-on-surface)',
+            fontSize: 12,
+            cursor: 'pointer',
+          }}
+        >
+          {preset}s
+        </button>
+      ))}
+      <label style={{ fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+        Custom
+        <input
+          type="number"
+          aria-label={`${idPrefix} custom delay seconds`}
+          min={DELAY_MIN_SECONDS}
+          max={DELAY_MAX_SECONDS}
+          value={isPreset ? '' : value}
+          placeholder={String(value)}
+          onChange={(e) => {
+            const parsed = Number(e.target.value);
+            if (e.target.value !== '' && Number.isFinite(parsed)) {
+              onChange(clamp(parsed, DELAY_MIN_SECONDS, DELAY_MAX_SECONDS));
+            }
+          }}
+          style={{
+            width: 64,
+            marginLeft: 6,
+            padding: '6px 8px',
+            borderRadius: 8,
+            border: '1px solid var(--nudge-outline)',
+            background: 'var(--nudge-background)',
+            color: 'var(--nudge-on-surface)',
+          }}
+        />
+      </label>
+    </div>
+  );
+}
+
+/** One selectable "radio card" for the channel-list mode — plain-language label + a
+ * one-line explanation, because "blacklist"/"whitelist" mean nothing to most users. */
+function ChannelModeOption({
+  label,
+  description,
+  active,
+  onClick,
+}: {
+  label: string;
+  description: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        padding: '12px 14px',
+        marginBottom: 8,
+        borderRadius: 'var(--nudge-radius-sm)',
+        border: `1px solid ${active ? 'var(--nudge-primary)' : 'var(--nudge-outline)'}`,
+        background: active ? 'var(--nudge-primary-container)' : 'transparent',
+        cursor: 'pointer',
+      }}
+    >
+      <span
+        style={{
+          display: 'block',
+          fontSize: 14,
+          fontWeight: 600,
+          color: active ? 'var(--nudge-on-primary-container)' : 'var(--nudge-on-surface)',
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          display: 'block',
+          marginTop: 2,
+          fontSize: 12,
+          lineHeight: 1.45,
+          color: active ? 'var(--nudge-on-primary-container)' : 'var(--nudge-on-surface-variant)',
+        }}
+      >
+        {description}
+      </span>
+    </button>
+  );
+}
+
+/** A stable React key for a channel entry — it has no id field, but at least one of
+ * `channelId`/`handle` is always present (coerceChannel drops entries with neither). */
+function channelKey(entry: ChannelEntry): string {
+  return entry.channelId ?? entry.handle ?? entry.displayName;
+}
+
+/**
+ * The whole Phase 4 YouTube settings surface: Shorts (moved from SettingsPanel), the
+ * channel whitelist/blacklist (the differentiator), gray-screen mode, and the
+ * Unhook-parity hide toggles. Same propagation pattern as the rest of the dashboard —
+ * every change goes straight to `onChange`, which SettingsPanel patches into `NudgeSettings`
+ * and sends to the background (Strict Mode gates it there, never in the UI).
+ */
+export function YoutubePanel({
+  settings,
+  onChange,
+}: {
+  settings: YoutubeSettings;
+  onChange: (next: YoutubeSettings) => void;
+}) {
+  const [channelInput, setChannelInput] = useState('');
+  const [channelInputError, setChannelInputError] = useState<string | null>(null);
+
+  function patch(changes: Partial<YoutubeSettings>) {
+    onChange({ ...settings, ...changes });
+  }
+
+  function handleAddChannel() {
+    const entry = parseChannelInput(channelInput);
+    if (entry === null) {
+      setChannelInputError("That doesn't look like a channel handle, URL, or channel ID.");
+      return;
+    }
+    setChannelInputError(null);
+    setChannelInput('');
+    patch({ channels: addChannel(settings.channels, entry) });
+  }
+
+  function handleRemoveChannel(entry: ChannelEntry) {
+    patch({ channels: removeChannel(settings.channels, entry) });
+  }
+
+  const whitelistIsEmpty = settings.channelMode === 'WHITELIST' && settings.channels.length === 0;
+
+  return (
+    <>
+      <Card title="YouTube Shorts">
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 14 }}>
+          <Chip
+            label="Inherit"
+            active={settings.shortsMode === 'INHERIT'}
+            onClick={() => patch({ shortsMode: 'INHERIT' })}
+          />
+          {SHORTS_MODES.map((m) => (
+            <Chip
+              key={m}
+              label={MODE_LABELS[m]}
+              active={settings.shortsMode === m}
+              onClick={() => patch({ shortsMode: m })}
+            />
+          ))}
+        </div>
+        <p style={{ margin: '0 0 14px', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+          "Inherit" follows whatever rule you set for youtube.com.
+        </p>
+
+        {settings.shortsMode !== 'INHERIT' && settings.shortsMode !== 'HARD_BLOCK' && (
+          <div style={{ marginBottom: 14 }}>
+            <DelayPicker
+              value={settings.shortsDelaySeconds}
+              onChange={(shortsDelaySeconds) => patch({ shortsDelaySeconds })}
+              idPrefix="Shorts"
+            />
+          </div>
+        )}
+
+        <Toggle
+          checked={settings.hideShortsShelf}
+          onChange={(hideShortsShelf) => patch({ hideShortsShelf })}
+          label="Hide Shorts shelf"
+        />
+      </Card>
+
+      <Card title="Channels">
+        <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          Filter YouTube by channel — block specific channels, or lock things down to only the
+          ones you choose.
+        </p>
+
+        <div style={{ marginBottom: 4 }}>
+          {CHANNEL_MODE_OPTIONS.map(({ mode, label, description }) => (
+            <ChannelModeOption
+              key={mode}
+              label={label}
+              description={description}
+              active={settings.channelMode === mode}
+              onClick={() => patch({ channelMode: mode })}
+            />
+          ))}
+        </div>
+
+        {whitelistIsEmpty && (
+          <div
+            style={{
+              margin: '10px 0 16px',
+              padding: '12px 14px',
+              borderRadius: 'var(--nudge-radius-sm)',
+              border: '1px solid var(--nudge-danger)',
+            }}
+          >
+            <p style={{ margin: 0, fontSize: 13, fontWeight: 700, color: 'var(--nudge-danger)' }}>
+              Your allow list is empty — this currently blocks ALL of YouTube.
+            </p>
+            <p style={{ margin: '4px 0 0', fontSize: 12, color: 'var(--nudge-on-surface-variant)' }}>
+              Add at least one channel below to let anything through.
+            </p>
+          </div>
+        )}
+
+        {settings.channelMode !== 'OFF' && (
+          <>
+            <div style={{ margin: '16px 0' }}>
+              <p style={{ margin: '0 0 8px', fontSize: 13, fontWeight: 600 }}>
+                What happens to a {settings.channelMode === 'BLACKLIST' ? 'blocked' : 'disallowed'}{' '}
+                channel
+              </p>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 10 }}>
+                {CHANNEL_BLOCK_MODES.map((m) => (
+                  <Chip
+                    key={m}
+                    label={MODE_LABELS[m]}
+                    active={settings.channelBlockMode === m}
+                    onClick={() => patch({ channelBlockMode: m })}
+                  />
+                ))}
+              </div>
+              {settings.channelBlockMode !== 'HARD_BLOCK' && (
+                <DelayPicker
+                  value={settings.channelDelaySeconds}
+                  onChange={(channelDelaySeconds) => patch({ channelDelaySeconds })}
+                  idPrefix="channel"
+                />
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, marginBottom: 10, flexWrap: 'wrap' }}>
+              <input
+                type="text"
+                aria-label="Add YouTube channel"
+                value={channelInput}
+                placeholder="@handle, channel URL, or channel ID"
+                onChange={(e) => {
+                  setChannelInput(e.target.value);
+                  setChannelInputError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAddChannel();
+                }}
+                style={{
+                  flex: '1 1 220px',
+                  padding: '10px 12px',
+                  fontSize: 14,
+                  borderRadius: 8,
+                  border: '1px solid var(--nudge-outline)',
+                  background: 'var(--nudge-background)',
+                  color: 'var(--nudge-on-surface)',
+                }}
+              />
+              <Button onClick={handleAddChannel}>Add channel</Button>
+            </div>
+            {channelInputError && (
+              <p style={{ margin: '0 0 12px', fontSize: 13, color: 'var(--nudge-danger)' }}>
+                {channelInputError}
+              </p>
+            )}
+
+            {settings.channels.length === 0 ? (
+              !whitelistIsEmpty && (
+                <p style={{ margin: 0, fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+                  No channels added yet — add one above.
+                </p>
+              )
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {settings.channels.map((entry) => (
+                  <div
+                    key={channelKey(entry)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 12,
+                      padding: '8px 12px',
+                      borderRadius: 'var(--nudge-radius-sm)',
+                      border: '1px solid var(--nudge-surface-variant)',
+                    }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 14,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {entry.displayName}
+                    </span>
+                    <Button
+                      variant="muted"
+                      onClick={() => handleRemoveChannel(entry)}
+                      aria-label={`Remove ${entry.displayName}`}
+                      style={{ padding: '6px 12px', fontSize: 13, flexShrink: 0 }}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+
+      <Card title="Gray-screen mode">
+        <Toggle
+          checked={settings.grayScreen}
+          onChange={(grayScreen) => patch({ grayScreen })}
+          label="Turn YouTube grayscale"
+        />
+        <p style={{ margin: '10px 0 0', fontSize: 13, color: 'var(--nudge-on-surface-variant)' }}>
+          All of YouTube turns grayscale; channels you've allowed through the channel list above
+          come back in full colour. Honest caveat: this depends on the channel list above being
+          set up — with channel filtering off (or no channels added), everything just stays gray.
+        </p>
+      </Card>
+
+      <Card title="Hide on YouTube">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <Toggle
+            checked={settings.hideHomeFeed}
+            onChange={(hideHomeFeed) => patch({ hideHomeFeed })}
+            label="Hide home feed"
+          />
+          <Toggle
+            checked={settings.hideSidebarRecs}
+            onChange={(hideSidebarRecs) => patch({ hideSidebarRecs })}
+            label="Hide sidebar recommendations"
+          />
+          <Toggle
+            checked={settings.hideEndScreen}
+            onChange={(hideEndScreen) => patch({ hideEndScreen })}
+            label="Hide end-screen suggestions"
+          />
+          <Toggle
+            checked={settings.hideComments}
+            onChange={(hideComments) => patch({ hideComments })}
+            label="Hide comments"
+          />
+          <div>
+            <Toggle
+              checked={settings.disableAutoplay}
+              onChange={(disableAutoplay) => patch({ disableAutoplay })}
+              label="Disable autoplay"
+            />
+            <p
+              style={{
+                margin: '6px 0 0 30px',
+                fontSize: 12,
+                color: 'var(--nudge-on-surface-variant)',
+              }}
+            >
+              Best-effort: YouTube can restore its own player state, so autoplay may still turn
+              back on from time to time.
+            </p>
+          </div>
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/extension/tests/content/channelDetection.test.ts
+++ b/extension/tests/content/channelDetection.test.ts
@@ -22,19 +22,29 @@ import {
   detectCardChannel,
   detectWatchChannel,
   feedCards,
+  videoIdFromUrl,
 } from '../../src/content/channelDetection';
 import {
   ARIA_LABEL_VS_TEXT_HTML,
+  FRESH_DOM_CHANNEL_ID,
+  STALE_INLINE_CHANNEL_ID,
+  STALE_URL,
   TRICKY_CHANNEL_NAME,
   WATCH_DOM_ONLY_HTML,
   WATCH_INITIAL_DATA_ONLY_HTML,
+  WATCH_INLINE_MATCHES_URL_HTML,
   WATCH_MALFORMED_JSON_HTML,
   WATCH_NOTHING_HTML,
   WATCH_PLAYER_RESPONSE_HTML,
   WATCH_RENAMED_WRAPPERS_HTML,
+  WATCH_SPA_STALE_INLINE_HTML,
   WATCH_TRICKY_JSON_HTML,
 } from './fixtures/watchPage';
-import { EMPTY_FEED_HTML, FEED_MULTI_CHANNEL_HTML } from './fixtures/feedPage';
+import {
+  EMPTY_FEED_HTML,
+  FEED_MULTI_CHANNEL_HTML,
+  SEARCH_HREFLESS_PLACEHOLDER_HTML,
+} from './fixtures/feedPage';
 
 /** Mount a fixture into document.body so document-scoped lookups (script tags) can see it. */
 function mount(html: string): HTMLElement {
@@ -231,5 +241,66 @@ describe("resolving each feed card's own channel", () => {
 
     expect(() => feedCards(root)).not.toThrow();
     expect(feedCards(root)).toEqual([]);
+  });
+});
+
+describe('after a client-side navigation between videos', () => {
+  /**
+   * REGRESSION (live QA, 2026-07-26): YouTube does not rewrite its inline scripts on a
+   * watch -> watch SPA hop, so they keep describing the PREVIOUS video. Trusting them meant
+   * a non-whitelisted video played with no gate and in full colour, the whitelist, the
+   * blacklist and gray-screen were all silently bypassed during normal browsing.
+   */
+  it('identifies the channel of the video actually on screen, not the previous one', () => {
+    document.documentElement.innerHTML = WATCH_SPA_STALE_INLINE_HTML;
+
+    const detected = detectWatchChannel(document, { url: STALE_URL });
+
+    expect(detected?.channelId).toBe(FRESH_DOM_CHANNEL_ID);
+    expect(detected?.channelId).not.toBe(STALE_INLINE_CHANNEL_ID);
+  });
+
+  it('still uses the fast inline data when it describes the video actually on screen', () => {
+    // The guard must not throw away the good case: on a full page load the inline data
+    // agrees with the URL and remains the preferred, cheapest source.
+    document.documentElement.innerHTML = WATCH_INLINE_MATCHES_URL_HTML;
+
+    const detected = detectWatchChannel(document, { url: STALE_URL });
+
+    expect(detected?.channelId).toBe(STALE_INLINE_CHANNEL_ID);
+  });
+
+  it('reads the video id from a watch URL and from a Shorts URL', () => {
+    expect(videoIdFromUrl('https://www.youtube.com/watch?v=abc123&t=30')).toBe('abc123');
+    expect(videoIdFromUrl('https://www.youtube.com/shorts/xyz789')).toBe('xyz789');
+    expect(videoIdFromUrl('https://www.youtube.com/')).toBeNull();
+    expect(videoIdFromUrl('not a url')).toBeNull();
+  });
+
+  it('still identifies the channel on a page whose URL names no video at all', () => {
+    // A channel page has nothing to cross-check against, so the inline tiers stay usable.
+    document.documentElement.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+
+    const detected = detectWatchChannel(document, { url: 'https://www.youtube.com/@someone' });
+
+    expect(detected?.channelId).toBe('UCplayerresponse00000001');
+  });
+});
+
+describe('a card whose first channel anchor is an empty placeholder', () => {
+  /**
+   * REGRESSION (live QA, 2026-07-26, the "Big Think" search result): a hidden
+   * `ytd-channel-name` anchor with an empty href won the first selector rung, yielded no
+   * identifier, and the card was treated as unidentifiable, so it leaked through a
+   * whitelist even though its real `/@handle` link was right there in the same card.
+   */
+  it('still identifies the channel from the real link further down the card', () => {
+    document.body.innerHTML = SEARCH_HREFLESS_PLACEHOLDER_HTML;
+    const card = document.querySelector('[data-testid="card-bigthink"]');
+    if (card === null) throw new Error('fixture is missing the card');
+
+    const detected = detectCardChannel(card);
+
+    expect(detected?.handle).toBe('@bigthink');
   });
 });

--- a/extension/tests/content/channelDetection.test.ts
+++ b/extension/tests/content/channelDetection.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+/**
+ * Tests for YouTube channel detection (ext-03 §3).
+ *
+ * The contract these tests defend: Nudge's channel allow/block list has to know WHO
+ * uploaded the video the user is looking at, on a page whose channel data YouTube ships in
+ * three different shapes and reshuffles on its own schedule. A test suite that encodes
+ * "which code path ran" instead of "what channel did the user actually land on" is exactly
+ * how a real bug (an unscoped feed-card query, or a JSON-parse regression) survives green
+ * CI — so every case here is phrased as an observable result: the channel id/handle/name
+ * that comes back, or the fact that nothing throws.
+ *
+ * The repo's default vitest environment is `node` (src/core is pure); this file opts into
+ * jsdom with the directive above.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  channelFromDom,
+  channelFromInitialData,
+  channelFromPlayerResponse,
+  detectCardChannel,
+  detectWatchChannel,
+  feedCards,
+} from '../../src/content/channelDetection';
+import {
+  ARIA_LABEL_VS_TEXT_HTML,
+  TRICKY_CHANNEL_NAME,
+  WATCH_DOM_ONLY_HTML,
+  WATCH_INITIAL_DATA_ONLY_HTML,
+  WATCH_MALFORMED_JSON_HTML,
+  WATCH_NOTHING_HTML,
+  WATCH_PLAYER_RESPONSE_HTML,
+  WATCH_RENAMED_WRAPPERS_HTML,
+  WATCH_TRICKY_JSON_HTML,
+} from './fixtures/watchPage';
+import { EMPTY_FEED_HTML, FEED_MULTI_CHANNEL_HTML } from './fixtures/feedPage';
+
+/** Mount a fixture into document.body so document-scoped lookups (script tags) can see it. */
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  document.body.replaceChildren(root);
+  return root;
+}
+
+describe('identifying the channel on a watch page', () => {
+  it('identifies the channel on a normal watch page shipping ytInitialPlayerResponse', () => {
+    mount(WATCH_PLAYER_RESPONSE_HTML);
+
+    const result = detectWatchChannel(document);
+
+    // This fixture has THREE different candidate channels (player response, initial data,
+    // DOM) precisely so a passing test proves the player response was the one picked, not
+    // merely that "some channel" was found.
+    expect(result).toEqual({
+      channelId: 'UCplayerresponse00000001',
+      handle: null,
+      displayName: 'Player Response Channel',
+    });
+  });
+
+  it('still identifies the channel when ytInitialPlayerResponse is absent', () => {
+    mount(WATCH_INITIAL_DATA_ONLY_HTML);
+
+    const result = detectWatchChannel(document);
+
+    // Again a decoy is present (a different channel in the DOM) so a pass proves
+    // ytInitialData was preferred over the DOM fallback, not just "found A channel".
+    expect(result).toEqual({
+      channelId: 'UCinitialdataonly0000004',
+      handle: '@initialdataonlychannel',
+      displayName: 'Initial Data Only Channel',
+    });
+  });
+
+  it('falls back to the page itself when neither inline script is present', () => {
+    mount(WATCH_DOM_ONLY_HTML);
+
+    const result = detectWatchChannel(document);
+
+    expect(result).toEqual({
+      channelId: 'UCdomonlystandard0000006',
+      handle: null,
+      displayName: 'Standard Dom Channel',
+    });
+  });
+
+  it('still finds the channel after YouTube renames every specific wrapper element', () => {
+    mount(WATCH_RENAMED_WRAPPERS_HTML);
+
+    const result = detectWatchChannel(document);
+
+    expect(result).toEqual({
+      channelId: null,
+      handle: '@renamedhandlechannel',
+      displayName: 'Renamed Handle Channel',
+    });
+  });
+
+  it('identifies the channel even when the raw JSON has braces and escaped quotes inside a string', () => {
+    mount(WATCH_TRICKY_JSON_HTML);
+
+    const result = detectWatchChannel(document);
+
+    expect(result).toEqual({
+      channelId: 'UCtrickytrickytricky00007',
+      handle: '@trickychannel',
+      displayName: TRICKY_CHANNEL_NAME,
+    });
+  });
+
+  it('reports no channel, and never throws, on a page with nothing to find', () => {
+    mount(WATCH_NOTHING_HTML);
+
+    expect(() => detectWatchChannel(document)).not.toThrow();
+    expect(detectWatchChannel(document)).toBeNull();
+  });
+
+  it('reports no channel, and never throws, when the inline JSON is truncated mid-object', () => {
+    mount(WATCH_MALFORMED_JSON_HTML);
+
+    expect(() => detectWatchChannel(document)).not.toThrow();
+    expect(detectWatchChannel(document)).toBeNull();
+  });
+});
+
+describe('what each tier extracts on its own', () => {
+  it('channelFromPlayerResponse reads the channel id and uploader name straight off videoDetails', () => {
+    mount(WATCH_PLAYER_RESPONSE_HTML);
+
+    expect(channelFromPlayerResponse(document)).toEqual({
+      channelId: 'UCplayerresponse00000001',
+      handle: null,
+      displayName: 'Player Response Channel',
+    });
+  });
+
+  it('channelFromPlayerResponse finds nothing (without throwing) when the script is absent', () => {
+    mount(WATCH_INITIAL_DATA_ONLY_HTML);
+
+    expect(() => channelFromPlayerResponse(document)).not.toThrow();
+    expect(channelFromPlayerResponse(document)).toBeNull();
+  });
+
+  it('channelFromInitialData reads the channel id, handle and name off the render tree', () => {
+    mount(WATCH_INITIAL_DATA_ONLY_HTML);
+
+    expect(channelFromInitialData(document)).toEqual({
+      channelId: 'UCinitialdataonly0000004',
+      handle: '@initialdataonlychannel',
+      displayName: 'Initial Data Only Channel',
+    });
+  });
+
+  it('channelFromInitialData survives a truncated payload by returning null, not throwing', () => {
+    mount(WATCH_MALFORMED_JSON_HTML);
+
+    expect(() => channelFromInitialData(document)).not.toThrow();
+    expect(channelFromInitialData(document)).toBeNull();
+  });
+
+  it('channelFromDom reads the channel straight off the page when no script data exists', () => {
+    mount(WATCH_DOM_ONLY_HTML);
+
+    expect(channelFromDom(document)).toEqual({
+      channelId: 'UCdomonlystandard0000006',
+      handle: null,
+      displayName: 'Standard Dom Channel',
+    });
+  });
+
+  it('channelFromDom prefers the aria-label over disagreeing text content', () => {
+    mount(ARIA_LABEL_VS_TEXT_HTML);
+
+    const result = channelFromDom(document);
+
+    expect(result?.displayName).toBe('Aria Label Wins');
+    expect(result?.displayName).not.toContain('Different Text Content');
+  });
+});
+
+describe("resolving each feed card's own channel", () => {
+  it('resolves each card to its own channel rather than the first one on the page', () => {
+    const root = mount(FEED_MULTI_CHANNEL_HTML);
+
+    const cards = feedCards(root);
+    expect(cards).toHaveLength(4);
+
+    const results = cards.map((card) => detectCardChannel(card));
+
+    expect(results[0]).toEqual({
+      channelId: 'UCALPHACHANNEL000000001',
+      handle: null,
+      displayName: 'Alpha Channel',
+    });
+    expect(results[1]).toEqual({
+      channelId: null,
+      handle: '@bravochannel',
+      displayName: 'Bravo Channel',
+    });
+    expect(results[2]).toEqual({
+      channelId: null,
+      handle: 'charliechannel',
+      displayName: 'Charlie Channel',
+    });
+
+    // The identifying set is what actually catches an unscoped query: if `detectCardChannel`
+    // ever queried the whole document instead of the card it was given, every card would
+    // collapse onto the SAME channel (the page-level decoy, which sorts first in document
+    // order) and this set would have size 1, not 3.
+    const identifiers = new Set(
+      results.slice(0, 3).map((r) => r?.channelId ?? r?.handle),
+    );
+    expect(identifiers.size).toBe(3);
+    expect(identifiers.has('UCPAGELEVELDECOY000001')).toBe(false);
+  });
+
+  it('returns null, without throwing, for a card with no channel link of its own', () => {
+    const root = mount(FEED_MULTI_CHANNEL_HTML);
+    const cards = feedCards(root);
+    const noChannelCard = cards[3];
+    expect(noChannelCard).toBeDefined();
+
+    expect(() => detectCardChannel(noChannelCard as Element)).not.toThrow();
+    expect(detectCardChannel(noChannelCard as Element)).toBeNull();
+  });
+
+  it('finds no cards, without throwing, on a feed with none', () => {
+    const root = mount(EMPTY_FEED_HTML);
+
+    expect(() => feedCards(root)).not.toThrow();
+    expect(feedCards(root)).toEqual([]);
+  });
+});

--- a/extension/tests/content/channelFilter.test.ts
+++ b/extension/tests/content/channelFilter.test.ts
@@ -1,0 +1,290 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  applyChannelFilter,
+  applyGrayColor,
+  watchChannelVerdict,
+  type ChannelConfig,
+} from '../../src/content/channelFilter';
+import { CHANNEL_HIDDEN_CLASS, COLOR_CLASS } from '../../src/content/selectors';
+import type { ChannelEntry } from '../../src/core/settingsSchema';
+import { FEED_MULTI_CHANNEL_HTML } from './fixtures/feedPage';
+import { WATCH_NOTHING_HTML, WATCH_PLAYER_RESPONSE_HTML } from './fixtures/watchPage';
+
+/**
+ * These cover the SEAM: the decision matrix itself is exhaustively tested in
+ * tests/core/channels.test.ts, and detection in tests/content/channelDetection.test.ts.
+ * What can only break here is the wiring — does an allowed channel actually stay on screen,
+ * does a disallowed one actually disappear, and does the page actually turn colour.
+ */
+
+const ALPHA = 'UCALPHACHANNEL000000001';
+const PLAYER_RESPONSE_CHANNEL = 'UCplayerresponse00000001';
+
+function channel(overrides: Partial<ChannelEntry>): ChannelEntry {
+  return {
+    channelId: null,
+    handle: null,
+    displayName: 'Test Channel',
+    addedAt: 0,
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<ChannelConfig> = {}): ChannelConfig {
+  return {
+    enabled: true,
+    channelMode: 'OFF',
+    channels: [],
+    channelBlockMode: 'DELAY',
+    grayScreen: false,
+    ...overrides,
+  };
+}
+
+function loadFeed(): Document {
+  document.body.innerHTML = FEED_MULTI_CHANNEL_HTML;
+  return document;
+}
+
+function cardFor(testId: string): HTMLElement {
+  const card = document.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+  if (card === null) throw new Error(`fixture is missing the card "${testId}"`);
+  return card;
+}
+
+function isHidden(testId: string): boolean {
+  return cardFor(testId).classList.contains(CHANNEL_HIDDEN_CLASS);
+}
+
+/**
+ * jsdom's document origin is not youtube.com, so `pageTypeFor(doc.location.href)` would
+ * classify every fixture as 'other'. The real controller already passes the URL it just
+ * observed, so these do the same.
+ */
+const WATCH_URL = 'https://www.youtube.com/watch?v=abc';
+const HOME_URL = 'https://www.youtube.com/';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.classList.remove(COLOR_CLASS);
+});
+
+describe('the feed with channel lists off', () => {
+  it('shows every video, whatever is on the list', () => {
+    loadFeed();
+    applyChannelFilter(document, config({ channelMode: 'OFF', channels: [channel({ channelId: ALPHA })] }));
+
+    expect(isHidden('card-alpha')).toBe(false);
+    expect(isHidden('card-bravo')).toBe(false);
+    expect(isHidden('card-charlie')).toBe(false);
+  });
+});
+
+describe('the feed in "block these channels" mode', () => {
+  it('removes a video from a listed channel and keeps the rest', () => {
+    loadFeed();
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'BLACKLIST', channels: [channel({ channelId: ALPHA })] }),
+    );
+
+    expect(isHidden('card-alpha')).toBe(true);
+    expect(isHidden('card-bravo')).toBe(false);
+    expect(isHidden('card-charlie')).toBe(false);
+  });
+
+  it('matches a channel the user added by handle even though the card shows only a handle', () => {
+    loadFeed();
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'BLACKLIST', channels: [channel({ handle: 'bravochannel' })] }),
+    );
+
+    expect(isHidden('card-bravo')).toBe(true);
+    expect(isHidden('card-alpha')).toBe(false);
+  });
+});
+
+describe('the feed in "only allow these channels" mode', () => {
+  it('keeps the one channel on the list and removes the others', () => {
+    loadFeed();
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+    );
+
+    expect(isHidden('card-alpha')).toBe(false);
+    expect(isHidden('card-bravo')).toBe(true);
+    expect(isHidden('card-charlie')).toBe(true);
+  });
+
+  it('leaves a video visible when its channel cannot be identified at all', () => {
+    // Fail OPEN: a detection failure must look like normal YouTube, never like an empty
+    // feed the user cannot explain. Documented in core/channels.ts decideChannel.
+    loadFeed();
+    const result = applyChannelFilter(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+    );
+
+    expect(isHidden('card-no-channel')).toBe(false);
+    expect(result.unidentified).toBeGreaterThan(0);
+  });
+});
+
+describe('turning the channel filter off', () => {
+  it('brings the hidden videos back without a reload', () => {
+    loadFeed();
+    const blocking = config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] });
+    applyChannelFilter(document, blocking);
+    expect(isHidden('card-bravo')).toBe(true);
+
+    applyChannelFilter(document, config({ channelMode: 'OFF' }));
+
+    expect(isHidden('card-bravo')).toBe(false);
+    expect(isHidden('card-charlie')).toBe(false);
+  });
+
+  it('brings them back when Nudge is switched off entirely', () => {
+    loadFeed();
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+    );
+    expect(isHidden('card-bravo')).toBe(true);
+
+    applyChannelFilter(
+      document,
+      config({ enabled: false, channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+    );
+
+    expect(isHidden('card-bravo')).toBe(false);
+  });
+});
+
+describe('opening a video', () => {
+  it('interrupts a video from a channel the user chose to avoid', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    const verdict = watchChannelVerdict(
+      document,
+      config({
+        channelMode: 'BLACKLIST',
+        channels: [channel({ channelId: PLAYER_RESPONSE_CHANNEL })],
+        channelBlockMode: 'BREATHING',
+      }),
+      { url: WATCH_URL },
+    );
+
+    expect(verdict).toEqual({ action: 'BLOCK', mode: 'BREATHING' });
+  });
+
+  it('plays a video from a channel on the allow list', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    const verdict = watchChannelVerdict(
+      document,
+      config({
+        channelMode: 'WHITELIST',
+        channels: [channel({ channelId: PLAYER_RESPONSE_CHANNEL })],
+      }),
+      { url: WATCH_URL },
+    );
+
+    expect(verdict?.action).toBe('ALLOW');
+  });
+
+  it('plays on when the channel cannot be identified, rather than blocking all of YouTube', () => {
+    document.body.innerHTML = WATCH_NOTHING_HTML;
+    const verdict = watchChannelVerdict(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+      { url: WATCH_URL },
+    );
+
+    expect(verdict).toEqual({ action: 'ALLOW', reason: 'unknown-channel' });
+  });
+
+  it('is not interrupted at all while channel lists are off', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    expect(watchChannelVerdict(document, config({ channelMode: 'OFF' }), { url: WATCH_URL })).toBeNull();
+  });
+});
+
+describe('gray-screen mode', () => {
+  it('shows an allowed channel in colour', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    applyGrayColor(
+      document,
+      config({
+        grayScreen: true,
+        channelMode: 'WHITELIST',
+        channels: [channel({ channelId: PLAYER_RESPONSE_CHANNEL })],
+      }),
+      { url: WATCH_URL },
+    );
+
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(true);
+  });
+
+  it('leaves a channel the user did not pick in grayscale', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    applyGrayColor(
+      document,
+      config({
+        grayScreen: true,
+        channelMode: 'WHITELIST',
+        channels: [channel({ channelId: ALPHA })],
+      }),
+      { url: WATCH_URL },
+    );
+
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(false);
+  });
+
+  it('stays grayscale when the channel cannot be identified', () => {
+    // The opposite bias to blocking: staying gray is harmless, so an unknown channel never
+    // earns colour.
+    document.body.innerHTML = WATCH_NOTHING_HTML;
+    applyGrayColor(
+      document,
+      config({ grayScreen: true, channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+      { url: WATCH_URL },
+    );
+
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(false);
+  });
+
+  it('stays grayscale on a feed, which is a mix of many channels', () => {
+    loadFeed();
+    const feedUrl = HOME_URL;
+    applyGrayColor(
+      document,
+      config({
+        grayScreen: true,
+        channelMode: 'WHITELIST',
+        channels: [channel({ channelId: ALPHA })],
+      }),
+      { url: feedUrl },
+    );
+
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(false);
+  });
+
+  it('restores full colour everywhere once the mode is switched off', () => {
+    document.body.innerHTML = WATCH_PLAYER_RESPONSE_HTML;
+    const on = config({
+      grayScreen: true,
+      channelMode: 'WHITELIST',
+      channels: [channel({ channelId: PLAYER_RESPONSE_CHANNEL })],
+    });
+    applyGrayColor(document, on, { url: WATCH_URL });
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(true);
+
+    applyGrayColor(document, { ...on, grayScreen: false }, { url: WATCH_URL });
+
+    // The grayscale stylesheet is unregistered by the worker; this only has to make sure no
+    // stale colour class is left behind to fight the next enable.
+    expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(false);
+  });
+});

--- a/extension/tests/content/channelFilter.test.ts
+++ b/extension/tests/content/channelFilter.test.ts
@@ -9,8 +9,12 @@ import {
 } from '../../src/content/channelFilter';
 import { CHANNEL_HIDDEN_CLASS, COLOR_CLASS } from '../../src/content/selectors';
 import type { ChannelEntry } from '../../src/core/settingsSchema';
-import { FEED_MULTI_CHANNEL_HTML } from './fixtures/feedPage';
-import { WATCH_NOTHING_HTML, WATCH_PLAYER_RESPONSE_HTML } from './fixtures/watchPage';
+import { FEED_ALL_IDENTIFIABLE_HTML, FEED_MULTI_CHANNEL_HTML } from './fixtures/feedPage';
+import {
+  WATCH_FIXTURE_VIDEO_ID,
+  WATCH_NOTHING_HTML,
+  WATCH_PLAYER_RESPONSE_HTML,
+} from './fixtures/watchPage';
 
 /**
  * These cover the SEAM: the decision matrix itself is exhaustively tested in
@@ -63,7 +67,10 @@ function isHidden(testId: string): boolean {
  * classify every fixture as 'other'. The real controller already passes the URL it just
  * observed, so these do the same.
  */
-const WATCH_URL = 'https://www.youtube.com/watch?v=abc';
+// The `v` MUST match the fixture's inline videoId: detection deliberately rejects inline
+// data that describes a different video (the SPA-staleness guard), so a mismatched URL
+// here would silently be testing the DOM tier instead of the one we mean to exercise.
+const WATCH_URL = `https://www.youtube.com/watch?v=${WATCH_FIXTURE_VIDEO_ID}`;
 const HOME_URL = 'https://www.youtube.com/';
 
 beforeEach(() => {
@@ -286,5 +293,51 @@ describe('gray-screen mode', () => {
     // The grayscale stylesheet is unregistered by the worker; this only has to make sure no
     // stale colour class is left behind to fight the next enable.
     expect(document.documentElement.classList.contains(COLOR_CLASS)).toBe(false);
+  });
+});
+
+describe('when YouTube changes its DOM and channels stop being identifiable', () => {
+  /**
+   * The fail-open is deliberate, but it must not be SILENT: with no signal, selector rot
+   * degrades the channel filter into a no-op that looks exactly like "nothing on the list".
+   */
+  it('warns that filtering is degraded, naming how many cards it could not identify', () => {
+    loadFeed();
+    const warnings: string[] = [];
+
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+      { warn: (message) => warnings.push(message) },
+    );
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/degraded/i);
+    expect(warnings[0]).toMatch(/left visible/i);
+  });
+
+  it('stays quiet when every card on the page was identified', () => {
+    // No false alarms: a canary that cries wolf is a canary nobody listens to.
+    document.body.innerHTML = FEED_ALL_IDENTIFIABLE_HTML;
+    const warnings: string[] = [];
+
+    applyChannelFilter(
+      document,
+      config({ channelMode: 'WHITELIST', channels: [channel({ channelId: ALPHA })] }),
+      { warn: (message) => warnings.push(message) },
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('stays quiet while channel lists are switched off', () => {
+    loadFeed();
+    const warnings: string[] = [];
+
+    applyChannelFilter(document, config({ channelMode: 'OFF' }), {
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toEqual([]);
   });
 });

--- a/extension/tests/content/fixtures/feedPage.ts
+++ b/extension/tests/content/fixtures/feedPage.ts
@@ -1,0 +1,56 @@
+/**
+ * Feed-page fixtures for per-card channel detection (ext-03 §3).
+ *
+ * HAND-AUTHORED, NOT LIVE CAPTURES — same caveat as tests/content/fixtures/youtube.ts and
+ * watchPage.ts. REFRESH FROM REAL DOM WHEN POSSIBLE.
+ *
+ * `FEED_MULTI_CHANNEL_HTML` is the scoping test: four `VIDEO_RENDERERS` cards (ext-03 §3),
+ * three pointing at three DIFFERENT channels via three DIFFERENT rungs of the
+ * `CHANNEL_ELEMENTS` chain (a standard `ytd-channel-name` link, a class-anchored link, and a
+ * legacy `/c/` link), one with no channel link at all, PLUS a page-level "decoy" channel
+ * link that sits OUTSIDE every card, appearing first in document order.
+ *
+ * The decoy is the point: `queryWithFallback` matches in document order, so if per-card
+ * detection were ever accidentally run unscoped (e.g. against the whole document instead of
+ * the individual card element), EVERY card would silently resolve to the decoy's channel
+ * instead of its own — the exact bug class this fixture exists to catch. A test that only
+ * used distinct-but-ordered channels per card could pass even with a scoping bug, if the
+ * bug happened to preserve relative order; a decoy that isn't any card's real channel and
+ * sorts before all of them removes that loophole.
+ */
+
+export const FEED_MULTI_CHANNEL_HTML = `
+  <div id="page-manager">
+    <div id="masthead-decoy">
+      <a href="/channel/UCPAGELEVELDECOY000001" aria-label="Go to channel Page Level Decoy">Page Level Decoy</a>
+    </div>
+    <ytd-rich-grid-renderer>
+      <div id="contents">
+        <ytd-rich-item-renderer data-testid="card-alpha">
+          <ytd-channel-name id="channel-name">
+            <a class="yt-formatted-string" href="/channel/UCALPHACHANNEL000000001" aria-label="Go to channel Alpha Channel">Alpha Channel</a>
+          </ytd-channel-name>
+          <a id="video-title-link" href="/watch?v=alpha0001">Alpha's newest upload</a>
+        </ytd-rich-item-renderer>
+        <ytd-grid-video-renderer data-testid="card-bravo">
+          <a class="ytd-channel-name" href="/@bravochannel">Bravo Channel</a>
+          <a id="video-title-link" href="/watch?v=bravo0001">Bravo's newest upload</a>
+        </ytd-grid-video-renderer>
+        <ytd-compact-video-renderer data-testid="card-charlie">
+          <a href="/c/charliechannel" aria-label="Go to channel Charlie Channel - Channel">Charlie Channel</a>
+          <a id="video-title-link" href="/watch?v=charlie0001">Charlie's newest upload</a>
+        </ytd-compact-video-renderer>
+        <ytd-video-renderer data-testid="card-no-channel">
+          <a id="video-title-link" href="/watch?v=nochannel001">A video with no discoverable channel link</a>
+        </ytd-video-renderer>
+      </div>
+    </ytd-rich-grid-renderer>
+  </div>
+`;
+
+/** A feed container with no cards at all — `feedCards` must return an empty array, not throw. */
+export const EMPTY_FEED_HTML = `
+  <div id="page-manager">
+    <ytd-rich-grid-renderer><div id="contents"></div></ytd-rich-grid-renderer>
+  </div>
+`;

--- a/extension/tests/content/fixtures/feedPage.ts
+++ b/extension/tests/content/fixtures/feedPage.ts
@@ -54,3 +54,43 @@ export const EMPTY_FEED_HTML = `
     <ytd-rich-grid-renderer><div id="contents"></div></ytd-rich-grid-renderer>
   </div>
 `;
+
+/**
+ * The shape live QA hit on a YouTube SEARCH results page (the "Big Think" card, 2026-07-26).
+ *
+ * The card contains TWO channel anchors: a hidden placeholder `ytd-channel-name > a` with an
+ * EMPTY href that wins the first selector rung, and the real `/@handle` link further down.
+ * Taking only the first match of the first matching rung made the card look unidentifiable,
+ * so it leaked straight through a whitelist.
+ */
+export const SEARCH_HREFLESS_PLACEHOLDER_HTML = `
+  <div id="page-manager">
+    <ytd-video-renderer data-testid="card-bigthink">
+      <ytd-channel-name id="channel-name">
+        <a class="yt-formatted-string" href="" aria-label=""></a>
+      </ytd-channel-name>
+      <div id="byline">
+        <a href="/@bigthink" aria-label="Go to channel Big Think">Big Think</a>
+      </div>
+      <a id="video-title-link" href="/watch?v=bigthink001">A Big Think upload</a>
+    </ytd-video-renderer>
+  </div>
+`;
+
+/** A feed in which every card exposes a channel, the canary must stay silent on this one. */
+export const FEED_ALL_IDENTIFIABLE_HTML = `
+  <div id="page-manager">
+    <ytd-rich-grid-renderer>
+      <div id="contents">
+        <ytd-rich-item-renderer data-testid="card-alpha">
+          <ytd-channel-name id="channel-name">
+            <a class="yt-formatted-string" href="/channel/UCALPHACHANNEL000000001">Alpha Channel</a>
+          </ytd-channel-name>
+        </ytd-rich-item-renderer>
+        <ytd-grid-video-renderer data-testid="card-bravo">
+          <a class="ytd-channel-name" href="/@bravochannel">Bravo Channel</a>
+        </ytd-grid-video-renderer>
+      </div>
+    </ytd-rich-grid-renderer>
+  </div>
+`;

--- a/extension/tests/content/fixtures/unhookPages.ts
+++ b/extension/tests/content/fixtures/unhookPages.ts
@@ -86,6 +86,9 @@ export const WATCH_PAGE_ALL_SURFACES_HTML = `
               Autoplay
             </button>
           </div>
+          <div class="ytp-ce-element" data-testid="watch-end-cards">
+            Creator end-cards, which COEXIST with the suggestion grid below
+          </div>
           <div class="ytp-endscreen-content" data-testid="watch-end-screen">
             Real in-player end-screen suggestions
           </div>

--- a/extension/tests/content/fixtures/unhookPages.ts
+++ b/extension/tests/content/fixtures/unhookPages.ts
@@ -1,0 +1,175 @@
+/**
+ * Fixtures for the Unhook-parity hide toggles (Home Feed, Sidebar Recs, End Screen,
+ * Comments) plus the Autoplay-off switch.
+ *
+ * HAND-AUTHORED FROM THE ext-03 §5 TAXONOMY, NOT LIVE CAPTURES — same caveat as every other
+ * fixture file in tests/content/fixtures/. REFRESH FROM REAL DOM WHEN POSSIBLE.
+ *
+ * Every fixture that hides something also carries at least one element that must survive,
+ * so a chain that over-matches (eats more than its own surface) gets caught.
+ */
+
+/** Left nav present on most pages — not itself a hide-toggle surface, just page furniture. */
+const MINI_GUIDE = `
+  <ytd-mini-guide-renderer id="mini-guide">
+    <ytd-mini-guide-entry-renderer><a href="/" title="Home">Home</a></ytd-mini-guide-entry-renderer>
+    <ytd-mini-guide-entry-renderer><a href="/shorts/" title="Shorts">Shorts</a></ytd-mini-guide-entry-renderer>
+  </ytd-mini-guide-renderer>
+`;
+
+/** A normal home-feed video card, outside the feed `#contents` region under test. */
+const MASTHEAD = `
+  <ytd-masthead id="masthead" data-testid="masthead">
+    <div id="logo">Nudge does not touch this</div>
+  </ytd-masthead>
+`;
+
+/**
+ * HOME PAGE — `home-feed` surface (`ytd-browse[page-subtype="home"] #contents`, the first
+ * rung of the chain in selectors.ts), plus unrelated chrome (masthead, mini nav) that must
+ * survive every pass regardless of toggle state.
+ *
+ * Also carries a decoy `#related` element — the exact id the `sidebar-recs` surface's
+ * second chain rung looks for — sitting OUTSIDE any watch-only wrapper. It exists purely to
+ * prove page-type scoping: `sidebar-recs.pages` is `['watch']` only, so a test that turns
+ * `hideSidebarRecs` on while viewing this HOME page must never touch the decoy, because the
+ * surface should never even be queried here.
+ */
+export const HOME_PAGE_HTML = `
+  <div id="page-manager">
+    ${MASTHEAD}
+    ${MINI_GUIDE}
+    <ytd-browse page-subtype="home">
+      <div id="primary">
+        <div id="contents" data-testid="home-feed-contents">
+          <ytd-rich-item-renderer class="normal-video" data-testid="home-video-1">
+            A perfectly normal home-feed video
+          </ytd-rich-item-renderer>
+          <ytd-rich-item-renderer class="normal-video" data-testid="home-video-2">
+            Another normal home-feed video
+          </ytd-rich-item-renderer>
+        </div>
+      </div>
+    </ytd-browse>
+    <div id="related" data-testid="home-related-decoy">
+      A sidebar-recs-shaped decoy that must never be considered on the home page
+    </div>
+  </div>
+`;
+
+/**
+ * WATCH PAGE — every hide-toggle surface present at once, PLUS the autoplay switch ON, PLUS
+ * an overlay-guard decoy.
+ *
+ *  - sidebar-recs: `#secondary #related` (rung 1) wraps a real recommendation and one that
+ *    happens to look like a Short — irrelevant here, `sidebar-recs` hides the whole block.
+ *  - end-screen: TWO `.ytp-endscreen-content` elements match the SAME winning rung — one is
+ *    the real in-player suggestion grid, the other is nested inside our own overlay
+ *    (`#nudge-shorts-gate`, `NUDGE_OVERLAY_ID`). Both match the selector; only the real one
+ *    may ever be hidden. This is the "never hide our own overlay, whatever a selector
+ *    claims" case — the decoy shares a rung with a genuine match, so both come back from
+ *    the SAME `queryWithFallback` call and the overlay-guard in `applyHideToggles` is what
+ *    has to tell them apart, not chain selection.
+ *  - comments: `#comments #contents` (rung 1).
+ *  - autoplay: `.ytp-autonav-toggle-button[aria-checked="true"]` (rung 1).
+ */
+export const WATCH_PAGE_ALL_SURFACES_HTML = `
+  <div id="page-manager">
+    ${MASTHEAD}
+    ${MINI_GUIDE}
+    <ytd-watch-flexy>
+      <div id="primary">
+        <div id="player">
+          <video id="movie_player"></video>
+          <div class="ytp-chrome-controls">
+            <button class="ytp-autonav-toggle-button" aria-checked="true" data-testid="autoplay-toggle">
+              Autoplay
+            </button>
+          </div>
+          <div class="ytp-endscreen-content" data-testid="watch-end-screen">
+            Real in-player end-screen suggestions
+          </div>
+        </div>
+        <div id="nudge-shorts-gate" class="nudge-overlay" data-testid="nudge-overlay">
+          <div class="nudge-overlay__card">
+            <div class="ytp-endscreen-content" data-testid="overlay-endscreen-decoy">
+              Coincidentally matches the end-screen selector — lives INSIDE our own overlay
+              and must never be hidden.
+            </div>
+          </div>
+        </div>
+        <div id="comments" data-testid="watch-comments">
+          <div id="contents" data-testid="watch-comments-contents">
+            <ytd-comment-thread-renderer data-testid="comment-1">A real comment</ytd-comment-thread-renderer>
+          </div>
+        </div>
+      </div>
+      <div id="secondary">
+        <div id="related" data-testid="watch-related">
+          <ytd-compact-video-renderer class="normal-video" data-testid="watch-rec-1">
+            A recommended video
+          </ytd-compact-video-renderer>
+          <ytd-compact-video-renderer class="normal-video" data-testid="watch-rec-2">
+            Another recommended video
+          </ytd-compact-video-renderer>
+        </div>
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * WATCH PAGE, AUTOPLAY ALREADY OFF — otherwise minimal (autoplay is the only thing under
+ * test here). `aria-checked="false"` must not match EITHER `AUTOPLAY_TOGGLE` rung.
+ */
+export const WATCH_PAGE_AUTOPLAY_OFF_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-watch-flexy>
+      <div id="primary">
+        <div id="player">
+          <video id="movie_player"></video>
+          <div class="ytp-chrome-controls">
+            <button class="ytp-autonav-toggle-button" aria-checked="false" data-testid="autoplay-toggle-off">
+              Autoplay
+            </button>
+          </div>
+        </div>
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * THE CHAIN-PROGRESSION CASE. The `comments` surface's first two rungs (`#comments
+ * #contents`, `#comments`) are both absent — YouTube renamed the wrapper the way it
+ * periodically does — leaving only the third rung, `#watch-discussion` (the DF Tube legacy
+ * target), to find anything. Every OTHER surface on this page is left in its normal,
+ * unrenamed shape, so a test can isolate "does the chain still find comments via its last
+ * rung" from every other surface's behaviour.
+ */
+export const WATCH_PAGE_RENAMED_COMMENTS_HTML = `
+  <div id="page-manager">
+    ${MINI_GUIDE}
+    <ytd-watch-flexy>
+      <div id="primary">
+        <div id="player"><video id="movie_player"></video></div>
+        <div class="ytp-endscreen-content" data-testid="renamed-end-screen">
+          End-screen suggestions, unrenamed
+        </div>
+        <div id="watch-discussion" data-testid="renamed-comments-legacy">
+          <ytd-comment-thread-renderer data-testid="renamed-comment-1">
+            A comment findable only via the legacy rung
+          </ytd-comment-thread-renderer>
+        </div>
+      </div>
+      <div id="secondary">
+        <div id="related" data-testid="renamed-related">
+          <ytd-compact-video-renderer class="normal-video" data-testid="renamed-rec-1">
+            A recommended video
+          </ytd-compact-video-renderer>
+        </div>
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;

--- a/extension/tests/content/fixtures/watchPage.ts
+++ b/extension/tests/content/fixtures/watchPage.ts
@@ -38,10 +38,12 @@ function standardChannelDom(opts: { href: string; name: string; ariaLabel?: stri
 }
 
 /** `ytInitialPlayerResponse` inline script — tier 1's shape. */
+export const WATCH_FIXTURE_VIDEO_ID = 'watchvideo0001';
+
 function playerResponseScript(channelId: string, author: string): string {
   const payload = {
     videoDetails: {
-      videoId: 'watchvideo0001',
+      videoId: WATCH_FIXTURE_VIDEO_ID,
       title: 'A perfectly normal video',
       channelId,
       author,
@@ -260,5 +262,72 @@ export const WATCH_TRICKY_JSON_HTML = `
 export const ARIA_LABEL_VS_TEXT_HTML = `
   <div id="page-manager">
     <a href="/channel/UCariaVsText0000000008" aria-label="Go to channel Aria Label Wins">Different Text Content</a>
+  </div>
+`;
+
+/**
+ * THE SPA-STALENESS CASE (live QA, 2026-07-26).
+ *
+ * YouTube does not rewrite the inline scripts on a watch -> watch client-side navigation, so
+ * after hopping from one video to another the page carries: inline JSON describing the
+ * PREVIOUS video (and its channel), and a freshly re-rendered DOM byline describing the
+ * CURRENT one. Detection must notice the video ids disagree and trust the DOM.
+ *
+ * Pair with `STALE_URL` / `STALE_INLINE_VIDEO_ID` below.
+ */
+export const STALE_INLINE_VIDEO_ID = 'previousvideo01';
+export const CURRENT_VIDEO_ID = 'currentvideo002';
+export const STALE_URL = `https://www.youtube.com/watch?v=${CURRENT_VIDEO_ID}`;
+export const STALE_INLINE_CHANNEL_ID = 'UCstalepinnedchannel001';
+export const FRESH_DOM_CHANNEL_ID = 'UCfreshdomchannel000002';
+
+export const WATCH_SPA_STALE_INLINE_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <script>var ytInitialPlayerResponse = ${JSON.stringify({
+      videoDetails: {
+        videoId: STALE_INLINE_VIDEO_ID,
+        title: 'The video we navigated AWAY from',
+        channelId: STALE_INLINE_CHANNEL_ID,
+        author: 'Stale Pinned Channel',
+      },
+      playabilityStatus: { status: 'OK' },
+    })};</script>
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        ${standardChannelDom({
+          href: `/channel/${FRESH_DOM_CHANNEL_ID}`,
+          name: 'Fresh Dom Channel',
+          ariaLabel: 'Go to channel Fresh Dom Channel',
+        })}
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/** The same page after a FULL load: the inline data agrees with the URL, so it is usable. */
+export const WATCH_INLINE_MATCHES_URL_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <script>var ytInitialPlayerResponse = ${JSON.stringify({
+      videoDetails: {
+        videoId: CURRENT_VIDEO_ID,
+        title: 'The video actually on screen',
+        channelId: STALE_INLINE_CHANNEL_ID,
+        author: 'Stale Pinned Channel',
+      },
+      playabilityStatus: { status: 'OK' },
+    })};</script>
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        ${standardChannelDom({
+          href: `/channel/${FRESH_DOM_CHANNEL_ID}`,
+          name: 'Fresh Dom Channel',
+          ariaLabel: 'Go to channel Fresh Dom Channel',
+        })}
+      </div>
+    </ytd-watch-flexy>
   </div>
 `;

--- a/extension/tests/content/fixtures/watchPage.ts
+++ b/extension/tests/content/fixtures/watchPage.ts
@@ -1,0 +1,264 @@
+/**
+ * Watch-page fixtures for channel detection (ext-03 §3).
+ *
+ * HAND-AUTHORED, NOT LIVE CAPTURES — same caveat as tests/content/fixtures/youtube.ts and
+ * feedPage.ts. These reproduce the SHAPES documented in
+ * ops/routes/nudge/research/ext-03-youtube-techniques.md §3:
+ *   - `ytInitialPlayerResponse.videoDetails.{channelId,author}` (tier 1)
+ *   - `ytInitialData`'s `videoSecondaryInfoRenderer.owner.videoOwnerRenderer` (tier 2)
+ *   - the `CHANNEL_ELEMENTS` DOM chain (tier 3, selectors.ts)
+ *
+ * REFRESH FROM REAL DOM/PAYLOADS WHEN POSSIBLE.
+ *
+ * The inline `<script>` JSON payloads are built as plain JS object literals below and
+ * serialized with `JSON.stringify` rather than typed out as JSON text by hand. The SHAPE is
+ * still hand-authored from the taxonomy; letting `JSON.stringify` own the escaping is what
+ * makes the braces-in-strings / escaped-quotes fixture trustworthy — a hand-typed JSON
+ * string is exactly the kind of thing that silently drifts out of being valid JSON, which
+ * would make it a bad test of a JSON parser.
+ */
+
+const MINI_NAV = `
+  <ytd-mini-guide-renderer id="mini-guide">
+    <ytd-mini-guide-entry-renderer><a href="/" title="Home">Home</a></ytd-mini-guide-entry-renderer>
+    <ytd-mini-guide-entry-renderer><a href="/shorts/" title="Shorts">Shorts</a></ytd-mini-guide-entry-renderer>
+  </ytd-mini-guide-renderer>
+`;
+
+const PLAYER = `<div id="player"><video id="movie_player"></video></div>`;
+
+/** A standard, non-renamed channel-name element (tier 3's best-case rung). */
+function standardChannelDom(opts: { href: string; name: string; ariaLabel?: string }): string {
+  const aria = opts.ariaLabel !== undefined ? ` aria-label="${opts.ariaLabel}"` : '';
+  return `
+    <ytd-channel-name id="channel-name">
+      <a class="yt-formatted-string" href="${opts.href}"${aria}>${opts.name}</a>
+    </ytd-channel-name>
+  `;
+}
+
+/** `ytInitialPlayerResponse` inline script — tier 1's shape. */
+function playerResponseScript(channelId: string, author: string): string {
+  const payload = {
+    videoDetails: {
+      videoId: 'watchvideo0001',
+      title: 'A perfectly normal video',
+      channelId,
+      author,
+    },
+    playabilityStatus: { status: 'OK' },
+  };
+  return `<script>var ytInitialPlayerResponse = ${JSON.stringify(payload)};</script>`;
+}
+
+/**
+ * `ytInitialData` inline script — tier 2's shape. `videoSecondaryInfoRenderer` is nested a
+ * few renderer wrappers deep, matching the real page's render tree; `findRenderer` in
+ * channelDetection.ts finds it by key, not by this exact path, so the wrappers above it
+ * could be renamed and this would still work.
+ */
+function initialDataScript(opts: {
+  varDeclaration?: 'var' | 'bracket';
+  channelId: string;
+  handlePath: string;
+  name: string;
+}): string {
+  const payload = {
+    contents: {
+      twoColumnWatchNextResults: {
+        results: {
+          results: {
+            contents: [
+              {
+                videoSecondaryInfoRenderer: {
+                  owner: {
+                    videoOwnerRenderer: {
+                      title: {
+                        runs: [
+                          {
+                            text: opts.name,
+                            navigationEndpoint: {
+                              browseEndpoint: { browseId: opts.channelId },
+                            },
+                          },
+                        ],
+                      },
+                      navigationEndpoint: {
+                        browseEndpoint: {
+                          browseId: opts.channelId,
+                          canonicalBaseUrl: opts.handlePath,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+  const json = JSON.stringify(payload);
+  const assignment =
+    opts.varDeclaration === 'bracket'
+      ? `window["ytInitialData"] = ${json};`
+      : `var ytInitialData = ${json};`;
+  return `<script>${assignment}</script>`;
+}
+
+/**
+ * TIER 1 WINS. All three tiers are present, each with a DIFFERENT channel, so a test can
+ * assert the composite picked the player response specifically — not just "found A channel".
+ */
+export const WATCH_PLAYER_RESPONSE_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    ${playerResponseScript('UCplayerresponse00000001', 'Player Response Channel')}
+    ${initialDataScript({
+      channelId: 'UCinitialdatawins0000002',
+      handlePath: '/@initialdatachannel',
+      name: 'Initial Data Channel',
+    })}
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        ${standardChannelDom({
+          href: '/channel/UCdomfallback0000000003',
+          name: 'Dom Fallback Channel',
+          ariaLabel: 'Go to channel Dom Fallback Channel',
+        })}
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * TIER 2 WINS. No `ytInitialPlayerResponse` at all (some surfaces genuinely omit it) — the
+ * composite must fall through to `ytInitialData`, and prefer it over the DOM, which also
+ * carries a (different, deliberately wrong-to-pick) channel.
+ */
+export const WATCH_INITIAL_DATA_ONLY_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    ${initialDataScript({
+      channelId: 'UCinitialdataonly0000004',
+      handlePath: '/@initialdataonlychannel',
+      name: 'Initial Data Only Channel',
+    })}
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        ${standardChannelDom({
+          href: '/channel/UCdomshouldnotwin0000005',
+          name: 'Dom Should Not Win',
+          ariaLabel: 'Go to channel Dom Should Not Win',
+        })}
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/** TIER 3 WINS. Neither script is present — only the standard (non-renamed) channel DOM. */
+export const WATCH_DOM_ONLY_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        ${standardChannelDom({
+          href: '/channel/UCdomonlystandard0000006',
+          name: 'Standard Dom Channel',
+          ariaLabel: 'Go to channel Standard Dom Channel',
+        })}
+      </div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * THE UPSTREAM-CHURN CASE. No scripts, and every specific CHANNEL_ELEMENTS wrapper has been
+ * renamed the way Google periodically renames them — `ytd-channel-name` becomes
+ * `yt-owner-view-model`, no `/channel/` link exists. Only the generic `a[href^="/@"]` rung
+ * can still find the channel, which is precisely the case ext-03 §3 flags as the reason
+ * that rung exists.
+ */
+export const WATCH_RENAMED_WRAPPERS_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <yt-watch-view-model>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary">
+        <yt-owner-view-model>
+          <a href="/@renamedhandlechannel" aria-label="Go to channel Renamed Handle Channel">Renamed Handle Channel</a>
+        </yt-owner-view-model>
+      </div>
+    </yt-watch-view-model>
+  </div>
+`;
+
+/** No scripts, no channel DOM anywhere. Every tier should come up empty, cleanly. */
+export const WATCH_NOTHING_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary"><div id="related"></div></div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * A truncated `ytInitialData` payload — the object literal never closes. Exercises the
+ * brace scanner's unbalanced-input path (returns null rather than slicing something
+ * unparseable) as well as the "never throw" contract end to end.
+ */
+export const WATCH_MALFORMED_JSON_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    <script>var ytInitialData = {"contents": {"twoColumnWatchNextResults": {"results": {"results": {"contents": [{"videoSecondaryInfoRenderer": {"owner": {"videoOwnerRenderer":</script>
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary"><div id="related"></div></div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * The channel display name deliberately contains `{`, `}`, escaped double quotes and an
+ * escaped backslash — the exact content shape that breaks a naive delimiter-split JSON
+ * extraction and that only a real brace-counting, string-aware scanner survives. Exported
+ * so the test file can assert the exact round-tripped value rather than re-typing it.
+ */
+export const TRICKY_CHANNEL_NAME = 'Weird {Channel} "Name" \\ Co.';
+
+/**
+ * THE BRACE-SCANNER STRESS CASE. Uses the `window["ytInitialData"] = …` assignment form (a
+ * second proof the assignment-finder isn't tied to `var …`), and a display name containing
+ * unescaped braces plus escaped quotes/backslashes inside the JSON string value.
+ */
+export const WATCH_TRICKY_JSON_HTML = `
+  <div id="page-manager">
+    ${MINI_NAV}
+    ${initialDataScript({
+      varDeclaration: 'bracket',
+      channelId: 'UCtrickytrickytricky00007',
+      handlePath: '/@trickychannel',
+      name: TRICKY_CHANNEL_NAME,
+    })}
+    <ytd-watch-flexy>
+      <div id="primary">${PLAYER}</div>
+      <div id="secondary"></div>
+    </ytd-watch-flexy>
+  </div>
+`;
+
+/**
+ * Isolated case for `channelFromDom`'s "aria-label first" rule: the aria-label and the
+ * text content deliberately disagree, so a test can prove which one wins.
+ */
+export const ARIA_LABEL_VS_TEXT_HTML = `
+  <div id="page-manager">
+    <a href="/channel/UCariaVsText0000000008" aria-label="Go to channel Aria Label Wins">Different Text Content</a>
+  </div>
+`;

--- a/extension/tests/content/selectors.test.ts
+++ b/extension/tests/content/selectors.test.ts
@@ -176,8 +176,11 @@ describe('selector chains match the intended elements per page type', () => {
       warn: () => {},
     });
 
+    // Assert the OUTCOME (the Shorts entry was found, without falling back to the generic
+    // catch-all), not WHICH rung won: the chain is deliberately reordered as YouTube's DOM
+    // changes, and pinning the winning selector string turns every legitimate refresh into
+    // a false failure.
     expect(result.usedFallback).toBe(false);
-    expect(result.matchedSelector).toBe("ytd-mini-guide-entry-renderer>a[href='/shorts/']");
     expect(result.elements).toHaveLength(1);
     expect(result.elements[0]?.getAttribute('title')).toBe('Shorts');
   });

--- a/extension/tests/content/unhook.test.ts
+++ b/extension/tests/content/unhook.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the Unhook-parity hide toggles (`applyHideToggles`) and the best-effort
+ * autoplay-off click (`applyAutoplayOff`).
+ *
+ * Every test is phrased as a USER-VISIBLE outcome (what's on screen / what got clicked),
+ * never as "which selector rung matched" or "which internal branch ran" — this codebase has
+ * a documented incident (extension/CLAUDE.md "Lessons") where a critical bug survived 400
+ * tests because two of them asserted the internal branch instead of the visible behaviour.
+ * "Hidden" here means "carries `UNHOOK_HIDDEN_CLASS`", the same class the real stylesheet
+ * keys off `display: none` — checking the class IS checking what the user would see.
+ *
+ * Repo default vitest environment is `node` (src/core is pure); this file opts into jsdom.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NUDGE_OVERLAY_ID, resetFallbackWarnings } from '../../src/content/selectors';
+import { UNHOOK_HIDDEN_CLASS, applyAutoplayOff, applyHideToggles } from '../../src/content/unhook';
+import {
+  HOME_PAGE_HTML,
+  WATCH_PAGE_ALL_SURFACES_HTML,
+  WATCH_PAGE_AUTOPLAY_OFF_HTML,
+  WATCH_PAGE_RENAMED_COMMENTS_HTML,
+} from './fixtures/unhookPages';
+
+/** Mount a fixture in a detached root so tests never fight over document.body. */
+function mount(html: string): HTMLElement {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  document.body.replaceChildren(root);
+  return root;
+}
+
+/** Every toggle off — the caller opts individual surfaces in from this baseline. */
+const ALL_OFF = {
+  enabled: true,
+  hideHomeFeed: false,
+  hideSidebarRecs: false,
+  hideEndScreen: false,
+  hideComments: false,
+};
+
+function isHidden(root: HTMLElement, testId: string): boolean {
+  const el = root.querySelector(`[data-testid="${testId}"]`);
+  if (!el) throw new Error(`fixture missing [data-testid="${testId}"]`);
+  return el.classList.contains(UNHOOK_HIDDEN_CLASS);
+}
+
+beforeEach(() => {
+  resetFallbackWarnings();
+});
+
+describe('applyHideToggles — each toggle independently hides only its own surface', () => {
+  it('hides the home feed and leaves the rest of the page visible', () => {
+    const root = mount(HOME_PAGE_HTML);
+
+    const result = applyHideToggles(
+      root,
+      { ...ALL_OFF, hideHomeFeed: true },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    expect(result.hidden).toBeGreaterThan(0);
+    expect(isHidden(root, 'home-feed-contents')).toBe(true);
+    expect(isHidden(root, 'masthead')).toBe(false);
+    expect(isHidden(root, 'home-related-decoy')).toBe(false);
+  });
+
+  it('hides the sidebar recommendations on a watch page, leaving comments and the end screen visible', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    applyHideToggles(root, { ...ALL_OFF, hideSidebarRecs: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-related')).toBe(true);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-end-screen')).toBe(false);
+  });
+
+  it('hides the in-player end screen on a watch page, leaving comments and recommendations visible', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    applyHideToggles(root, { ...ALL_OFF, hideEndScreen: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-end-screen')).toBe(true);
+    expect(isHidden(root, 'watch-related')).toBe(false);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+  });
+
+  it('hides the comments section on a watch page, leaving the end screen and recommendations visible', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    applyHideToggles(root, { ...ALL_OFF, hideComments: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+    expect(isHidden(root, 'watch-end-screen')).toBe(false);
+    expect(isHidden(root, 'watch-related')).toBe(false);
+  });
+
+  it('still hides comments when YouTube has renamed the primary comments wrapper', () => {
+    const root = mount(WATCH_PAGE_RENAMED_COMMENTS_HTML);
+
+    applyHideToggles(root, { ...ALL_OFF, hideComments: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'renamed-comments-legacy')).toBe(true);
+    expect(isHidden(root, 'renamed-end-screen')).toBe(false);
+    expect(isHidden(root, 'renamed-related')).toBe(false);
+  });
+});
+
+describe('applyHideToggles — off toggles leave their surface visible', () => {
+  it('leaves every surface visible when every toggle is off', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    const result = applyHideToggles(root, ALL_OFF, { pageType: 'watch', warn: () => {} });
+
+    expect(result.hidden).toBe(0);
+    expect(isHidden(root, 'watch-related')).toBe(false);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-end-screen')).toBe(false);
+  });
+});
+
+describe('applyHideToggles — flipping a toggle off reveals what it hid', () => {
+  it('brings the comments section back, still in the DOM, once hideComments is turned off', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    const nodeCountBefore = root.querySelectorAll('*').length;
+
+    applyHideToggles(root, { ...ALL_OFF, hideComments: true }, { pageType: 'watch', warn: () => {} });
+    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+
+    const off = applyHideToggles(root, ALL_OFF, { pageType: 'watch', warn: () => {} });
+
+    expect(off.revealed).toBeGreaterThan(0);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    // Reversible by construction: no node was ever removed, only the class toggled.
+    expect(root.querySelectorAll('*').length).toBe(nodeCountBefore);
+    expect(root.querySelector('[data-testid="watch-comments"]')).not.toBeNull();
+  });
+});
+
+describe('applyHideToggles — enabled: false reveals everything', () => {
+  it('brings back every surface it had hidden when Nudge is globally disabled', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    applyHideToggles(
+      root,
+      { ...ALL_OFF, hideSidebarRecs: true, hideEndScreen: true, hideComments: true },
+      { pageType: 'watch', warn: () => {} },
+    );
+    expect(isHidden(root, 'watch-related')).toBe(true);
+    expect(isHidden(root, 'watch-end-screen')).toBe(true);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+
+    const result = applyHideToggles(
+      root,
+      { ...ALL_OFF, enabled: false, hideSidebarRecs: true, hideEndScreen: true, hideComments: true },
+      { pageType: 'watch', warn: () => {} },
+    );
+
+    expect(result.hidden).toBe(0);
+    expect(result.revealed).toBeGreaterThan(0);
+    expect(isHidden(root, 'watch-related')).toBe(false);
+    expect(isHidden(root, 'watch-end-screen')).toBe(false);
+    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(root.querySelectorAll(`.${UNHOOK_HIDDEN_CLASS}`)).toHaveLength(0);
+  });
+});
+
+describe('applyHideToggles — page-type scoping', () => {
+  it('never hides a watch-only surface on the home page, even one shaped exactly like it', () => {
+    const root = mount(HOME_PAGE_HTML);
+
+    // hideSidebarRecs is ON, but sidebar-recs only applies to 'watch' pages — the home
+    // page's #related-shaped decoy must survive because the surface is never even
+    // considered here, not because this particular selector happened to miss it.
+    applyHideToggles(
+      root,
+      { ...ALL_OFF, hideSidebarRecs: true },
+      { pageType: 'home', warn: () => {} },
+    );
+
+    expect(isHidden(root, 'home-related-decoy')).toBe(false);
+  });
+});
+
+describe('applyHideToggles — our own overlay is never hidden', () => {
+  it('hides the real end screen but never anything living inside the Nudge overlay', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    expect(root.querySelector(`#${NUDGE_OVERLAY_ID}`)).not.toBeNull();
+
+    applyHideToggles(root, { ...ALL_OFF, hideEndScreen: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-end-screen')).toBe(true);
+    expect(isHidden(root, 'overlay-endscreen-decoy')).toBe(false);
+    expect(isHidden(root, 'nudge-overlay')).toBe(false);
+  });
+});
+
+describe('applyHideToggles — never throws', () => {
+  it('does nothing and does not throw on a page with none of the expected DOM', () => {
+    const root = mount('');
+
+    expect(() =>
+      applyHideToggles(
+        root,
+        { enabled: true, hideHomeFeed: true, hideSidebarRecs: true, hideEndScreen: true, hideComments: true },
+        { pageType: 'home', warn: () => {} },
+      ),
+    ).not.toThrow();
+
+    const result = applyHideToggles(
+      root,
+      { enabled: true, hideHomeFeed: true, hideSidebarRecs: true, hideEndScreen: true, hideComments: true },
+      { pageType: 'watch', warn: () => {} },
+    );
+    expect(result).toEqual({ hidden: 0, revealed: 0, degradedSurfaces: [] });
+
+    expect(() => applyHideToggles(root, { ...ALL_OFF, enabled: false }, { pageType: 'other' })).not.toThrow();
+  });
+});
+
+describe('applyAutoplayOff', () => {
+  it('clicks the autoplay switch off when it is currently on', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    const clickSpy = vi.spyOn(HTMLElement.prototype, 'click');
+
+    try {
+      const clicked = applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} });
+
+      expect(clicked).toBe(true);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      const toggle = root.querySelector('[data-testid="autoplay-toggle"]');
+      expect(clickSpy.mock.instances).toContain(toggle);
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('does not click anything when autoplay is already off', () => {
+    const root = mount(WATCH_PAGE_AUTOPLAY_OFF_HTML);
+    const clickSpy = vi.spyOn(HTMLElement.prototype, 'click');
+
+    try {
+      const clicked = applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} });
+
+      expect(clicked).toBe(false);
+      expect(clickSpy).not.toHaveBeenCalled();
+      const toggle = root.querySelector('[data-testid="autoplay-toggle-off"]');
+      expect(toggle?.getAttribute('aria-checked')).toBe('false');
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('does nothing when the disableAutoplay toggle itself is off, even if the switch is on', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    const clickSpy = vi.spyOn(HTMLElement.prototype, 'click');
+
+    try {
+      const clicked = applyAutoplayOff(root, { enabled: true, disableAutoplay: false }, { warn: () => {} });
+
+      expect(clicked).toBe(false);
+      expect(clickSpy).not.toHaveBeenCalled();
+    } finally {
+      clickSpy.mockRestore();
+    }
+  });
+
+  it('calling it twice never re-enables autoplay', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    const toggle = root.querySelector('[data-testid="autoplay-toggle"]');
+    if (!toggle) throw new Error('fixture missing the autoplay toggle');
+    // Model YouTube's own response to the click: the switch flips itself off. Nothing in
+    // applyAutoplayOff does this — it only ever acts on a switch that reads as ON.
+    toggle.addEventListener('click', () => toggle.setAttribute('aria-checked', 'false'));
+
+    const first = applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} });
+    expect(first).toBe(true);
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    const second = applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} });
+    expect(second).toBe(false);
+    // Still off — a second pass never turns it back on.
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('does not throw on a page with no player at all', () => {
+    const root = mount('');
+
+    expect(() =>
+      applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} }),
+    ).not.toThrow();
+    expect(applyAutoplayOff(root, { enabled: true, disableAutoplay: true })).toBe(false);
+  });
+});

--- a/extension/tests/content/unhook.test.ts
+++ b/extension/tests/content/unhook.test.ts
@@ -72,7 +72,7 @@ describe('applyHideToggles — each toggle independently hides only its own surf
     applyHideToggles(root, { ...ALL_OFF, hideSidebarRecs: true }, { pageType: 'watch', warn: () => {} });
 
     expect(isHidden(root, 'watch-related')).toBe(true);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-comments')).toBe(false);
     expect(isHidden(root, 'watch-end-screen')).toBe(false);
   });
 
@@ -83,15 +83,18 @@ describe('applyHideToggles — each toggle independently hides only its own surf
 
     expect(isHidden(root, 'watch-end-screen')).toBe(true);
     expect(isHidden(root, 'watch-related')).toBe(false);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-comments')).toBe(false);
   });
 
+  // Hiding the whole `#comments` section (not just its inner list) is deliberate: leaving
+  // the wrapper visible left the "N Comments / Sort by" header on screen as dead chrome
+  // (live QA, 2026-07-26).
   it('hides the comments section on a watch page, leaving the end screen and recommendations visible', () => {
     const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
 
     applyHideToggles(root, { ...ALL_OFF, hideComments: true }, { pageType: 'watch', warn: () => {} });
 
-    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+    expect(isHidden(root, 'watch-comments')).toBe(true);
     expect(isHidden(root, 'watch-end-screen')).toBe(false);
     expect(isHidden(root, 'watch-related')).toBe(false);
   });
@@ -115,7 +118,7 @@ describe('applyHideToggles — off toggles leave their surface visible', () => {
 
     expect(result.hidden).toBe(0);
     expect(isHidden(root, 'watch-related')).toBe(false);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-comments')).toBe(false);
     expect(isHidden(root, 'watch-end-screen')).toBe(false);
   });
 });
@@ -126,12 +129,12 @@ describe('applyHideToggles — flipping a toggle off reveals what it hid', () =>
     const nodeCountBefore = root.querySelectorAll('*').length;
 
     applyHideToggles(root, { ...ALL_OFF, hideComments: true }, { pageType: 'watch', warn: () => {} });
-    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+    expect(isHidden(root, 'watch-comments')).toBe(true);
 
     const off = applyHideToggles(root, ALL_OFF, { pageType: 'watch', warn: () => {} });
 
     expect(off.revealed).toBeGreaterThan(0);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-comments')).toBe(false);
     // Reversible by construction: no node was ever removed, only the class toggled.
     expect(root.querySelectorAll('*').length).toBe(nodeCountBefore);
     expect(root.querySelector('[data-testid="watch-comments"]')).not.toBeNull();
@@ -149,7 +152,7 @@ describe('applyHideToggles — enabled: false reveals everything', () => {
     );
     expect(isHidden(root, 'watch-related')).toBe(true);
     expect(isHidden(root, 'watch-end-screen')).toBe(true);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(true);
+    expect(isHidden(root, 'watch-comments')).toBe(true);
 
     const result = applyHideToggles(
       root,
@@ -161,7 +164,7 @@ describe('applyHideToggles — enabled: false reveals everything', () => {
     expect(result.revealed).toBeGreaterThan(0);
     expect(isHidden(root, 'watch-related')).toBe(false);
     expect(isHidden(root, 'watch-end-screen')).toBe(false);
-    expect(isHidden(root, 'watch-comments-contents')).toBe(false);
+    expect(isHidden(root, 'watch-comments')).toBe(false);
     expect(root.querySelectorAll(`.${UNHOOK_HIDDEN_CLASS}`)).toHaveLength(0);
   });
 });
@@ -291,5 +294,32 @@ describe('applyAutoplayOff', () => {
       applyAutoplayOff(root, { enabled: true, disableAutoplay: true }, { warn: () => {} }),
     ).not.toThrow();
     expect(applyAutoplayOff(root, { enabled: true, disableAutoplay: true })).toBe(false);
+  });
+});
+
+describe('applyHideToggles, the end screen has two parts that show together', () => {
+  /**
+   * Live QA, 2026-07-26: `.ytp-endscreen-content` (the suggestion grid) and
+   * `.ytp-ce-element` (the creator's own end-cards) are DIFFERENT elements shown at the same
+   * time, not alternative selectors for one element. First-match-wins hid the grid and left
+   * the cards sitting on top of the video.
+   */
+  it('hides both the suggestion grid and the creator end-cards', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+
+    applyHideToggles(root, { ...ALL_OFF, hideEndScreen: true }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-end-screen')).toBe(true);
+    expect(isHidden(root, 'watch-end-cards')).toBe(true);
+  });
+
+  it('brings both back when the toggle is switched off', () => {
+    const root = mount(WATCH_PAGE_ALL_SURFACES_HTML);
+    applyHideToggles(root, { ...ALL_OFF, hideEndScreen: true }, { pageType: 'watch', warn: () => {} });
+
+    applyHideToggles(root, { ...ALL_OFF, hideEndScreen: false }, { pageType: 'watch', warn: () => {} });
+
+    expect(isHidden(root, 'watch-end-screen')).toBe(false);
+    expect(isHidden(root, 'watch-end-cards')).toBe(false);
   });
 });

--- a/extension/tests/core/channelFreshness.test.ts
+++ b/extension/tests/core/channelFreshness.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  channelFreshness,
+  channelKey,
+  SETTLE_MS,
+  SETTLE_RECHECK_MS,
+  type FreshnessInput,
+} from '../../src/core/channelFreshness';
+
+/**
+ * The settle window (live QA, 2026-07-26). After a watch -> watch SPA hop YouTube's owner
+ * byline keeps describing the PREVIOUS video for a second or more, so acting on it
+ * immediately either ungates a blocked channel or — much worse — accuses an allowed one.
+ *
+ * These are outcome-phrased in the terms the caller cares about: may we act on what we just
+ * detected, or must we keep waiting?
+ */
+
+const ALLOWED = channelKey({ channelId: 'UCallowed0000000000001' })!;
+const OTHER = channelKey({ channelId: 'UCother00000000000002' })!;
+
+function input(overrides: Partial<FreshnessInput> = {}): FreshnessInput {
+  return {
+    videoId: 'newvideo001',
+    inlineVideoId: 'oldvideo000',
+    detectedKey: OTHER,
+    previousKey: ALLOWED,
+    msSinceNav: 0,
+    ...overrides,
+  };
+}
+
+describe('channelKey', () => {
+  it('treats the same channel reached by id or by handle as one identity', () => {
+    expect(channelKey({ channelId: 'UCabc', handle: null })).toBe(
+      channelKey({ channelId: 'UCabc', handle: null }),
+    );
+    expect(channelKey({ handle: 'Veritasium' })).toBe(channelKey({ handle: 'veritasium' }));
+  });
+
+  it('has no identity for a channel that could not be identified', () => {
+    expect(channelKey(null)).toBeNull();
+    expect(channelKey({ channelId: null, handle: null })).toBeNull();
+  });
+});
+
+describe('right after navigating to a different video', () => {
+  it('acts immediately once the byline shows a different channel than before', () => {
+    // The byline demonstrably re-rendered, so there is nothing left to wait for.
+    expect(channelFreshness(input({ detectedKey: OTHER, previousKey: ALLOWED }))).toBe(
+      'CONFIRMED',
+    );
+  });
+
+  it('keeps waiting while the byline still shows the channel from the previous video', () => {
+    // Indistinguishable from "stale", so we withhold the verdict rather than risk accusing
+    // a channel the user allowed.
+    expect(channelFreshness(input({ detectedKey: ALLOWED, previousKey: ALLOWED }))).toBe(
+      'SETTLING',
+    );
+  });
+
+  it('acts immediately when the page data itself describes the video in the address bar', () => {
+    // A full page load: the inline data is authoritative, so no waiting is warranted.
+    expect(
+      channelFreshness(
+        input({ videoId: 'newvideo001', inlineVideoId: 'newvideo001', detectedKey: ALLOWED }),
+      ),
+    ).toBe('CONFIRMED');
+  });
+
+  it('stops waiting once the settle window has elapsed', () => {
+    const stuck = input({ detectedKey: ALLOWED, previousKey: ALLOWED });
+
+    expect(channelFreshness({ ...stuck, msSinceNav: SETTLE_MS - 1 })).toBe('SETTLING');
+    expect(channelFreshness({ ...stuck, msSinceNav: SETTLE_MS })).toBe('CONFIRMED');
+  });
+
+  it('acts immediately on the first video of a session, with nothing to be stale from', () => {
+    expect(channelFreshness(input({ previousKey: null, detectedKey: ALLOWED }))).toBe(
+      'CONFIRMED',
+    );
+  });
+
+  it('stops waiting when nothing can be identified, leaving the fail-open to handle it', () => {
+    // Detecting NOTHING is already safe to act on: the caller's unknown-channel path allows
+    // the video through without an interstitial and withholds colour. Waiting here would add
+    // latency without changing any outcome.
+    expect(channelFreshness(input({ detectedKey: null, previousKey: ALLOWED }))).toBe(
+      'CONFIRMED',
+    );
+  });
+});
+
+describe('the reverse case that made this necessary', () => {
+  it('does not act on a blocked-looking byline in the moment after leaving that channel', () => {
+    // blocked -> allowed hop. The byline still reports the blocked channel; acting now is
+    // exactly the 3-5s false "This channel is off your list" QA saw on an allowed video.
+    const justAfterNav = input({
+      detectedKey: OTHER,
+      previousKey: OTHER,
+      msSinceNav: 200,
+    });
+
+    expect(channelFreshness(justAfterNav)).toBe('SETTLING');
+  });
+
+  it('acts as soon as the byline catches up to the allowed channel', () => {
+    const bylineCaughtUp = input({
+      detectedKey: ALLOWED,
+      previousKey: OTHER,
+      msSinceNav: 900,
+    });
+
+    expect(channelFreshness(bylineCaughtUp)).toBe('CONFIRMED');
+  });
+});
+
+describe('the post-navigation re-check schedule', () => {
+  it('re-checks several times, ending after the settle window closes', () => {
+    // The debounced observer can be starved indefinitely by YouTube's mutation storm, so
+    // these fixed timers are what guarantee the corrective pass actually happens.
+    expect(SETTLE_RECHECK_MS.length).toBeGreaterThan(2);
+    expect(Math.min(...SETTLE_RECHECK_MS)).toBeLessThan(1_000);
+    expect(Math.max(...SETTLE_RECHECK_MS)).toBeGreaterThan(SETTLE_MS);
+  });
+
+  it('is strictly increasing, so each re-check is a fresh look rather than a duplicate', () => {
+    const sorted = [...SETTLE_RECHECK_MS].sort((a, b) => a - b);
+    expect(SETTLE_RECHECK_MS).toEqual(sorted);
+    expect(new Set(SETTLE_RECHECK_MS).size).toBe(SETTLE_RECHECK_MS.length);
+  });
+});

--- a/extension/tests/core/channels.test.ts
+++ b/extension/tests/core/channels.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addChannel,
+  decideChannel,
+  findChannel,
+  isChannelListed,
+  parseChannelInput,
+  removeChannel,
+  sameChannel,
+  shouldShowInColor,
+  type ChannelProbe,
+} from '../../src/core/channels';
+import type { ChannelEntry, ChannelListMode } from '../../src/core/settingsSchema';
+
+/**
+ * Port intent: mirrors the house style set by domainMatcher.test.ts/blockEngine.test.ts —
+ * every case is phrased as a user-visible outcome ("blocks a channel not on the
+ * whitelist"), never as which internal branch fired. That rule exists because of a real
+ * incident on this codebase: a critical BlockEngine bug survived 400 tests because two of
+ * them asserted the (wrong) internal branch instead of the user-visible behaviour.
+ */
+
+const VALID_CHANNEL_ID = 'UCHnyfMqiRRG1u-2MsSQLbXA';
+
+function entry(overrides: Partial<ChannelEntry>): ChannelEntry {
+  return {
+    channelId: null,
+    handle: null,
+    displayName: 'placeholder',
+    addedAt: 0,
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------------------
+// parseChannelInput
+// -----------------------------------------------------------------------------------
+
+describe('parseChannelInput — recognized forms', () => {
+  it('accepts a bare handle written with the leading @', () => {
+    const result = parseChannelInput('@veritasium', 1000);
+    expect(result).toEqual({
+      channelId: null,
+      handle: 'veritasium',
+      displayName: '@veritasium',
+      addedAt: 1000,
+    });
+  });
+
+  it('accepts a bare handle written without the leading @', () => {
+    const result = parseChannelInput('veritasium', 1000);
+    expect(result).toEqual({
+      channelId: null,
+      handle: 'veritasium',
+      displayName: '@veritasium',
+      addedAt: 1000,
+    });
+  });
+
+  it('accepts a full handle URL', () => {
+    const result = parseChannelInput('https://www.youtube.com/@veritasium', 1000);
+    expect(result?.handle).toBe('veritasium');
+    expect(result?.channelId).toBeNull();
+  });
+
+  it('accepts a schemeless handle URL with a trailing path segment', () => {
+    const result = parseChannelInput('youtube.com/@veritasium/videos', 1000);
+    expect(result?.handle).toBe('veritasium');
+  });
+
+  it('accepts a canonical channel-id URL and keeps the id exactly as given', () => {
+    const result = parseChannelInput(
+      `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`,
+      1000,
+    );
+    expect(result).toEqual({
+      channelId: VALID_CHANNEL_ID,
+      handle: null,
+      displayName: VALID_CHANNEL_ID,
+      addedAt: 1000,
+    });
+  });
+
+  it('accepts a bare channel id', () => {
+    const result = parseChannelInput(VALID_CHANNEL_ID, 1000);
+    expect(result?.channelId).toBe(VALID_CHANNEL_ID);
+    expect(result?.handle).toBeNull();
+  });
+
+  it('accepts a legacy "/c/" custom URL, using the name as a handle-ish identifier', () => {
+    const result = parseChannelInput('youtube.com/c/Veritasium', 1000);
+    expect(result).toEqual({
+      channelId: null,
+      handle: 'veritasium',
+      displayName: 'Veritasium',
+      addedAt: 1000,
+    });
+  });
+
+  it('accepts a legacy "/user/" URL, using the name as a handle-ish identifier', () => {
+    const result = parseChannelInput('youtube.com/user/1veritasium', 1000);
+    expect(result).toEqual({
+      channelId: null,
+      handle: '1veritasium',
+      displayName: '1veritasium',
+      addedAt: 1000,
+    });
+  });
+
+  it('defaults addedAt to the current time when no clock is injected', () => {
+    const before = Date.now();
+    const result = parseChannelInput('@veritasium');
+    const after = Date.now();
+    expect(result?.addedAt).toBeGreaterThanOrEqual(before);
+    expect(result?.addedAt).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('parseChannelInput — case handling', () => {
+  it('lowercases and strips "@" from a mixed-case handle URL', () => {
+    const result = parseChannelInput('@VeriTasium', 1000);
+    expect(result?.handle).toBe('veritasium');
+    expect(result?.displayName).toBe('@veritasium');
+  });
+
+  it('lowercases an uppercase bare handle', () => {
+    const result = parseChannelInput('VERITASIUM', 1000);
+    expect(result?.handle).toBe('veritasium');
+  });
+
+  it('preserves the exact case of a channel id (ids are case-sensitive)', () => {
+    const mixedCaseId = 'UCaBcDeFgHiJkLmNoPqRsTuV';
+    const result = parseChannelInput(mixedCaseId, 1000);
+    expect(result?.channelId).toBe(mixedCaseId);
+  });
+});
+
+describe('parseChannelInput — rejects non-channel input', () => {
+  it('rejects a blank string', () => {
+    expect(parseChannelInput('', 1000)).toBeNull();
+  });
+
+  it('rejects a whitespace-only string', () => {
+    expect(parseChannelInput('   ', 1000)).toBeNull();
+  });
+
+  it('rejects a watch URL (it names a video, not a channel)', () => {
+    expect(
+      parseChannelInput('https://www.youtube.com/watch?v=dQw4w9WgXcQ', 1000),
+    ).toBeNull();
+  });
+
+  it('rejects a YouTube URL with no channel anywhere in the path', () => {
+    expect(parseChannelInput('https://www.youtube.com/feed/trending', 1000)).toBeNull();
+  });
+
+  it('rejects the bare YouTube homepage (no path at all)', () => {
+    expect(parseChannelInput('https://www.youtube.com/', 1000)).toBeNull();
+  });
+
+  it('rejects a canonical channel URL missing the id segment', () => {
+    expect(parseChannelInput('https://www.youtube.com/channel/', 1000)).toBeNull();
+  });
+
+  it('rejects free-text garbage that is not a URL, handle, or id', () => {
+    expect(parseChannelInput('this is not a channel!!', 1000)).toBeNull();
+  });
+
+  it('rejects a channel id that is one character short of valid (a near-miss)', () => {
+    const nearMiss = VALID_CHANNEL_ID.slice(0, -1);
+    expect(parseChannelInput(nearMiss, 1000)).toBeNull();
+  });
+
+  it('rejects a channel id that has an extra trailing character (a near-miss)', () => {
+    const nearMiss = `${VALID_CHANNEL_ID}A`;
+    expect(parseChannelInput(nearMiss, 1000)).toBeNull();
+  });
+});
+
+// -----------------------------------------------------------------------------------
+// sameChannel
+// -----------------------------------------------------------------------------------
+
+describe('sameChannel', () => {
+  it('recognizes two entries for the same channel when the ids match exactly', () => {
+    const a = entry({ channelId: VALID_CHANNEL_ID });
+    const b = entry({ channelId: VALID_CHANNEL_ID, displayName: 'Different Name' });
+    expect(sameChannel(a, b)).toBe(true);
+  });
+
+  it('treats channel ids as case-sensitive (a differently-cased id is a different channel)', () => {
+    const a = entry({ channelId: VALID_CHANNEL_ID });
+    const b = entry({ channelId: VALID_CHANNEL_ID.toLowerCase() });
+    expect(sameChannel(a, b)).toBe(false);
+  });
+
+  it('recognizes two entries for the same channel when handles match regardless of case', () => {
+    const a = entry({ handle: 'veritasium' });
+    const b = entry({ handle: 'VeriTasium' });
+    expect(sameChannel(a, b)).toBe(true);
+  });
+
+  it('treats two entries with unrelated ids and handles as different channels', () => {
+    const a = entry({ channelId: VALID_CHANNEL_ID, handle: 'veritasium' });
+    const b = entry({ channelId: 'UCzzzzzzzzzzzzzzzzzzzzzz', handle: 'someoneelse' });
+    expect(sameChannel(a, b)).toBe(false);
+  });
+
+  it('does not match two entries that only carry non-overlapping identifier types', () => {
+    const a = entry({ channelId: VALID_CHANNEL_ID, handle: null });
+    const b = entry({ channelId: null, handle: 'veritasium' });
+    expect(sameChannel(a, b)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------------
+// findChannel / isChannelListed
+// -----------------------------------------------------------------------------------
+
+describe('findChannel', () => {
+  const list: ChannelEntry[] = [
+    entry({ channelId: VALID_CHANNEL_ID, handle: 'veritasium', displayName: 'Veritasium' }),
+    entry({ channelId: null, handle: 'mkbhd', displayName: '@mkbhd' }),
+  ];
+
+  it('finds a channel by id-only probe', () => {
+    const probe: ChannelProbe = { channelId: VALID_CHANNEL_ID };
+    expect(findChannel(list, probe)?.displayName).toBe('Veritasium');
+  });
+
+  it('finds a channel by handle-only probe', () => {
+    const probe: ChannelProbe = { handle: 'mkbhd' };
+    expect(findChannel(list, probe)?.displayName).toBe('@mkbhd');
+  });
+
+  it('finds a channel by handle probe even when the probe handle has a leading @ and different case', () => {
+    const probe: ChannelProbe = { handle: '@MKBHD' };
+    expect(findChannel(list, probe)?.handle).toBe('mkbhd');
+  });
+
+  it('cross-matches when the stored entry has both identifiers but the probe only carries one', () => {
+    const probe: ChannelProbe = { handle: 'veritasium' };
+    expect(findChannel(list, probe)?.channelId).toBe(VALID_CHANNEL_ID);
+  });
+
+  it('returns null when neither identifier on the probe matches anything on the list', () => {
+    const probe: ChannelProbe = { channelId: 'UCnotintheL1stnotintheL1' };
+    expect(findChannel(list, probe)).toBeNull();
+  });
+
+  it('returns null when the probe carries neither identifier', () => {
+    expect(findChannel(list, {})).toBeNull();
+  });
+
+  it('returns null against an empty list', () => {
+    expect(findChannel([], { handle: 'veritasium' })).toBeNull();
+  });
+});
+
+describe('isChannelListed', () => {
+  const list: ChannelEntry[] = [entry({ handle: 'veritasium' })];
+
+  it('reports a listed channel as listed', () => {
+    expect(isChannelListed(list, { handle: 'veritasium' })).toBe(true);
+  });
+
+  it('reports an unlisted channel as not listed', () => {
+    expect(isChannelListed(list, { handle: 'someoneelse' })).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------------
+// decideChannel — full mode x listed/not-listed/unknown matrix
+// -----------------------------------------------------------------------------------
+
+describe('decideChannel', () => {
+  const listedProbe: ChannelProbe = { handle: 'veritasium' };
+  const notListedProbe: ChannelProbe = { handle: 'someoneelse' };
+  const unknownProbe: ChannelProbe = {};
+  const channels: ChannelEntry[] = [entry({ handle: 'veritasium' })];
+
+  function decide(mode: ChannelListMode, probe: ChannelProbe) {
+    return decideChannel({ mode, channels, probe, blockMode: 'DELAY' });
+  }
+
+  describe('mode OFF — the feature is disabled, so it never blocks anything', () => {
+    it('lets a listed channel through', () => {
+      expect(decide('OFF', listedProbe)).toEqual({ action: 'ALLOW', reason: 'mode-off' });
+    });
+
+    it('lets an unlisted channel through', () => {
+      expect(decide('OFF', notListedProbe)).toEqual({ action: 'ALLOW', reason: 'mode-off' });
+    });
+
+    it('lets an unidentifiable channel through', () => {
+      expect(decide('OFF', unknownProbe)).toEqual({ action: 'ALLOW', reason: 'mode-off' });
+    });
+  });
+
+  describe('mode BLACKLIST — only listed channels are blocked', () => {
+    it('blocks a channel that is on the blacklist', () => {
+      expect(decide('BLACKLIST', listedProbe)).toEqual({ action: 'BLOCK', mode: 'DELAY' });
+    });
+
+    it('allows a channel that is not on the blacklist', () => {
+      expect(decide('BLACKLIST', notListedProbe)).toEqual({
+        action: 'ALLOW',
+        reason: 'not-listed',
+      });
+    });
+
+    it('allows a channel it could not identify (fails open, never blocks all of YouTube on a detection miss)', () => {
+      expect(decide('BLACKLIST', unknownProbe)).toEqual({
+        action: 'ALLOW',
+        reason: 'unknown-channel',
+      });
+    });
+  });
+
+  describe('mode WHITELIST — only listed channels are allowed', () => {
+    it('allows a channel that is on the whitelist', () => {
+      expect(decide('WHITELIST', listedProbe)).toEqual({ action: 'ALLOW', reason: 'listed' });
+    });
+
+    it('blocks a channel that is not on the whitelist', () => {
+      expect(decide('WHITELIST', notListedProbe)).toEqual({ action: 'BLOCK', mode: 'DELAY' });
+    });
+
+    it('allows a channel it could not identify rather than breaking all of YouTube on a detection miss', () => {
+      expect(decide('WHITELIST', unknownProbe)).toEqual({
+        action: 'ALLOW',
+        reason: 'unknown-channel',
+      });
+    });
+  });
+
+  it('reports the caller-configured block mode, not a hardcoded one', () => {
+    expect(decideChannel({ mode: 'BLACKLIST', channels, probe: listedProbe, blockMode: 'HARD_BLOCK' })).toEqual({
+      action: 'BLOCK',
+      mode: 'HARD_BLOCK',
+    });
+  });
+});
+
+// -----------------------------------------------------------------------------------
+// shouldShowInColor — same matrix, the unknown channel must always stay gray
+// -----------------------------------------------------------------------------------
+
+describe('shouldShowInColor', () => {
+  const listedProbe: ChannelProbe = { handle: 'veritasium' };
+  const notListedProbe: ChannelProbe = { handle: 'someoneelse' };
+  const unknownProbe: ChannelProbe = {};
+  const channels: ChannelEntry[] = [entry({ handle: 'veritasium' })];
+
+  function show(mode: ChannelListMode, probe: ChannelProbe) {
+    return shouldShowInColor({ mode, channels, probe });
+  }
+
+  it('keeps everything gray while the feature is off', () => {
+    expect(show('OFF', listedProbe)).toBe(false);
+    expect(show('OFF', notListedProbe)).toBe(false);
+    expect(show('OFF', unknownProbe)).toBe(false);
+  });
+
+  it('keeps a blacklisted channel gray', () => {
+    expect(show('BLACKLIST', listedProbe)).toBe(false);
+  });
+
+  it('shows a non-blacklisted channel in color', () => {
+    expect(show('BLACKLIST', notListedProbe)).toBe(true);
+  });
+
+  it('shows a whitelisted channel in color', () => {
+    expect(show('WHITELIST', listedProbe)).toBe(true);
+  });
+
+  it('keeps a non-whitelisted channel gray', () => {
+    expect(show('WHITELIST', notListedProbe)).toBe(false);
+  });
+
+  it('keeps a channel it could not identify gray, in every mode — gray is always the safe default', () => {
+    expect(show('BLACKLIST', unknownProbe)).toBe(false);
+    expect(show('WHITELIST', unknownProbe)).toBe(false);
+    expect(show('OFF', unknownProbe)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------------
+// addChannel / removeChannel — purity + duplicate merging
+// -----------------------------------------------------------------------------------
+
+describe('addChannel', () => {
+  it('adds a channel to an empty list', () => {
+    const result = addChannel([], entry({ handle: 'veritasium' }));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.handle).toBe('veritasium');
+  });
+
+  it('adds a new, unrelated channel alongside existing ones', () => {
+    const existing = [entry({ handle: 'veritasium' })];
+    const result = addChannel(existing, entry({ handle: 'mkbhd' }));
+    expect(result).toHaveLength(2);
+  });
+
+  it('does not create a duplicate row for a channel that is already on the list', () => {
+    const existing = [entry({ handle: 'veritasium', channelId: null })];
+    const result = addChannel(existing, entry({ handle: 'veritasium', channelId: VALID_CHANNEL_ID }));
+    expect(result).toHaveLength(1);
+  });
+
+  it('fills in a missing identifier when merging a duplicate add', () => {
+    const existing = [entry({ handle: 'veritasium', channelId: null, displayName: '@veritasium' })];
+    const result = addChannel(
+      existing,
+      entry({ handle: 'veritasium', channelId: VALID_CHANNEL_ID, displayName: '@veritasium' }),
+    );
+    expect(result[0]?.channelId).toBe(VALID_CHANNEL_ID);
+    expect(result[0]?.handle).toBe('veritasium');
+  });
+
+  it('prefers a real display name over a bare "@handle" placeholder when merging', () => {
+    const existing = [entry({ handle: 'veritasium', displayName: '@veritasium' })];
+    const result = addChannel(existing, entry({ handle: 'veritasium', displayName: 'Veritasium' }));
+    expect(result[0]?.displayName).toBe('Veritasium');
+  });
+
+  it('never mutates the input list (by reference and by content)', () => {
+    const existing = [entry({ handle: 'veritasium' })];
+    const snapshot = JSON.parse(JSON.stringify(existing));
+    const result = addChannel(existing, entry({ handle: 'mkbhd' }));
+    expect(existing).toEqual(snapshot);
+    expect(result).not.toBe(existing);
+  });
+});
+
+describe('removeChannel', () => {
+  it('removes a channel matched by id', () => {
+    const list = [entry({ channelId: VALID_CHANNEL_ID, handle: 'veritasium' })];
+    const result = removeChannel(list, entry({ channelId: VALID_CHANNEL_ID }));
+    expect(result).toHaveLength(0);
+  });
+
+  it('removes a channel matched by handle', () => {
+    const list = [entry({ handle: 'veritasium' })];
+    const result = removeChannel(list, entry({ handle: 'VeriTasium' }));
+    expect(result).toHaveLength(0);
+  });
+
+  it('leaves unrelated channels untouched', () => {
+    const list = [entry({ handle: 'veritasium' }), entry({ handle: 'mkbhd' })];
+    const result = removeChannel(list, entry({ handle: 'veritasium' }));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.handle).toBe('mkbhd');
+  });
+
+  it('is a no-op (content-wise) when the channel is not on the list', () => {
+    const list = [entry({ handle: 'veritasium' })];
+    const result = removeChannel(list, entry({ handle: 'someoneelse' }));
+    expect(result).toEqual(list);
+  });
+
+  it('never mutates the input list (by reference and by content)', () => {
+    const list = [entry({ handle: 'veritasium' }), entry({ handle: 'mkbhd' })];
+    const snapshot = JSON.parse(JSON.stringify(list));
+    const result = removeChannel(list, entry({ handle: 'veritasium' }));
+    expect(list).toEqual(snapshot);
+    expect(result).not.toBe(list);
+  });
+});

--- a/extension/tests/core/settingsSchema.test.ts
+++ b/extension/tests/core/settingsSchema.test.ts
@@ -218,3 +218,120 @@ describe('migrateSettings — idempotence', () => {
     expect(twice).toEqual(valid);
   });
 });
+
+describe('upgrading an existing user from schema v1 to v2', () => {
+  /**
+   * The realistic shape stored by the shipped v1 release: no channel list, no gray-screen,
+   * no hide toggles, those fields simply did not exist yet.
+   */
+  const V1_SETTINGS = {
+    schemaVersion: 1,
+    globalEnabled: true,
+    onboardingComplete: true,
+    rules: [
+      {
+        id: 'rule-youtube.com',
+        domain: 'youtube.com',
+        mode: 'DELAY',
+        delaySeconds: 30,
+        dailyLimitMinutes: 45,
+        enabled: true,
+        createdAt: 1_700_000_000_000,
+        showTimeRemaining: true,
+        schedule: null,
+      },
+    ],
+    messages: {
+      delayTitles: ['My own title'],
+      delaySubtitles: [],
+      hardBlockMessages: [],
+    },
+    strictMode: { enabled: true, challengeLength: 48 },
+    emergencyPass: { enabled: false },
+    youtube: { shortsMode: 'HARD_BLOCK', hideShortsShelf: true, shortsDelaySeconds: 20 },
+    tempAllowMinutes: 25,
+  };
+
+  it('keeps every setting the user had already chosen', () => {
+    const migrated = migrateSettings(V1_SETTINGS);
+
+    expect(migrated.rules).toHaveLength(1);
+    expect(migrated.rules[0]).toMatchObject({
+      domain: 'youtube.com',
+      mode: 'DELAY',
+      delaySeconds: 30,
+      dailyLimitMinutes: 45,
+      showTimeRemaining: true,
+    });
+    expect(migrated.messages.delayTitles).toEqual(['My own title']);
+    expect(migrated.strictMode).toEqual({ enabled: true, challengeLength: 48 });
+    expect(migrated.emergencyPass.enabled).toBe(false);
+    expect(migrated.tempAllowMinutes).toBe(25);
+    expect(migrated.youtube).toMatchObject({
+      shortsMode: 'HARD_BLOCK',
+      hideShortsShelf: true,
+      shortsDelaySeconds: 20,
+    });
+  });
+
+  it('leaves every new feature switched off, so upgrading changes nothing the user sees', () => {
+    const migrated = migrateSettings(V1_SETTINGS);
+
+    expect(migrated.youtube.channelMode).toBe('OFF');
+    expect(migrated.youtube.channels).toEqual([]);
+    expect(migrated.youtube.grayScreen).toBe(false);
+    expect(migrated.youtube.hideHomeFeed).toBe(false);
+    expect(migrated.youtube.hideSidebarRecs).toBe(false);
+    expect(migrated.youtube.hideEndScreen).toBe(false);
+    expect(migrated.youtube.hideComments).toBe(false);
+    expect(migrated.youtube.disableAutoplay).toBe(false);
+  });
+
+  it('is stamped as the current schema version', () => {
+    expect(migrateSettings(V1_SETTINGS).schemaVersion).toBe(SCHEMA_VERSION);
+  });
+
+  it('does not change again on a second upgrade', () => {
+    const once = migrateSettings(V1_SETTINGS);
+    expect(migrateSettings(once)).toEqual(once);
+  });
+
+  it('drops a channel entry that carries no identifier at all, since it could never match', () => {
+    const withJunk = {
+      ...V1_SETTINGS,
+      youtube: {
+        ...V1_SETTINGS.youtube,
+        channels: [
+          { channelId: 'UCrealchannel00000000001', handle: null, displayName: 'Real', addedAt: 1 },
+          { channelId: null, handle: null, displayName: 'Ghost', addedAt: 2 },
+        ],
+      },
+    };
+
+    const channels = migrateSettings(withJunk).youtube.channels;
+    expect(channels).toHaveLength(1);
+    expect(channels[0]?.displayName).toBe('Real');
+  });
+
+  it('merges two entries that describe the same channel by different identifiers', () => {
+    const duplicated = {
+      ...V1_SETTINGS,
+      youtube: {
+        ...V1_SETTINGS.youtube,
+        channels: [
+          { channelId: 'UCsamechannel00000000001', handle: null, displayName: '@veritasium', addedAt: 1 },
+          { channelId: 'UCsamechannel00000000001', handle: 'veritasium', displayName: 'Veritasium', addedAt: 2 },
+        ],
+      },
+    };
+
+    const channels = migrateSettings(duplicated).youtube.channels;
+    expect(channels).toHaveLength(1);
+    // The merge fills in the identifier the first copy was missing, and prefers a real name.
+    expect(channels[0]).toMatchObject({
+      channelId: 'UCsamechannel00000000001',
+      handle: 'veritasium',
+      displayName: 'Veritasium',
+    });
+  });
+});

--- a/extension/tests/core/strictMode.test.ts
+++ b/extension/tests/core/strictMode.test.ts
@@ -417,7 +417,7 @@ describe('strictMode: isWeakening() — tempAllowMinutes axis', () => {
 describe('strictMode: isWeakening() — youtube.shortsMode axis', () => {
   function withShorts(mode: 'INHERIT' | 'HARD_BLOCK' | 'DELAY' | 'BREATHING'): NudgeSettings {
     return baseSettings({
-      youtube: { shortsMode: mode, hideShortsShelf: false, shortsDelaySeconds: 15 },
+      youtube: { ...DEFAULT_SETTINGS.youtube, shortsMode: mode },
     });
   }
 

--- a/extension/tests/ui/youtubePanel.test.tsx
+++ b/extension/tests/ui/youtubePanel.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { useState } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '../../src/core/settingsSchema';
+import type { YoutubeSettings } from '../../src/core/settingsSchema';
+import { YoutubePanel } from '../../src/entrypoints/dashboard/YoutubePanel';
+
+function makeYoutubeSettings(overrides: Partial<YoutubeSettings> = {}): YoutubeSettings {
+  return {
+    ...DEFAULT_SETTINGS.youtube,
+    channels: [...DEFAULT_SETTINGS.youtube.channels],
+    ...overrides,
+  };
+}
+
+/** Renders YoutubePanel as a controlled component so interactive flows (add/remove a
+ * channel, flip a toggle) are actually visible in the DOM after the change, the same way
+ * the real Dashboard/SettingsPanel controls it. `onEmit` lets tests additionally inspect
+ * exactly what was emitted on a given change without having to diff DOM state. */
+function Harness({
+  initial,
+  onEmit,
+}: {
+  initial: YoutubeSettings;
+  onEmit?: (next: YoutubeSettings) => void;
+}) {
+  const [settings, setSettings] = useState(initial);
+  return (
+    <YoutubePanel
+      settings={settings}
+      onChange={(next) => {
+        onEmit?.(next);
+        setSettings(next);
+      }}
+    />
+  );
+}
+
+function addChannel(text: string) {
+  fireEvent.change(screen.getByLabelText('Add YouTube channel'), { target: { value: text } });
+  fireEvent.click(screen.getByRole('button', { name: 'Add channel' }));
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('YoutubePanel — channel list', () => {
+  it('adds a channel by @handle to the list', () => {
+    render(<Harness initial={makeYoutubeSettings({ channelMode: 'BLACKLIST' })} />);
+
+    addChannel('@veritasium');
+
+    expect(screen.getByText('@veritasium')).toBeDefined();
+    // The input clears on a successful add — the user can immediately type the next one.
+    expect((screen.getByLabelText('Add YouTube channel') as HTMLInputElement).value).toBe('');
+  });
+
+  it('adds a channel by full channel URL to the list', () => {
+    render(<Harness initial={makeYoutubeSettings({ channelMode: 'BLACKLIST' })} />);
+
+    addChannel('https://www.youtube.com/@testchannel/videos');
+
+    expect(screen.getByText('@testchannel')).toBeDefined();
+  });
+
+  it('adds a channel by UCxxxx channel id to the list', () => {
+    render(<Harness initial={makeYoutubeSettings({ channelMode: 'BLACKLIST' })} />);
+    const channelId = 'UCabcdefghijklmnopqrstuv'; // "UC" + 22 chars, the exact accepted shape
+
+    addChannel(channelId);
+
+    expect(screen.getByText(channelId)).toBeDefined();
+  });
+
+  it('shows an inline error and adds nothing for garbage input', () => {
+    render(<Harness initial={makeYoutubeSettings({ channelMode: 'BLACKLIST' })} />);
+
+    addChannel('this is not a channel at all!!');
+
+    expect(screen.getByText(/doesn't look like a channel/i)).toBeDefined();
+    // Still the empty-list state — nothing was added.
+    expect(screen.getByText('No channels added yet — add one above.')).toBeDefined();
+  });
+
+  it('removes a channel from the list', () => {
+    const entry = { channelId: null, handle: 'veritasium', displayName: '@veritasium', addedAt: 0 };
+    render(
+      <Harness initial={makeYoutubeSettings({ channelMode: 'BLACKLIST', channels: [entry] })} />,
+    );
+
+    expect(screen.getByText('@veritasium')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Remove @veritasium' }));
+
+    expect(screen.queryByText('@veritasium')).toBeNull();
+    expect(screen.getByText('No channels added yet — add one above.')).toBeDefined();
+  });
+
+  it('warns prominently when "only allow these channels" is chosen with an empty list, and the warning clears once a channel is added', () => {
+    render(<Harness initial={makeYoutubeSettings({ channelMode: 'OFF' })} />);
+
+    expect(screen.queryByText(/blocks ALL of YouTube/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Only allow these channels/ }));
+    expect(screen.getByText(/blocks ALL of YouTube/i)).toBeDefined();
+
+    addChannel('@somechannel');
+    expect(screen.queryByText(/blocks ALL of YouTube/i)).toBeNull();
+  });
+});
+
+describe('YoutubePanel — hide toggles', () => {
+  const HIDE_TOGGLES: { label: string; key: keyof YoutubeSettings }[] = [
+    { label: 'Hide home feed', key: 'hideHomeFeed' },
+    { label: 'Hide sidebar recommendations', key: 'hideSidebarRecs' },
+    { label: 'Hide end-screen suggestions', key: 'hideEndScreen' },
+    { label: 'Hide comments', key: 'hideComments' },
+    { label: 'Disable autoplay', key: 'disableAutoplay' },
+  ];
+
+  for (const { label, key } of HIDE_TOGGLES) {
+    it(`flipping "${label}" changes only that setting in the emitted settings object`, () => {
+      const initial = makeYoutubeSettings();
+      const onEmit = vi.fn();
+      render(<Harness initial={initial} onEmit={onEmit} />);
+
+      fireEvent.click(screen.getByLabelText(label));
+
+      expect(onEmit).toHaveBeenCalledTimes(1);
+      const emitted = onEmit.mock.calls[0]![0] as YoutubeSettings;
+      expect(emitted[key]).toBe(true);
+      for (const other of HIDE_TOGGLES) {
+        if (other.key === key) continue;
+        expect(emitted[other.key]).toBe(initial[other.key]);
+      }
+      // Untouched fields outside the hide-toggle group stay untouched too.
+      expect(emitted.grayScreen).toBe(initial.grayScreen);
+      expect(emitted.channelMode).toBe(initial.channelMode);
+      expect(emitted.shortsMode).toBe(initial.shortsMode);
+    });
+  }
+});
+
+describe('YoutubePanel — gray-screen mode', () => {
+  it('flipping the gray-screen toggle changes only grayScreen', () => {
+    const initial = makeYoutubeSettings();
+    const onEmit = vi.fn();
+    render(<Harness initial={initial} onEmit={onEmit} />);
+
+    fireEvent.click(screen.getByLabelText('Turn YouTube grayscale'));
+
+    expect(onEmit).toHaveBeenCalledTimes(1);
+    const emitted = onEmit.mock.calls[0]![0] as YoutubeSettings;
+    expect(emitted.grayScreen).toBe(true);
+    expect(emitted.hideHomeFeed).toBe(initial.hideHomeFeed);
+    expect(emitted.hideSidebarRecs).toBe(initial.hideSidebarRecs);
+    expect(emitted.hideEndScreen).toBe(initial.hideEndScreen);
+    expect(emitted.hideComments).toBe(initial.hideComments);
+    expect(emitted.disableAutoplay).toBe(initial.disableAutoplay);
+    expect(emitted.channelMode).toBe(initial.channelMode);
+    expect(emitted.shortsMode).toBe(initial.shortsMode);
+  });
+
+  it('states honestly that gray-screen depends on the channel list', () => {
+    render(<Harness initial={makeYoutubeSettings()} />);
+    expect(screen.getByText(/depends on the channel list/i)).toBeDefined();
+  });
+});
+
+describe('YoutubePanel — autoplay caveat', () => {
+  it('shows the best-effort caveat for disable autoplay', () => {
+    render(<Harness initial={makeYoutubeSettings()} />);
+    expect(screen.getByText(/best-effort/i)).toBeDefined();
+    expect(screen.getByText(/YouTube can restore its own player state/i)).toBeDefined();
+  });
+});

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
       'unlimitedStorage',
       'alarms',
       'idle',
+      // Gray-screen mode registers grayscale.css as a DYNAMIC content script so it can be
+      // turned off AND still inject before first paint. No install-time warning.
+      'scripting',
     ],
     host_permissions: ['<all_urls>'],
     // A DNR `redirect.extensionPath` target MUST be web-accessible or the redirect


### PR DESCRIPTION
Phase 4, the differentiator features, all YouTube. Builds on the merged MVP (#9).

## What's in it

**Channel whitelist / blacklist.** Three modes (off / "block these channels" / "only allow these channels"), applied to both feed composition and the watch page. Identification is three-tier per ext-03 §3, `ytInitialPlayerResponse` → a brace-counting `ytInitialData` scan → a DOM chain, because YouTube ships different shapes on different surfaces. Entries store **both** the `UCxxxx` id and the handle and match on either, since feed cards usually expose only `/@handle` while watch pages expose the canonical id.

**Gray-screen mode.** YouTube goes grayscale; channels you allowed come back in colour.

**Unhook-parity toggles.** Hide home feed / sidebar recs / end-screen suggestions / comments, plus disable autoplay. Five independent switches, all default off.

## The two decisions worth reviewing

**1. The unknown-channel case fails OPEN, deliberately and observably.**

Detection can fail, YouTube moves its DOM, or the page hasn't hydrated. A hard whitelist that failed *shut* would block the entire site the moment a selector rots. So an unidentified channel is allowed, but carries a distinct `reason: 'unknown-channel'` so "checked and it's fine" stays distinguishable from "couldn't tell at all". A silent fail-open is a bug; a documented, observable one is a design decision. Gray-screen takes the **opposite** bias, an unidentified channel never earns colour, because staying gray is harmless while over-blocking is not.

**2. Gray-screen's mechanism, the requirement looks contradictory.**

The CSS must be *gateable* (off when the feature is off) **and** applied *before first paint* (or the page flashes full colour, which is the exact hit the feature exists to remove). Neither obvious option gives both:

| Approach | Gateable? | Flash-free? |
|---|---|---|
| Static `content_scripts.css` | No, always on | Yes |
| CSS injected from JS after a storage read | Yes | No, paints colour first |
| **Dynamic `registerContentScripts` with `css`** | **Yes** | **Yes** |

I verified against the `chrome.scripting` reference that `registerContentScripts` accepts `css` and injects it "before any DOM is constructed or displayed". The worker registers `grayscale.css` while the feature is on and unregisters it when off, re-deriving from settings on every wake (`persistAcrossSessions` defaults true, so a stale registration would otherwise outlive its setting). Adds the `scripting` permission, no new install warning.

The one flash that remains is gray → **colour** on an *allowed* channel, which is unavoidable and the right direction. Documented with the tradeoff table in `extension/CLAUDE.md`, as requested.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm test` | **570 passing, 20 files** (+130) |
| `npm run build` | loadable, `grayscale.css` ships |
| `npm run e2e` | **35/35 passing** (+8) |

E2E now drives the **real YouTube content script with zero network**: `*.youtube.com` is mapped onto the local fixture server, so the script that only matches `*://*.youtube.com/*` runs for real against a page carrying a genuine `ytInitialPlayerResponse`. That required moving the fixture server to **HTTPS**, youtube.com is HSTS-preloaded, so `http://` is force-upgraded before the resolver rule applies and a plain-HTTP server answers `ERR_SSL_PROTOCOL_ERROR`. It generates a throwaway self-signed cert per run (never committed). The grayscale specs assert **computed style**, which is what actually proves the dynamically-registered CSS loaded.

## Schema migration

v1 → v2 is purely additive and **every new default is off**, so upgrading changes nothing an existing user is protected from. `migrateSettings` was already total, so there's no per-version branch. Explicit tests assert a realistic v1 object keeps every setting intact, comes out with all new features off, and re-migrating is a no-op.

## Reviewer notes

- Every test is phrased as a **user-visible outcome**, never an internal branch, carrying forward the lesson from the redirect-loop incident.
- Each hiding feature owns its **own CSS class**: with one shared class, turning Shorts hiding off would un-hide your comments.
- **Autoplay is honestly best-effort**, no API exists, so we click the player's own switch only when it reads `aria-checked="true"` (idempotent by construction). YouTube can restore its own state; the dashboard says so rather than implying certainty.
- Instagram / TikTok / X reel surfaces are in the PRD's v1.1 but **not** in this phase; they stay in the known-gaps list.

Draft on purpose, the orchestrator QA-gates the merge.
