### PR TITLE
chore(play): default releases to 100% rollout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,13 +56,29 @@ CI runs on every tag push (`.github/workflows/release.yml`). Builds `assembleRel
 GitHub releases are automatic; **Google Play is a separate, deliberate step** that runs **from the laptop, not CI**:
 
 ```bash
-# Safe verify: upload as a production DRAFT (no users affected).
+# Default: live to 100% of production users. This is the standing default.
 scripts/publish-to-play.sh 1.7.0
-# Go live to a 20% staged rollout (halt-able from Play Console).
+# Opt in to a staged, halt-able rollout — only for genuinely risky releases,
+# and you then OWE the promote step (see below).
 STATUS=inProgress ROLLOUT=0.2 scripts/publish-to-play.sh 1.7.0
-# Full rollout once confident.
-STATUS=completed ROLLOUT=1.0 scripts/publish-to-play.sh 1.7.0
+# Upload as a production DRAFT (no users affected) to eyeball it first.
+STATUS=draft scripts/publish-to-play.sh 1.7.0
 ```
+
+**Full rollout is the default (Anti, 2026-07-30: "for google play it's just easier that way").** A staged rollout is a second owed step days later, and the promotion can't be done by this script — so twice running (v1.9.4, v1.10.0) the tail step was forgotten or cost time, for ~no signal at our install base. Stage only when a release is genuinely risky, and file the promote as a dated task when you do.
+
+**Promoting a staged/draft release later** — `publish-to-play.sh` CANNOT do it (`gplay release` re-uploads the AAB; Play rejects an existing versionCode), and **`gplay rollout complete` is also broken** — it sets `status=completed` but leaves `userFraction`, which Play rejects with `COMPLETED release must not have fraction`. Use the edit cycle:
+
+```bash
+EDIT=$(gplay edits create --package dev.astraedus.nudge | jq -r '.id')
+gplay tracks get --package dev.astraedus.nudge --edit "$EDIT" --track production \
+  | jq '[ .releases[] | select(.name=="X.Y.Z") | (.status="completed" | del(.userFraction)) ]' > /tmp/rel.json
+gplay tracks update --package dev.astraedus.nudge --edit "$EDIT" --track production --releases @/tmp/rel.json
+gplay edits validate --package dev.astraedus.nudge --edit "$EDIT"
+gplay edits commit   --package dev.astraedus.nudge --edit "$EDIT"
+gplay status --package dev.astraedus.nudge --pretty   # verify
+```
+Submit ONLY the release being promoted — the superseded one drops off the track automatically.
 
 The script pulls the CI-built AAB from the GitHub Release (or `SOURCE=run` for a `workflow_dispatch` artifact), runs `gplay preflight` (offline secret/compliance scan), then `gplay release` to the chosen track with release notes auto-extracted from `CHANGELOG.md`.
 
@@ -355,7 +371,7 @@ After any feature addition or significant change:
 8. Update this CLAUDE.md (architecture docs, feature descriptions) if applicable
 9. Commit all changes, tag, push: `git push origin main --tags`
 10. Create GitHub release (fast path): `gh release create vX.Y.Z nudge-vX.Y.Z.apk --title "vX.Y.Z" --generate-notes`
-11. **Publish to Google Play** — the standing default so Play never drifts behind GitHub again. After CI attaches the AAB, run `scripts/publish-to-play.sh X.Y.Z` (stages a production DRAFT to verify), then `STATUS=completed ROLLOUT=1.0 scripts/publish-to-play.sh X.Y.Z` for full rollout (or `STATUS=inProgress ROLLOUT=0.2 …` for a staged, halt-able rollout). Play credentials stay on the laptop — never in CI. See the **Releasing → Google Play** section for the security rationale.
+11. **Publish to Google Play** — the standing default so Play never drifts behind GitHub again. After CI attaches the AAB, run `scripts/publish-to-play.sh X.Y.Z` — that ships to **100% of production** in one step, no follow-up owed. Stage (`STATUS=inProgress ROLLOUT=0.2 …`) only for a genuinely risky release, and file the promote step as a dated task if you do. Play credentials stay on the laptop — never in CI. See the **Releasing → Google Play** section for the security rationale.
 12. Update store listing copy if user-facing
 
 **This is the standard ship flow. Every change that touches user-facing behavior gets a device QA gate before push.**

--- a/scripts/publish-to-play.sh
+++ b/scripts/publish-to-play.sh
@@ -15,7 +15,7 @@
 #   1. Resolve the signed AAB for a version (from the GitHub Release, a CI
 #      workflow-run artifact, or an explicit path).
 #   2. gplay preflight  — offline secret/compliance/hygiene scan of the bundle.
-#   3. gplay release     — upload to a track with a staged rollout.
+#   3. gplay release     — upload to a track and release it (100% by default).
 #   4. gplay status      — print the resulting release-health snapshot.
 #
 # USAGE:
@@ -23,31 +23,49 @@
 #
 #   Env overrides (all optional):
 #     TRACK=production|beta|alpha|internal   (default: production)
-#     ROLLOUT=0.0-1.0                        (default: 0.2  → 20% staged rollout)
+#     ROLLOUT=0.0-1.0                        (default: 1.0  → everyone)
 #     STATUS=draft|inProgress|halted|completed
-#                                            (default: draft → uploaded but NOT
-#                                             released to users until promoted)
+#                                            (default: completed → live to 100%)
+#
+#   WHY the default is a FULL rollout, not a staged one (Anti, 2026-07-30):
+#   a staged rollout is a SECOND owed step — someone must come back days later
+#   and promote it, and `gplay rollout complete` is broken (see below), so the
+#   promotion is a hand-run edit cycle. Twice now (v1.9.4, v1.10.0) that tail
+#   step was forgotten or cost time, leaving users on an old build for no gain.
+#   Our install base is small enough that a staged rollout buys ~nothing in
+#   signal but reliably costs a follow-up. Ship to 100%; if a release is
+#   genuinely risky (schema migration you can't test), opt IN explicitly with
+#   STATUS=inProgress ROLLOUT=0.2 and file the promote step as a dated task.
 #     SOURCE=release|run                     (default: release; "run" = pull the
 #                                             AAB from the latest workflow_dispatch
 #                                             run artifact instead of a GH Release)
 #
 # EXAMPLES:
-#   # Safe: upload 1.7.0 as a production DRAFT (no users affected) to verify.
+#   # Default: go live to 100% of production users.
 #   scripts/publish-to-play.sh 1.7.0
 #
-#   # Go live to 20% of production users, halt-able from Play Console.
+#   # Opt in to a staged, halt-able rollout (then you OWE the promote step).
 #   STATUS=inProgress ROLLOUT=0.2 scripts/publish-to-play.sh 1.7.0
 #
-#   # Full rollout once you're confident.
-#   STATUS=completed ROLLOUT=1.0 scripts/publish-to-play.sh 1.7.0
+#   # Upload as a production DRAFT (no users affected) to eyeball it first.
+#   STATUS=draft scripts/publish-to-play.sh 1.7.0
+#
+# PROMOTING a staged/draft release later: this script CANNOT do it — `gplay
+# release` re-uploads the AAB and Play rejects a versionCode that already
+# exists. And `gplay rollout complete` is ALSO broken: it sets status=completed
+# while leaving userFraction set, which Play rejects with
+# "COMPLETED release must not have fraction". The working recipe is the edit
+# cycle (edits create → tracks get → jq the release to status=completed with
+# userFraction DELETED → tracks update --releases @file → validate → commit).
+# Full recipe: ~/ops/references/play-console-cli.md.
 #
 set -euo pipefail
 
 REPO="astraedus/nudge"
 PKG="dev.astraedus.nudge"
 TRACK="${TRACK:-production}"
-ROLLOUT="${ROLLOUT:-0.2}"
-STATUS="${STATUS:-draft}"
+ROLLOUT="${ROLLOUT:-1.0}"
+STATUS="${STATUS:-completed}"
 SOURCE="${SOURCE:-release}"
 
 VERSION="${1:-}"


### PR DESCRIPTION
Anti, 2026-07-30: "can we make it 100% lol for google play it's just easier that way."

- `publish-to-play.sh` defaults flipped to `STATUS=completed ROLLOUT=1.0` (were `draft`/0.2), with the rationale inline.
- Documents that **`gplay rollout complete` is broken**, it sets `status=completed` but leaves `userFraction`, and Play rejects it with `COMPLETED release must not have fraction`. The working edit-cycle recipe now lives in the script header + CLAUDE.md instead of only in tasks/lessons.md.
- Post-feature checklist step 11 rewritten: publishing is one step, no owed follow-up.

Docs + defaults only; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)