### PR TITLE
Fix daily limits, feature-only blocking, the DM-reel bypass and #15's wrong timers

### DIFF
--- a/app/src/main/java/com/astraedus/nudge/data/repository/UsageRepository.kt
+++ b/app/src/main/java/com/astraedus/nudge/data/repository/UsageRepository.kt
@@ -9,7 +9,6 @@ import com.astraedus.nudge.domain.engine.TimeTracker
 import com.astraedus.nudge.service.UsageProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,13 +20,6 @@ class UsageRepository @Inject constructor(
 ) : UsageProvider {
 
     suspend fun logEvent(event: UsageEvent) = usageEventDao.insert(event)
-
-    /** Total usage in milliseconds for a package today. */
-    fun getDailyUsage(packageName: String): Flow<Long> {
-        val todayStart = timeTracker.startOfToday()
-        return usageEventDao.getTotalDurationForPackage(packageName, todayStart)
-            .map { it ?: 0L }
-    }
 
     /**
      * Get today's foreground usage time from queryEvents (ACTIVITY_RESUMED/PAUSED pairs).

--- a/app/src/main/java/com/astraedus/nudge/domain/engine/BlockEngine.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/engine/BlockEngine.kt
@@ -19,6 +19,13 @@ class BlockEngine @Inject constructor(
      *   [includeWholeAppRulesForFeature] is false.
      *
      * Priority: HARD_BLOCK > time budget exceeded > DELAY > BREATHING > Allow
+     *
+     * [BlockMode.NONE] deliberately matches none of the block branches below, so a rule carrying
+     * it yields Allow. It still participates in the time-budget check, which keys off
+     * `dailyLimitMinutes` rather than the mode — an app-level NONE rule with a daily limit means
+     * "don't gate this app, but stop me after N minutes", and its counter/overlay settings still
+     * apply. This is what lets a feature-scoped rule (Shorts, Reels) block while its host app
+     * stays open.
      */
     fun evaluate(
         packageName: String,

--- a/app/src/main/java/com/astraedus/nudge/domain/engine/RuleEvaluator.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/engine/RuleEvaluator.kt
@@ -46,7 +46,8 @@ class RuleEvaluator @Inject constructor() {
 
     /**
      * Build a human-readable label describing what a rule does.
-     * Examples: "Reels - Delay", "Hard Block (30 min/day)", "Shorts - Breathing (scheduled)"
+     * Examples: "Reels - Delay", "Hard Block (30 min/day)", "Shorts - Breathing (scheduled)",
+     * "Daily limit (30 min/day)" for a NONE rule that only caps usage.
      */
     private fun buildRuleName(rule: BlockRuleData): String {
         val parts = mutableListOf<String>()
@@ -59,8 +60,10 @@ class RuleEvaluator @Inject constructor() {
             }
         }
 
-        // Mode name
+        // Mode name. A NONE rule blocks nothing itself, so the only way its label ever reaches an
+        // overlay is the daily-limit path — call it what the user will actually be seeing.
         val modeName = when (rule.mode) {
+            BlockMode.NONE -> if (rule.dailyLimitMinutes != null) "Daily limit" else "No block"
             BlockMode.HARD_BLOCK -> "Hard Block"
             BlockMode.DELAY -> "Delay"
             BlockMode.BREATHING -> "Breathing"

--- a/app/src/main/java/com/astraedus/nudge/domain/lock/RuleWeakening.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/lock/RuleWeakening.kt
@@ -15,11 +15,16 @@ object RuleWeakening {
     /**
      * Block-mode strength ordering (higher = stronger protection). Anything not recognized
      * (e.g. a future mode, or "no rule") sorts below the known modes.
+     *
+     * NONE is listed explicitly rather than left to the fallback: it is a real, user-selectable
+     * mode meaning "this rule gates nothing", so switching a blocking rule to it is the single
+     * biggest weakening available in this editor and must be caught by Strict Mode.
      */
     private fun modeStrength(mode: String?): Int = when (mode) {
         "HARD_BLOCK" -> 3
         "DELAY" -> 2
         "BREATHING" -> 1
+        "NONE" -> 0
         else -> 0
     }
 

--- a/app/src/main/java/com/astraedus/nudge/domain/model/BlockMode.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/model/BlockMode.kt
@@ -1,6 +1,22 @@
 package com.astraedus.nudge.domain.model
 
 enum class BlockMode {
+    /**
+     * Blocks nothing on its own. Exists so an app-level rule can carry the daily limit, the
+     * interaction counter, the time-remaining overlay, grayscale and web domains WITHOUT also
+     * gating the whole app — which is what makes "block only Shorts, leave the rest of YouTube
+     * alone" expressible.
+     *
+     * Before this existed, [com.astraedus.nudge.ui.screens.config.UnifiedAppConfigScreen] always
+     * wrote a blocking app-level rule and feature overrides could only differ from it, so a
+     * feature-scoped rule with an unblocked host app could not be configured at all.
+     *
+     * [com.astraedus.nudge.domain.engine.BlockEngine] matches NONE in none of its block branches,
+     * so it yields Allow. A daily limit on a NONE rule is still enforced — the time-budget check
+     * keys off `dailyLimitMinutes`, not the mode — which is deliberate: "don't block it, but cap
+     * it at 60 min/day" is a real thing users want.
+     */
+    NONE,
     HARD_BLOCK,
     DELAY,
     BREATHING

--- a/app/src/main/java/com/astraedus/nudge/domain/usecase/EvaluateBlockUseCase.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/usecase/EvaluateBlockUseCase.kt
@@ -12,7 +12,9 @@ import com.astraedus.nudge.domain.model.BlockDecision
 import com.astraedus.nudge.domain.model.BlockMode
 import com.astraedus.nudge.domain.model.BlockRuleData
 import com.astraedus.nudge.domain.model.GroupMembership
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class EvaluateBlockUseCase @Inject constructor(
@@ -71,7 +73,7 @@ class EvaluateBlockUseCase @Inject constructor(
         }
 
         val activeRules = ruleEvaluator.resolveRulesForPackage(packageName, ruleDataList, memberships)
-        val dailyUsageMs = usageRepository.getDailyUsage(packageName).first()
+        val dailyUsageMs = dailyUsageMs(packageName)
 
         return blockEngine.evaluate(
             packageName = packageName,
@@ -122,7 +124,7 @@ class EvaluateBlockUseCase @Inject constructor(
 
         // Use the first matching rule's package for usage stats lookup
         val trackingPackage = matchingRules.first().packageName ?: "web"
-        val dailyUsageMs = usageRepository.getDailyUsage(trackingPackage).first()
+        val dailyUsageMs = dailyUsageMs(trackingPackage)
 
         val decision = blockEngine.evaluate(
             packageName = trackingPackage,
@@ -157,7 +159,7 @@ class EvaluateBlockUseCase @Inject constructor(
         // Track usage under a synthetic "web" package, consistent with how
         // web-domain rules without an associated app are tracked.
         val trackingPackage = "web"
-        val dailyUsageMs = usageRepository.getDailyUsage(trackingPackage).first()
+        val dailyUsageMs = dailyUsageMs(trackingPackage)
 
         val activeRule = ActiveRule(
             mode = mode,
@@ -177,6 +179,24 @@ class EvaluateBlockUseCase @Inject constructor(
 
         return WebDomainBlockResult(decision, trackingPackage)
     }
+
+    /**
+     * Today's foreground time for [packageName], the number the daily budget is spent against.
+     *
+     * This MUST come from `UsageStatsManager` (issue #14). The obvious-looking alternative — the
+     * Room `usage_events` table — cannot work: that table logs block/allow *decisions*, and its
+     * `durationMs` column is never written, so summing it returns 0 for every package forever.
+     * Feeding that 0 to [BlockEngine] made `dailyUsageMs >= limit` permanently false, so the
+     * daily-limit HARD_BLOCK never fired and the "X left today" line on the overlay was pinned at
+     * the full limit. `TimeRemainingHandler` already reads the correct source, which is why the
+     * limit appeared to work — but only for rules that had opted into the time-remaining overlay.
+     *
+     * The read is a synchronous binder call, hence [Dispatchers.IO]; it returns 0 without throwing
+     * when Usage Access has not been granted, which fails toward *allowing* the app. That is the
+     * right direction: a permission the user has not granted must not manufacture a block.
+     */
+    private suspend fun dailyUsageMs(packageName: String): Long =
+        withContext(Dispatchers.IO) { usageRepository.getDailyForegroundTimeMs(packageName) }
 
     private fun buildWebDomainRuleName(packageName: String?, mode: String): String {
         val modeName = when (mode) {

--- a/app/src/main/java/com/astraedus/nudge/service/InAppDetector.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/InAppDetector.kt
@@ -1,6 +1,7 @@
 package com.astraedus.nudge.service
 
 import android.view.accessibility.AccessibilityNodeInfo
+import com.astraedus.nudge.BuildConfig
 import com.astraedus.nudge.util.NudgeLogger
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,6 +18,13 @@ class InAppDetector @Inject constructor(
     private val logger: NudgeLogger
 ) : InAppDetectorApi {
 
+    /**
+     * Signatures of surfaces already reported by [dumpViewIdsForDiagnosis], so each unrecognised
+     * screen is logged once per process rather than once per accessibility event. Debug builds
+     * only; bounded in practice by the handful of distinct screens these apps have.
+     */
+    private val loggedUnknownSurfaces = mutableSetOf<String>()
+
     enum class Feature(val displayName: String, val key: String) {
         REELS("Instagram Reels", "REELS"),
         SHORTS("YouTube Shorts", "SHORTS"),
@@ -32,6 +40,40 @@ class InAppDetector @Inject constructor(
             "com.zhiliaoapp.musically",
             "com.ss.android.ugc.trill"
         )
+
+        /** Cap for the debug-only view-id harvest; keeps the walk off the hot path's budget. */
+        private const val DIAGNOSTIC_NODE_LIMIT = 800
+
+        /**
+         * Containers unique to Instagram's full-screen reel player, harvested from a real device
+         * (Galaxy S24 / Android 16) while watching a reel opened from a DM.
+         *
+         * Checked instead of the bottom-nav tabs because the player is hosted in a modal activity
+         * with no nav bar. Verified absent from the home feed (which shows inline video under
+         * `media_group` / `carousel_video_media_group`) and from a DM thread, so these do not
+         * over-match ordinary browsing.
+         *
+         * More than one is listed because the player's tree varies between entry points — the
+         * DM-opened variant additionally carries a reply bar. Any single match is sufficient.
+         */
+        private val INSTAGRAM_CLIPS_VIEWER_IDS = listOf(
+            "com.instagram.android:id/clips_viewer_view_pager",
+            "com.instagram.android:id/clips_video_container",
+            "com.instagram.android:id/clips_media_component"
+        )
+    }
+
+    /** True if any of [viewIds] resolves in [root]. Nodes are recycled before returning. */
+    private fun findsAnyViewId(root: AccessibilityNodeInfo, viewIds: List<String>): Boolean {
+        for (id in viewIds) {
+            val nodes = root.findAccessibilityNodeInfosByViewId(id)
+            if (nodes.isNotEmpty()) {
+                recycleNodes(nodes)
+                return true
+            }
+            recycleNodes(nodes)
+        }
+        return false
     }
 
     /**
@@ -52,6 +94,7 @@ class InAppDetector @Inject constructor(
                 "com.zhiliaoapp.musically", "com.ss.android.ugc.trill" -> Feature.TIKTOK_FEED
                 else -> null
             }
+            if (feature == null) dumpViewIdsForDiagnosis(packageName, rootNode)
             logger.d("feature detection result package=$packageName feature=$feature")
             feature
         } catch (e: Exception) {
@@ -60,7 +103,53 @@ class InAppDetector @Inject constructor(
         }
     }
 
+    /**
+     * DIAGNOSTIC (debug builds only): log the distinct view IDs present when detection found
+     * nothing, so an undetected surface can be identified from logcat.
+     *
+     * Exists because the usual external tools cannot see these surfaces: `uiautomator dump` waits
+     * for an idle window and a continuously playing reel/short never idles, so it hangs and gets
+     * Killed; `dumpsys activity top` times out on the same screens. The accessibility tree this
+     * service already walks has no such constraint.
+     *
+     * Reads ONLY `viewIdResourceName` — never text or contentDescription, which on these screens
+     * would be the user's private messages and captions. Bounded to [DIAGNOSTIC_NODE_LIMIT] nodes,
+     * matching the bounded-harvest convention used by the Strict Mode escape guard.
+     */
+    private fun dumpViewIdsForDiagnosis(packageName: String, root: AccessibilityNodeInfo) {
+        if (!BuildConfig.DEBUG) return
+        val ids = LinkedHashSet<String>()
+        var visited = 0
+        val queue = ArrayDeque<AccessibilityNodeInfo>()
+        queue += root
+        while (queue.isNotEmpty() && visited < DIAGNOSTIC_NODE_LIMIT) {
+            val node = queue.removeFirst()
+            visited++
+            node.viewIdResourceName?.let { ids += it }
+            for (i in 0 until node.childCount) {
+                queue += node.getChild(i) ?: continue
+            }
+        }
+        // Log each DISTINCT surface once. Detection runs on a firehose of content-change events —
+        // a measured ~800 failed detections in three minutes of Instagram use — so logging every
+        // miss buries the signal. What matters is "which surfaces do we not recognise", and that
+        // set is tiny.
+        val signature = ids.joinToString(",")
+        if (!loggedUnknownSurfaces.add(signature)) return
+        logger.d("undetected surface package=$packageName nodes=$visited viewIds=$signature")
+    }
+
     private fun detectInstagram(root: AccessibilityNodeInfo): Feature? {
+        // The reel PLAYER first, before any tab reasoning. A reel opened from a DM (or a share
+        // link, or a profile) runs in com.instagram.modal.ModalActivity, which has NO bottom nav
+        // at all — so tab-based detection cannot see it even in principle, and the user scrolled
+        // reels indefinitely with a HARD_BLOCK rule active. Keying on the player's own container
+        // covers every entry route, including the Reels tab, where these IDs are also present.
+        if (findsAnyViewId(root, INSTAGRAM_CLIPS_VIEWER_IDS)) {
+            logger.d("instagram clips viewer detected")
+            return Feature.REELS
+        }
+
         // Use resource IDs for reliable tab detection. Instagram's bottom nav tabs:
         //   feed_tab (Home), clips_tab (Reels), search_tab (Search/Explore), profile_tab (Profile)
         // The tab FrameLayout itself has selected=false, but its child tab_icon ImageView

--- a/app/src/main/java/com/astraedus/nudge/service/InAppDetector.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/InAppDetector.kt
@@ -25,6 +25,10 @@ class InAppDetector @Inject constructor(
      */
     private val loggedUnknownSurfaces = mutableSetOf<String>()
 
+    /** Last time the debug harvest actually walked the tree; see [dumpViewIdsForDiagnosis]. */
+    @Volatile
+    private var lastDiagnosticMs = 0L
+
     enum class Feature(val displayName: String, val key: String) {
         REELS("Instagram Reels", "REELS"),
         SHORTS("YouTube Shorts", "SHORTS"),
@@ -43,6 +47,9 @@ class InAppDetector @Inject constructor(
 
         /** Cap for the debug-only view-id harvest; keeps the walk off the hot path's budget. */
         private const val DIAGNOSTIC_NODE_LIMIT = 800
+
+        /** Minimum gap between debug harvest walks. Bounds the cost to ~1 tree walk per interval. */
+        private const val DIAGNOSTIC_THROTTLE_MS = 5_000L
 
         /**
          * Containers unique to Instagram's full-screen reel player, harvested from a real device
@@ -118,6 +125,14 @@ class InAppDetector @Inject constructor(
      */
     private fun dumpViewIdsForDiagnosis(packageName: String, root: AccessibilityNodeInfo) {
         if (!BuildConfig.DEBUG) return
+        // Throttle the WALK, not just the logging. Detection fails on a firehose of content-change
+        // events — ~800 times in three minutes of measured Instagram use — and each call would
+        // otherwise BFS up to DIAGNOSTIC_NODE_LIMIT nodes on the accessibility hot path. A new
+        // surface stays on screen for far longer than this interval, so nothing is missed.
+        val now = System.currentTimeMillis()
+        if (now - lastDiagnosticMs < DIAGNOSTIC_THROTTLE_MS) return
+        lastDiagnosticMs = now
+
         val ids = LinkedHashSet<String>()
         var visited = 0
         val queue = ArrayDeque<AccessibilityNodeInfo>()

--- a/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
@@ -839,32 +839,41 @@ class NudgeAccessibilityService : AccessibilityService() {
         }
 
         evaluateForegroundPackage(packageName)
+        detectAndEvaluateFeature(packageName)
+    }
 
+    /**
+     * Inspect the foreground tree for an in-app feature (Reels / Shorts / TikTok feed) and block if
+     * a feature rule matches. Debounced per package via [lastContentChangedTime] — the tree read is
+     * the expensive part and these events arrive in bursts.
+     *
+     * Driven by `TYPE_WINDOW_CONTENT_CHANGED`, which is plentiful inside these apps — a device
+     * capture measured ~26k content-change events against ~1.8k scrolls during a few minutes of
+     * Instagram use, of which ~800 detection attempts survived the debounce. Detection opportunity
+     * has never been the bottleneck; recognising the surface is.
+     */
+    private fun detectAndEvaluateFeature(packageName: String) {
         val now = System.currentTimeMillis()
         val lastTime = lastContentChangedTime[packageName] ?: 0L
         if ((now - lastTime) < contentChangedDebounceMs) return
         lastContentChangedTime[packageName] = now
 
         val rootNode = try { rootInActiveWindow } catch (_: Exception) { null } ?: return
-        val feature = entryPoint.inAppDetector().detectFeature(packageName, rootNode)
+        val feature = entryPoint.inAppDetector().detectFeature(packageName, rootNode) ?: return
         val passthrough = entryPoint.passthroughManager()
 
-        if (feature != null) {
-            if (passthrough.shouldSkipFeatureEvaluation(packageName, feature.key)) {
-                return
-            }
+        if (passthrough.shouldSkipFeatureEvaluation(packageName, feature.key)) return
 
-            serviceScope.launch {
-                val globalEnabled = entryPoint.nudgePreferences().isGlobalEnabled.first()
-                if (!globalEnabled) return@launch
+        serviceScope.launch {
+            val globalEnabled = entryPoint.nudgePreferences().isGlobalEnabled.first()
+            if (!globalEnabled) return@launch
 
-                val decision = entryPoint.evaluateBlockUseCase().invoke(
-                    packageName = packageName,
-                    detectedFeature = feature.key,
-                    includeWholeAppRulesForFeature = !passthrough.shouldSkipForegroundEvaluation(packageName)
-                )
-                handleDecision(decision, packageName, feature.key)
-            }
+            val decision = entryPoint.evaluateBlockUseCase().invoke(
+                packageName = packageName,
+                detectedFeature = feature.key,
+                includeWholeAppRulesForFeature = !passthrough.shouldSkipForegroundEvaluation(packageName)
+            )
+            handleDecision(decision, packageName, feature.key)
         }
     }
 

--- a/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.key
 import androidx.lifecycle.Lifecycle
 import com.astraedus.nudge.data.db.entity.UsageEvent
 import com.astraedus.nudge.data.preferences.NudgePreferences
@@ -29,6 +30,14 @@ class BlockOverlayActivity : ComponentActivity() {
     @Inject lateinit var passthroughManager: PassthroughManager
     @Inject lateinit var nudgePreferences: NudgePreferences
     @Inject lateinit var emergencyPassManager: EmergencyPassManager
+
+    /**
+     * Incremented on every [render] so each delivered block composes under a fresh [key], discarding
+     * the previous block's remembered countdown state. A counter rather than the block's contents:
+     * two different apps can legitimately share a package-mode-delay triple, and re-delivering the
+     * *same* block is still a new attempt that must start from full.
+     */
+    private var renderToken = 0
 
     companion object {
         const val EXTRA_BLOCK_MODE = "block_mode"
@@ -131,8 +140,23 @@ class BlockOverlayActivity : ComponentActivity() {
             finish()
         }
 
+        // Issue #15: a block delivered while the overlay is already up arrives via onNewIntent, and
+        // setContent on an existing ComposeView REUSES the composition — same call positions, so
+        // every `remember` slot survives. The new block's appLabel and delaySeconds are parameters
+        // and update, but the countdown state does not, so the overlay showed the NEW app's name
+        // over the PREVIOUS app's remaining seconds. The progress ring froze too, because
+        // `remainingSeconds / delaySeconds` went off-scale (30 remaining over a 15s delay = 2.0).
+        //
+        // Keying the subtree on a per-delivery token discards all remembered state for a new block.
+        // Done once here rather than by keying individual `remember` calls: this covers all three
+        // overlays at once, and a per-`remember` key would have to be derived from the block's
+        // identity anyway — keying on delaySeconds alone is NOT enough, since two apps sharing the
+        // default 15s delay would still hand each other stale state.
+        val blockToken = ++renderToken
+
         setContent {
             NudgeTheme {
+                key(blockToken) {
                 when (mode) {
                     // Unreachable: the early return above already finished us. Present so the
                     // `when` stays exhaustive and a future mode cannot silently fall through.
@@ -188,6 +212,7 @@ class BlockOverlayActivity : ComponentActivity() {
                             onUseEmergencyPass = onUsePass
                         )
                     }
+                }
                 }
             }
         }

--- a/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/overlay/BlockOverlayActivity.kt
@@ -67,6 +67,16 @@ class BlockOverlayActivity : ComponentActivity() {
         } catch (_: IllegalArgumentException) {
             BlockMode.HARD_BLOCK
         }
+        // BlockMode.NONE blocks nothing, so BlockEngine never produces a Block carrying it and this
+        // activity should never be launched for one. If it somehow is, dismiss rather than render:
+        // there is no "no-op overlay", and showing any of the three below would gate an app the
+        // user explicitly chose not to gate.
+        if (mode == BlockMode.NONE) {
+            NudgeAccessibilityService.isOverlayActive = false
+            finish()
+            return
+        }
+
         val delaySeconds = intent.getIntExtra(EXTRA_DELAY_SECONDS, 15)
         val packageName = intent.getStringExtra(EXTRA_PACKAGE_NAME) ?: ""
         val ruleName = intent.getStringExtra(EXTRA_RULE_NAME)
@@ -124,6 +134,10 @@ class BlockOverlayActivity : ComponentActivity() {
         setContent {
             NudgeTheme {
                 when (mode) {
+                    // Unreachable: the early return above already finished us. Present so the
+                    // `when` stays exhaustive and a future mode cannot silently fall through.
+                    BlockMode.NONE -> Unit
+
                     BlockMode.HARD_BLOCK -> {
                         HardBlockContent(
                             packageName = packageName,

--- a/app/src/main/java/com/astraedus/nudge/ui/overlay/BreathingContent.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/overlay/BreathingContent.kt
@@ -52,6 +52,8 @@ fun BreathingContent(
     nextPassMs: Long = 0L,
     onUseEmergencyPass: () -> Unit = {}
 ) {
+    // Unkeyed by design: BlockOverlayActivity composes this subtree under a per-delivery key, so a
+    // re-delivered block already gets fresh state (issue #15).
     val subtitle = remember { subtitlePool.random() }
     val circleScale = remember { Animatable(0.6f) }
     var isInhaling by remember { mutableStateOf(true) }
@@ -65,6 +67,9 @@ fun BreathingContent(
     // it survives a pause, and accumulated per visible segment rather than measured from a single
     // start timestamp — otherwise time spent away from the overlay would still count down (#8).
     var elapsedMs by remember { mutableLongStateOf(0L) }
+    // Mirror dailyTimeRemainingMs as mutable state so the "X left today" line ticks down alongside
+    // the breathing progress instead of showing a frozen snapshot.
+    var shownDailyRemainingMs by remember { mutableStateOf(dailyTimeRemainingMs) }
 
     // repeatOnLifecycle cancels the block below RESUMED and starts a NEW one from the top on
     // re-entry. Once elapsedMs has covered totalMs, the first tick() of that new block would
@@ -82,9 +87,14 @@ fun BreathingContent(
             // bar, and report whether the exercise is finished.
             fun tick(): Boolean {
                 val now = System.currentTimeMillis()
+                val delta = (now - segmentStart).coerceAtLeast(0L)
                 elapsedMs = advanceBreathingElapsed(elapsedMs, segmentStart, now)
                 segmentStart = now
                 overallProgress = breathingProgress(elapsedMs, totalMs)
+                // Tick the daily-remaining display down by the same wall-clock delta.
+                shownDailyRemainingMs = shownDailyRemainingMs?.let {
+                    (it - delta).coerceAtLeast(0L)
+                }
                 return isBreathingComplete(elapsedMs, totalMs)
             }
 
@@ -137,11 +147,11 @@ fun BreathingContent(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                if (dailyTimeRemainingMs != null && dailyLimitMinutes != null && dailyLimitMinutes > 0) {
+                if (shownDailyRemainingMs != null && dailyLimitMinutes != null && dailyLimitMinutes > 0) {
                     Text(
-                        text = "${formatDuration(dailyTimeRemainingMs)} left today",
+                        text = "${formatDuration(shownDailyRemainingMs!!)} left today",
                         style = MaterialTheme.typography.bodyMedium,
-                        color = timeRemainingColor(dailyTimeRemainingMs, dailyLimitMinutes)
+                        color = timeRemainingColor(shownDailyRemainingMs!!, dailyLimitMinutes)
                     )
                 }
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/astraedus/nudge/ui/overlay/DelayContent.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/overlay/DelayContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -50,7 +51,13 @@ fun DelayContent(
 ) {
     val title = remember { titlePool.random() }
     val subtitle = remember { subtitlePool.random() }
+    // Unkeyed by design: BlockOverlayActivity composes this subtree under a per-delivery key, so a
+    // new block already gets fresh state (issue #15). Keying here on delaySeconds would look like a
+    // fix but miss the common case — two apps both on the default 15s delay would still share it.
     var remainingSeconds by remember { mutableIntStateOf(delaySeconds) }
+    // Mirror dailyTimeRemainingMs as mutable state so the "X left today" line ticks down each
+    // second alongside the delay countdown instead of showing a frozen snapshot.
+    var shownDailyRemainingMs by remember { mutableStateOf(dailyTimeRemainingMs) }
 
     val progress by animateFloatAsState(
         targetValue = if (delaySeconds > 0) remainingSeconds.toFloat() / delaySeconds.toFloat() else 0f,
@@ -75,6 +82,11 @@ fun DelayContent(
             while (remainingSeconds > 0) {
                 delay(1000L)
                 remainingSeconds--
+                // Tick the daily-remaining display down in sync with the countdown so the user
+                // sees live time instead of the frozen snapshot passed at launch.
+                shownDailyRemainingMs = shownDailyRemainingMs?.let {
+                    (it - 1000L).coerceAtLeast(0L)
+                }
             }
             if (completed.compareAndSet(false, true)) onComplete()
         }
@@ -98,12 +110,12 @@ fun DelayContent(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                if (dailyTimeRemainingMs != null && dailyLimitMinutes != null && dailyLimitMinutes > 0) {
-                    Text(
-                        text = "${formatDuration(dailyTimeRemainingMs)} left today",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = timeRemainingColor(dailyTimeRemainingMs, dailyLimitMinutes)
-                    )
+                if (shownDailyRemainingMs != null && dailyLimitMinutes != null && dailyLimitMinutes > 0) {
+                        Text(
+                            text = "${formatDuration(shownDailyRemainingMs!!)} left today",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = timeRemainingColor(shownDailyRemainingMs!!, dailyLimitMinutes)
+                        )
                 }
                 Spacer(modifier = Modifier.height(24.dp))
             }

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigScreen.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigScreen.kt
@@ -364,42 +364,62 @@ fun UnifiedAppConfigScreen(
                 InfoButton("These settings apply whenever no scheduled override is active.")
             }
 
-            // Block mode segmented button
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    BlockMode.entries.forEachIndexed { index, mode ->
-                        SegmentedButton(
-                            selected = state.defaultMode == mode,
-                            onClick = { viewModel.setDefaultMode(mode) },
-                            shape = SegmentedButtonDefaults.itemShape(
-                                index = index,
-                                count = BlockMode.entries.size
-                            )
-                        ) {
-                            Text(
-                                when (mode) {
-                                    BlockMode.HARD_BLOCK -> "Hard Block"
-                                    BlockMode.DELAY -> "Delay"
-                                    BlockMode.BREATHING -> "Breathing"
-                                }
-                            )
-                        }
-                    }
+            // Whether the app itself is gated at all. Off => the app-level rule is BlockMode.NONE,
+            // so the app opens freely and only the feature overrides below apply. This is the
+            // switch that makes "block only Shorts, leave YouTube alone" expressible.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Block the whole app", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        if (state.blocksWholeApp) {
+                            "Opening ${state.appName} triggers the block below."
+                        } else if (state.supportsFeatures) {
+                            "${state.appName} opens normally. Only the features you turn on below are blocked."
+                        } else {
+                            "${state.appName} opens normally. Any daily limit below still applies."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
-
-                Text(
-                    when (state.defaultMode) {
-                        BlockMode.HARD_BLOCK -> "Completely blocks the app. You can only go back to the home screen."
-                        BlockMode.DELAY -> "Shows a countdown timer before letting you in."
-                        BlockMode.BREATHING -> "Guides you through a breathing exercise before opening."
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                Switch(
+                    checked = state.blocksWholeApp,
+                    onCheckedChange = { viewModel.setBlocksWholeApp(it) }
                 )
             }
 
+            // Block mode segmented button — only meaningful when the app itself is blocked.
+            if (state.blocksWholeApp) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        BLOCKING_MODES.forEachIndexed { index, mode ->
+                            SegmentedButton(
+                                selected = state.defaultMode == mode,
+                                onClick = { viewModel.setDefaultMode(mode) },
+                                shape = SegmentedButtonDefaults.itemShape(
+                                    index = index,
+                                    count = BLOCKING_MODES.size
+                                )
+                            ) {
+                                Text(blockModeLabel(mode))
+                            }
+                        }
+                    }
+
+                    Text(
+                        blockModeDescription(state.defaultMode),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
             // Delay duration (if applicable)
-            if (state.defaultMode != BlockMode.HARD_BLOCK) {
+            if (state.blocksWholeApp && state.defaultMode != BlockMode.HARD_BLOCK) {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
                         "Delay Duration",
@@ -652,22 +672,16 @@ fun UnifiedAppConfigScreen(
 
                     // Scheduled mode
                     SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                        BlockMode.entries.forEachIndexed { index, mode ->
+                        BLOCKING_MODES.forEachIndexed { index, mode ->
                             SegmentedButton(
                                 selected = state.scheduledMode == mode,
                                 onClick = { viewModel.setScheduledMode(mode) },
                                 shape = SegmentedButtonDefaults.itemShape(
                                     index = index,
-                                    count = BlockMode.entries.size
+                                    count = BLOCKING_MODES.size
                                 )
                             ) {
-                                Text(
-                                    when (mode) {
-                                        BlockMode.HARD_BLOCK -> "Hard Block"
-                                        BlockMode.DELAY -> "Delay"
-                                        BlockMode.BREATHING -> "Breathing"
-                                    }
-                                )
+                                Text(blockModeLabel(mode))
                             }
                         }
                     }
@@ -917,4 +931,28 @@ private fun TimeSelector(
             label = { Text(String.format("%02d", minute)) }
         )
     }
+}
+
+/**
+ * The modes that actually gate an app, in ascending severity.
+ *
+ * Deliberately NOT `BlockMode.entries`: [BlockMode.NONE] must never appear in a mode picker.
+ * At app level it is expressed by the "Block the whole app" switch, and for a SCHEDULED override
+ * it would be an outright lie — a scheduled rule is additive, so a NONE scheduled rule adds
+ * nothing rather than carving out an unblocked window during those hours.
+ */
+private val BLOCKING_MODES = listOf(BlockMode.HARD_BLOCK, BlockMode.DELAY, BlockMode.BREATHING)
+
+private fun blockModeLabel(mode: BlockMode): String = when (mode) {
+    BlockMode.NONE -> "Off"
+    BlockMode.HARD_BLOCK -> "Hard Block"
+    BlockMode.DELAY -> "Delay"
+    BlockMode.BREATHING -> "Breathing"
+}
+
+private fun blockModeDescription(mode: BlockMode): String = when (mode) {
+    BlockMode.NONE -> "Not blocked."
+    BlockMode.HARD_BLOCK -> "Completely blocks the app. You can only go back to the home screen."
+    BlockMode.DELAY -> "Shows a countdown timer before letting you in."
+    BlockMode.BREATHING -> "Guides you through a breathing exercise before opening."
 }

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigState.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigState.kt
@@ -39,6 +39,12 @@ data class UnifiedAppConfigState(
 
     // Default behavior
     val defaultMode: BlockMode = BlockMode.DELAY,
+    /**
+     * Mode to restore when the user turns whole-app blocking back on after switching it off.
+     * Without this, toggling off and on again would silently discard a configured Hard Block or
+     * Breathing choice and substitute the DELAY default.
+     */
+    val lastBlockingMode: BlockMode = BlockMode.DELAY,
     val defaultDelaySeconds: Int = 15,
     val defaultAutoKickEnabled: Boolean = false,
     val defaultAutoKickByInteractions: Boolean = true,
@@ -70,6 +76,12 @@ data class UnifiedAppConfigState(
     val showDeleteConfirmation: Boolean = false
 ) {
     val supportsFeatures: Boolean get() = availableFeatures.isNotEmpty()
+
+    /**
+     * Whether the app itself is gated. False means the app-level rule is [BlockMode.NONE]: the app
+     * opens freely and only the feature overrides (Shorts, Reels, …) and the daily limit apply.
+     */
+    val blocksWholeApp: Boolean get() = defaultMode != BlockMode.NONE
 
     companion object {
         val FEATURES_BY_PACKAGE: Map<String, List<FeatureInfo>> = mapOf(

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigViewModel.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/config/UnifiedAppConfigViewModel.kt
@@ -136,6 +136,10 @@ class UnifiedAppConfigViewModel @Inject constructor(
                 webDomains = webDomainsValue,
                 // Default behavior
                 defaultMode = parseBlockMode(defaultAppRule?.mode),
+                // If the saved rule is NONE there is no prior blocking choice to restore, so
+                // offer DELAY when the user switches whole-app blocking back on.
+                lastBlockingMode = parseBlockMode(defaultAppRule?.mode)
+                    .takeIf { it != BlockMode.NONE } ?: BlockMode.DELAY,
                 defaultDelaySeconds = defaultAppRule?.delaySeconds ?: 15,
                 defaultAutoKickEnabled = defaultAppRule?.autoKickAfter != null || defaultAppRule?.autoKickAfterMinutes != null,
                 defaultAutoKickByInteractions = defaultAppRule == null || defaultAppRule.autoKickAfter != null,
@@ -167,9 +171,12 @@ class UnifiedAppConfigViewModel @Inject constructor(
     }
 
     private fun parseBlockMode(mode: String?): BlockMode = when (mode) {
+        "NONE" -> BlockMode.NONE
         "HARD_BLOCK" -> BlockMode.HARD_BLOCK
         "DELAY" -> BlockMode.DELAY
         "BREATHING" -> BlockMode.BREATHING
+        // Includes null (no existing rule): a brand-new rule defaults to DELAY, not NONE, so
+        // opening the editor for an unconfigured app still proposes actual protection.
         else -> BlockMode.DELAY
     }
 
@@ -399,7 +406,24 @@ class UnifiedAppConfigViewModel @Inject constructor(
     // ═══ Default behavior ═══
 
     fun setDefaultMode(mode: BlockMode) {
-        _uiState.value = _uiState.value.copy(defaultMode = mode)
+        _uiState.value = _uiState.value.copy(
+            defaultMode = mode,
+            // Remember the last real blocking choice so toggling whole-app blocking off and back
+            // on restores it instead of snapping to DELAY.
+            lastBlockingMode = if (mode == BlockMode.NONE) _uiState.value.lastBlockingMode else mode
+        )
+    }
+
+    /**
+     * Turn whole-app blocking on/off. Off writes [BlockMode.NONE] on the app-level rule, which
+     * keeps the daily limit, counter, overlays, grayscale and web domains intact while letting the
+     * app itself open — the combination needed to block only Shorts/Reels.
+     */
+    fun setBlocksWholeApp(blocks: Boolean) {
+        val current = _uiState.value
+        _uiState.value = current.copy(
+            defaultMode = if (blocks) current.lastBlockingMode else BlockMode.NONE
+        )
     }
 
     fun setDefaultDelaySeconds(seconds: Int) {

--- a/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorScreen.kt
+++ b/app/src/main/java/com/astraedus/nudge/ui/screens/rules/RuleEditorScreen.kt
@@ -196,18 +196,21 @@ fun RuleEditorScreen(
                     )
                 }
 
+                // BlockMode.NONE is excluded here: this editor has no "block the whole app" switch,
+                // so a NONE option would produce a rule that silently does nothing.
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    BlockMode.entries.forEachIndexed { index, mode ->
+                    EDITOR_BLOCKING_MODES.forEachIndexed { index, mode ->
                         SegmentedButton(
                             selected = state.blockMode == mode,
                             onClick = { viewModel.setBlockMode(mode) },
                             shape = SegmentedButtonDefaults.itemShape(
                                 index = index,
-                                count = BlockMode.entries.size
+                                count = EDITOR_BLOCKING_MODES.size
                             )
                         ) {
                             Text(
                                 when (mode) {
+                                    BlockMode.NONE -> "Off"
                                     BlockMode.HARD_BLOCK -> "Hard Block"
                                     BlockMode.DELAY -> "Delay"
                                     BlockMode.BREATHING -> "Breathing"
@@ -219,6 +222,7 @@ fun RuleEditorScreen(
 
                 Text(
                     when (state.blockMode) {
+                        BlockMode.NONE -> "Not blocked."
                         BlockMode.HARD_BLOCK -> "Completely blocks the app. You can only go back to the home screen."
                         BlockMode.DELAY -> "Shows a countdown timer before letting you in. Gives you time to reconsider."
                         BlockMode.BREATHING -> "Guides you through a breathing exercise before opening. Calms the impulse."
@@ -869,3 +873,10 @@ private fun TimeSelector(
         )
     }
 }
+
+/**
+ * Modes offered by this editor. Excludes [BlockMode.NONE], which is only meaningful alongside the
+ * "Block the whole app" switch in `UnifiedAppConfigScreen`.
+ */
+private val EDITOR_BLOCKING_MODES =
+    listOf(BlockMode.HARD_BLOCK, BlockMode.DELAY, BlockMode.BREATHING)

--- a/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineNoneModeTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/engine/BlockEngineNoneModeTest.kt
@@ -1,0 +1,152 @@
+package com.astraedus.nudge.domain.engine
+
+import com.astraedus.nudge.domain.model.ActiveRule
+import com.astraedus.nudge.domain.model.BlockDecision
+import com.astraedus.nudge.domain.model.BlockMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The "block only Shorts, leave YouTube alone" contract.
+ *
+ * Before [BlockMode.NONE] existed, the app config screen always wrote a *blocking* app-level rule
+ * and feature overrides could only differ from it — so a feature-scoped rule whose host app stayed
+ * open was not expressible at all, and users who wanted Shorts blocked got the whole of YouTube
+ * blocked instead.
+ *
+ * NONE makes the app-level rule a carrier for the daily limit / counter / overlays without gating
+ * the app. These tests pin both halves: it must block nothing on its own, and it must still honour
+ * a daily budget.
+ */
+class BlockEngineNoneModeTest {
+
+    private val engine = BlockEngine(ScheduleEvaluator())
+    private val pkg = "com.google.android.youtube"
+
+    private fun noneAppRule(dailyLimitMinutes: Int? = null) = ActiveRule(
+        mode = BlockMode.NONE,
+        delaySeconds = 15,
+        dailyLimitMinutes = dailyLimitMinutes,
+        enabled = true,
+        inAppFeatures = null,
+        grayscale = false,
+        ruleName = "No block"
+    )
+
+    private fun shortsRule(mode: BlockMode = BlockMode.DELAY) = ActiveRule(
+        mode = mode,
+        delaySeconds = 15,
+        dailyLimitMinutes = null,
+        enabled = true,
+        inAppFeatures = listOf("SHORTS"),
+        grayscale = false,
+        ruleName = "Shorts - Delay"
+    )
+
+    @Test
+    fun `opening the app itself is allowed when the app-level rule is NONE`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule(), shortsRule()),
+            dailyUsageMs = 0L,
+            detectedFeature = null
+        )
+
+        assertEquals(BlockDecision.Allow, decision)
+    }
+
+    @Test
+    fun `the feature still blocks while the host app stays open`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule(), shortsRule()),
+            dailyUsageMs = 0L,
+            detectedFeature = "SHORTS"
+        )
+
+        assertTrue(decision is BlockDecision.Block)
+        assertEquals(BlockMode.DELAY, (decision as BlockDecision.Block).mode)
+    }
+
+    /** A NONE rule on its own is inert — no feature rule, nothing to fall back to. */
+    @Test
+    fun `a lone NONE rule never blocks`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule()),
+            dailyUsageMs = 0L,
+            detectedFeature = null
+        )
+
+        assertEquals(BlockDecision.Allow, decision)
+    }
+
+    /** NONE must not be treated as a blocking mode just because a feature was detected. */
+    @Test
+    fun `a lone NONE rule never blocks even when a feature is detected`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule()),
+            dailyUsageMs = 0L,
+            detectedFeature = "SHORTS"
+        )
+
+        assertEquals(BlockDecision.Allow, decision)
+    }
+
+    /**
+     * "Don't gate this app, but stop me after 30 minutes." The time-budget check keys off
+     * dailyLimitMinutes rather than the mode, so a NONE rule still enforces its cap.
+     */
+    @Test
+    fun `a NONE rule still enforces its daily limit once exhausted`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule(dailyLimitMinutes = 30)),
+            dailyUsageMs = 31L * 60L * 1000L,
+            detectedFeature = null
+        )
+
+        assertTrue(decision is BlockDecision.Block)
+        assertEquals(BlockMode.HARD_BLOCK, (decision as BlockDecision.Block).mode)
+    }
+
+    @Test
+    fun `a NONE rule under its daily limit still allows`() {
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule(dailyLimitMinutes = 30)),
+            dailyUsageMs = 10L * 60L * 1000L,
+            detectedFeature = null
+        )
+
+        assertEquals(BlockDecision.Allow, decision)
+    }
+
+    /**
+     * A NONE app rule must not soften a genuine block coming from another rule on the same
+     * package — priority is unchanged, NONE simply never wins a branch.
+     */
+    @Test
+    fun `a NONE rule does not suppress a sibling hard block`() {
+        val hardBlock = ActiveRule(
+            mode = BlockMode.HARD_BLOCK,
+            delaySeconds = 15,
+            dailyLimitMinutes = null,
+            enabled = true,
+            inAppFeatures = null,
+            grayscale = false,
+            ruleName = "Hard Block"
+        )
+
+        val decision = engine.evaluate(
+            packageName = pkg,
+            activeRules = listOf(noneAppRule(), hardBlock),
+            dailyUsageMs = 0L,
+            detectedFeature = null
+        )
+
+        assertEquals(BlockMode.HARD_BLOCK, (decision as BlockDecision.Block).mode)
+    }
+}

--- a/app/src/test/java/com/astraedus/nudge/domain/lock/RuleWeakeningTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/lock/RuleWeakeningTest.kt
@@ -65,6 +65,30 @@ class RuleWeakeningTest {
         assertFalse(RuleWeakening.isWeakening(rule(mode = "BREATHING"), rule(mode = "DELAY")))
     }
 
+    // ── mode NONE (whole-app blocking switched off) ──
+    // Turning off the "Block the whole app" switch writes NONE, which drops ALL gating of the app.
+    // It is the largest weakening the config screen can produce and must never save unchallenged.
+
+    @Test
+    fun `mode BREATHING to NONE is weakening`() {
+        assertTrue(RuleWeakening.isWeakening(rule(mode = "BREATHING"), rule(mode = "NONE")))
+    }
+
+    @Test
+    fun `mode HARD_BLOCK to NONE is weakening`() {
+        assertTrue(RuleWeakening.isWeakening(rule(mode = "HARD_BLOCK"), rule(mode = "NONE")))
+    }
+
+    @Test
+    fun `mode NONE to DELAY is not weakening`() {
+        assertFalse(RuleWeakening.isWeakening(rule(mode = "NONE"), rule(mode = "DELAY")))
+    }
+
+    @Test
+    fun `mode NONE to NONE is not weakening`() {
+        assertFalse(RuleWeakening.isWeakening(rule(mode = "NONE"), rule(mode = "NONE")))
+    }
+
     // ── daily limit ──
 
     @Test

--- a/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockContentFilterTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockContentFilterTest.kt
@@ -43,7 +43,7 @@ class EvaluateBlockContentFilterTest {
 
         // No explicit per-rule web domain rules -> always falls through to filter.
         every { blockRuleRepository.getEnabledRules() } returns flowOf(emptyList())
-        every { usageRepository.getDailyUsage(any()) } returns flowOf(0L)
+        every { usageRepository.getDailyForegroundTimeMs(any()) } returns 0L
         // Default strict-keywords pref to false (opt-in). Individual tests override.
         every { preferences.contentFilterStrictKeywords } returns flowOf(false)
 

--- a/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockDailyLimitTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockDailyLimitTest.kt
@@ -1,0 +1,143 @@
+package com.astraedus.nudge.domain.usecase
+
+import com.astraedus.nudge.data.db.entity.BlockRule
+import com.astraedus.nudge.data.preferences.NudgePreferences
+import com.astraedus.nudge.data.repository.BlockRuleRepository
+import com.astraedus.nudge.data.repository.ContentFilter
+import com.astraedus.nudge.data.repository.UsageRepository
+import com.astraedus.nudge.domain.engine.BlockEngine
+import com.astraedus.nudge.domain.engine.RuleEvaluator
+import com.astraedus.nudge.domain.engine.ScheduleEvaluator
+import com.astraedus.nudge.domain.model.BlockDecision
+import com.astraedus.nudge.domain.model.BlockMode
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for issue #14 ("daily timer/display not working").
+ *
+ * The daily budget must be spent against real foreground time from `UsageStatsManager`
+ * ([UsageRepository.getDailyForegroundTimeMs]). It used to be read from the Room `usage_events`
+ * table, whose `durationMs` column is never written — so the number was always 0, the
+ * time-budget HARD_BLOCK could never fire, and the overlay's "X left today" was pinned at the
+ * full limit no matter how long the app had been used.
+ *
+ * These tests fail against that old wiring: with a 30-minute limit and 40 minutes on the clock,
+ * the old code saw 0ms of usage and returned [BlockDecision.Allow].
+ */
+class EvaluateBlockDailyLimitTest {
+
+    private val pkg = "com.instagram.android"
+
+    private lateinit var blockRuleRepository: BlockRuleRepository
+    private lateinit var usageRepository: UsageRepository
+    private lateinit var preferences: NudgePreferences
+    private lateinit var contentFilter: ContentFilter
+    private lateinit var useCase: EvaluateBlockUseCase
+
+    @Before
+    fun setUp() {
+        blockRuleRepository = mockk()
+        usageRepository = mockk()
+        preferences = mockk()
+        contentFilter = mockk()
+
+        every { blockRuleRepository.getAllGroups() } returns flowOf(emptyList())
+
+        useCase = EvaluateBlockUseCase(
+            blockRuleRepository = blockRuleRepository,
+            usageRepository = usageRepository,
+            blockEngine = BlockEngine(ScheduleEvaluator()),
+            ruleEvaluator = RuleEvaluator(),
+            preferences = preferences,
+            contentFilter = contentFilter
+        )
+    }
+
+    /** A DELAY rule carrying a 30 min/day budget. */
+    private fun delayRuleWithDailyLimit(limitMinutes: Int = 30) = BlockRule(
+        id = 1L,
+        packageName = pkg,
+        mode = BlockMode.DELAY.name,
+        delaySeconds = 15,
+        dailyLimitMinutes = limitMinutes,
+        enabled = true
+    )
+
+    private fun withUsageMinutes(rule: BlockRule, minutes: Long) {
+        every { blockRuleRepository.getEnabledRules() } returns flowOf(listOf(rule))
+        every { usageRepository.getDailyForegroundTimeMs(pkg) } returns minutes * 60_000L
+    }
+
+    @Test
+    fun `budget exhausted hard-blocks instead of delaying`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 40)
+
+        val decision = useCase.invoke(pkg)
+
+        assertTrue("expected a block once the daily budget is spent", decision is BlockDecision.Block)
+        assertEquals(BlockMode.HARD_BLOCK, (decision as BlockDecision.Block).mode)
+    }
+
+    @Test
+    fun `budget exactly reached hard-blocks`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 30)
+
+        val decision = useCase.invoke(pkg)
+
+        assertEquals(BlockMode.HARD_BLOCK, (decision as BlockDecision.Block).mode)
+    }
+
+    @Test
+    fun `budget not yet spent still applies the rule's own mode`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 10)
+
+        val decision = useCase.invoke(pkg)
+
+        assertEquals(BlockMode.DELAY, (decision as BlockDecision.Block).mode)
+    }
+
+    /**
+     * The overlay's "X left today" line reads this field. Under the old wiring it was always the
+     * full limit; it must now shrink as the app is used.
+     */
+    @Test
+    fun `remaining time reflects real foreground usage`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 10)
+
+        val block = useCase.invoke(pkg) as BlockDecision.Block
+
+        assertEquals(30, block.dailyLimitMinutes)
+        assertEquals(20 * 60_000L, block.dailyTimeRemainingMs)
+    }
+
+    /** Never report negative time left once the user has overshot the budget. */
+    @Test
+    fun `remaining time floors at zero when overshooting the budget`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 45)
+
+        val block = useCase.invoke(pkg) as BlockDecision.Block
+
+        assertEquals(0L, block.dailyTimeRemainingMs)
+    }
+
+    /**
+     * Usage Access is a separate grant from the accessibility service. When it is missing the
+     * platform read returns 0, and the app must fall back to the rule's normal mode rather than
+     * manufacture a block out of a permission the user never gave.
+     */
+    @Test
+    fun `missing usage access does not manufacture a block`() = runTest {
+        withUsageMinutes(delayRuleWithDailyLimit(30), minutes = 0)
+
+        val decision = useCase.invoke(pkg)
+
+        assertEquals(BlockMode.DELAY, (decision as BlockDecision.Block).mode)
+    }
+}

--- a/app/src/test/java/com/astraedus/nudge/service/InAppDetectorClipsViewerTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/service/InAppDetectorClipsViewerTest.kt
@@ -1,0 +1,114 @@
+package com.astraedus.nudge.service
+
+import android.view.accessibility.AccessibilityNodeInfo
+import com.astraedus.nudge.util.NudgeLogger
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression tests for the DM-opened reel bypass (device-found 2026-08-08).
+ *
+ * Instagram's full-screen reel player is hosted in `com.instagram.modal.ModalActivity`, which has
+ * NO bottom navigation. Detection keyed exclusively on which bottom-nav tab was `selected`, so the
+ * player was structurally invisible: opening a reel from a DM produced no detected feature, and a
+ * user with a HARD_BLOCK rule on REELS could scroll reels indefinitely. Reels opened from the Reels
+ * TAB blocked correctly, which is why the gap went unnoticed.
+ *
+ * An instrumented capture on a Galaxy S24 recorded ~800 detection attempts on these screens, every
+ * one returning null. The fix keys on the player's own containers instead of the nav bar.
+ */
+class InAppDetectorClipsViewerTest {
+
+    private val detector = InAppDetector(mockk<NudgeLogger>(relaxed = true))
+
+    private val ig = "com.instagram.android"
+
+    /**
+     * A root whose [AccessibilityNodeInfo.findAccessibilityNodeInfosByViewId] resolves exactly the
+     * ids in [presentIds] and nothing else. childCount is 0 so the debug harvest terminates.
+     */
+    private fun rootWith(presentIds: Set<String>): AccessibilityNodeInfo {
+        val root = mockk<AccessibilityNodeInfo>(relaxed = true)
+        every { root.childCount } returns 0
+        every { root.viewIdResourceName } returns null
+        every { root.findAccessibilityNodeInfosByViewId(any()) } answers {
+            val id = firstArg<String>()
+            if (id in presentIds) listOf(mockk<AccessibilityNodeInfo>(relaxed = true)) else emptyList()
+        }
+        return root
+    }
+
+    /** The exact surface captured from a reel opened out of a DM thread. */
+    @Test
+    fun `reel opened from a DM is detected as REELS`() {
+        val root = rootWith(
+            setOf(
+                "com.instagram.android:id/clips_viewer_view_pager",
+                "com.instagram.android:id/clips_video_container",
+                "com.instagram.android:id/clips_media_component"
+            )
+        )
+
+        assertEquals(InAppDetector.Feature.REELS, detector.detectFeature(ig, root))
+    }
+
+    /**
+     * The player's tree varies by entry point — the DM variant carries a reply bar, others do not.
+     * Any single container is sufficient, so a partial match must still detect.
+     */
+    @Test
+    fun `any single clips container is enough`() {
+        listOf(
+            "com.instagram.android:id/clips_viewer_view_pager",
+            "com.instagram.android:id/clips_video_container",
+            "com.instagram.android:id/clips_media_component"
+        ).forEach { id ->
+            assertEquals(
+                "expected REELS from $id alone",
+                InAppDetector.Feature.REELS,
+                detector.detectFeature(ig, rootWith(setOf(id)))
+            )
+        }
+    }
+
+    /**
+     * The player check must not fire on ordinary browsing. A DM thread shows reel previews but
+     * carries none of the player containers — blocking here would make Instagram unusable for
+     * messaging, which is not what a REELS rule asks for.
+     */
+    @Test
+    fun `a DM thread is not detected as REELS`() {
+        val root = rootWith(
+            setOf(
+                "com.instagram.android:id/thread_fragment_container",
+                "com.instagram.android:id/message_list",
+                "com.instagram.android:id/message_composer_bar"
+            )
+        )
+
+        assertNull(detector.detectFeature(ig, root))
+    }
+
+    /** The player check must not hijack a surface with no clips containers and no active tab. */
+    @Test
+    fun `an unknown surface still returns null`() {
+        assertNull(detector.detectFeature(ig, rootWith(emptySet())))
+    }
+
+    /** A null root must never throw — detection is best-effort by contract. */
+    @Test
+    fun `null root returns null`() {
+        assertNull(detector.detectFeature(ig, null))
+    }
+
+    /** The player containers are Instagram-specific and must not leak into YouTube detection. */
+    @Test
+    fun `clips containers do not trigger for YouTube`() {
+        val root = rootWith(setOf("com.instagram.android:id/clips_viewer_view_pager"))
+
+        assertNull(detector.detectFeature("com.google.android.youtube", root))
+    }
+}


### PR DESCRIPTION
Six commits from a day of device QA on a Galaxy S24 / Android 16. Every change is unit-tested and device-verified; 595 tests pass.

Happy to split this into separate PRs, drop anything, or adjust naming — say the word.

## `fix(#14)`: the daily budget was spent against a column nothing writes

`EvaluateBlockUseCase` fed `BlockEngine` a `dailyUsageMs` from `getDailyUsage()`, which is `SUM(durationMs)` over `usage_events`. That table logs block/allow *decisions* and nothing ever writes `durationMs` — `ScreenTimeProvider` already says so in a comment. So the value is 0 for every package, forever:

- `dailyUsageMs >= limit` is permanently false, so the daily-limit HARD_BLOCK never fired
- `dailyTimeRemainingMs` was always the full limit, so "X left today" never moved

The subtle part: `TimeRemainingHandler` reads the correct source and enforces the limit itself, so daily limits appeared to work — but **only for rules that had opted into the time-remaining overlay**. For everyone else the feature was silently dead.

Routed through `getDailyForegroundTimeMs` and deleted `getDailyUsage` so the trap can't return. Verified by reverting the fix: 4 of the 6 new tests fail.

## `feat`: `BlockMode.NONE` — "block only Shorts/Reels" was not configurable

Reported by a user who configured YouTube and Instagram expecting Shorts/Reels-only blocking and got both apps blocked entirely. Not a misconfiguration — the app couldn't express it.

`performSave` always writes the app-level rule (it carries `dailyLimitMinutes`, `showCounter`, `showTimeRemaining`, `grayscale`, `webDomains`), and `FeatureMode.INHERIT` means "follow the app default", never "leave the app alone".

`NONE` keeps that rule as a settings carrier while contributing no block. **`BlockEngine` needed no logic change**; `mode` is a String column so **no migration**. A daily limit on a NONE rule is still enforced. Strict Mode gates switching to it.

UI is a "Block the whole app" switch rather than a fourth mode segment — "Don't block" beside "Hard Block" is the same ambiguity that caused the original report.

## `fix`: Instagram's reel player, not just the bottom-nav tab

A reel opened from a **DM** could be scrolled indefinitely with HARD_BLOCK on REELS. Reels from the Reels *tab* blocked fine, which hid it.

The player runs in `com.instagram.modal.ModalActivity` — **no bottom navigation** — and `detectInstagram` resolved the feature purely from which tab was `selected`. The player was undetectable in principle.

Now checks the player's own containers first, covering every entry route. IDs harvested from a real device and verified absent from the home feed and DM threads.

Worth flagging: **tab detection appears dead on current Instagram** — no tab reported `selected=true` in any capture (~800 detection attempts, all null). The player check is currently carrying Instagram detection alone.

Includes a debug-only view-id harvest, because the usual tools can't see these screens: `uiautomator dump` waits for an idle window and a playing reel never idles (hangs, then Killed); `dumpsys activity top` times out. Logs each distinct unrecognised surface once, one tree walk per 5s, and reads only `viewIdResourceName` — never text or contentDescription, which here would be private messages.

## `fix(#15)`: each delivered block gets its own composition

> "it played a timer titled 'Goguma' displayed a 30s timer (time for Discord...) the timer counted down, yet the circle did not move."

`BlockOverlayActivity` is `singleInstance`, so a second block arrives via `onNewIntent` → `setContent` — which **reuses the composition**, so every `remember` slot survives. `appLabel` and `delaySeconds` are parameters and update; the countdown state doesn't. Hence the new app's name over the old app's seconds, and a frozen ring (`30/15 = 2.0`, off-scale).

Keyed on a per-delivery token. Keying on `delaySeconds` is *not* enough — two apps both on the default 15s would still share state.

Not unit-testable (Compose composition identity across `onNewIntent`); device-verified instead.

## `feat`: order Manage Apps by rule status

The list showed every installed app unsorted, so configured apps were scattered through hundreds of untouched ones. Now: active rules, then apps whose rule is off, then the rest — alphabetical within each.

---

**Also found but not fixed here** (happy to file as issues): PiP defeats feature blocking — YouTube enters Picture-in-Picture when the overlay backgrounds it and the Short keeps playing. Root cause is platform behaviour (pinned tasks are always-on-top; the overlay is correctly fullscreen and `topResumedActivity` and still loses). The app-op fix is device-verified: turning off Picture-in-picture for YouTube removes the bypass. Nudge can't set that app-op itself, so the honest shape is detect-and-deep-link to `android.settings.PICTURE_IN_PICTURE_SETTINGS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)