### PR TITLE
fix(service): report when blocking is down, opt out of Auto Backup, gate the auto-kick cooldown on a live rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Nudge are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.15.4] - 2026-09-07
+
+### Fixed
+- **Nudge now tells you when it has stopped blocking.** Android can stop the accessibility service on its own, after a nightly backup or when it needs memory, and when it does, Nudge quietly enforces nothing until the system rebinds it. Android's own Settings screen said so ("Enabled, but your phone stopped it") while Nudge's notification carried on reading "Nudge is active". That notification now says what is actually true, and if blocking is down you get a notification that takes you straight to the toggle that restarts it.
+- **Nudge is no longer backed up to Google Drive.** Nudge has never asked for internet access and its data has always been meant to stay on your phone, but Android's automatic backup was uploading the database anyway, on a schedule nobody chose. Running that backup also force-killed the app every night, which is what stopped the blocking in the first place. Both are gone. To move your rules to a new phone, use Settings, Export rules, and import the file on the other side.
+- **An auto-kick cooldown can no longer outlive the rule that created it.** Deleting a rule, or turning its auto-kick off, while the cooldown timer was still running left the cooldown behind: Nudge would keep sending you out of an app that nothing was set to block, for as long as the timer had left, and none of it appeared in your stats. Cooldowns are now dropped as soon as no rule wants them, on websites as well as apps.
+- **The background service now follows the on/off switch.** It only ever started after a reboot, so a fresh install had nothing running until you next restarted your phone, and once running it never stopped, so its "Nudge is active" notification stayed up after you switched Nudge off.
+
 ## [1.15.3] - 2026-09-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,10 +129,10 @@ AccessibilityService: TYPE_WINDOW_STATE_CHANGED
 - Domain layer is pure Kotlin — no `android.*` imports. Fully unit-testable on JVM.
 - Single Activity architecture (MainActivity) + Compose Navigation.
 - BlockOverlayActivity is a separate activity with `singleInstance` launch mode, `excludeFromRecents`, empty `taskAffinity`.
-- AccessibilityService handles foreground app detection. ForegroundService keeps monitoring alive.
+- AccessibilityService handles foreground app detection AND every enforcement decision. `NudgeMonitorService` is a foreground service that holds the ongoing notification, keeps the process alive, and polls `ServiceHealth` so the user is told when Android has stopped the accessibility service. It reads no rules, evaluates nothing, and must NEVER start an Activity — pinned by `MonitorServiceContractTest`, because "a service put its UI over another app" is a bug report this repo has already received once.
 - All entities use Room `@Entity` annotations. DAOs return `Flow<>` for reactive queries.
 - ViewModels use `@HiltViewModel` and inject use cases/repositories.
-- No internet permission. No analytics. No telemetry.
+- No internet permission. No analytics. No telemetry. `allowBackup="false"` + `res/xml/data_extraction_rules.xml` / `backup_rules.xml` excluding every domain on both transports: Auto Backup would otherwise upload the database to Google Drive, and running a backup force-kills the process. Export/import is the only backup path.
 
 ## Block modes
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "dev.astraedus.nudge"
         minSdk = 26
         targetSdk = 36
-        versionCode = 46
-        versionName = "1.15.3"
+        versionCode = 47
+        versionName = "1.15.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,9 +25,32 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
 
+        <!-- Backup is OFF, deliberately, for two independent reasons.
+
+             1. PRIVACY. Nudge holds no INTERNET permission and its listing promises "all data
+                local". Android Auto Backup ignores both: with allowBackup="true" the framework
+                uploads the Room database (every rule, every app the user blocks, their whole usage
+                history) to Google Drive on the user's behalf. An app that advertises local-only
+                data must not have a cloud copy it never mentions.
+
+             2. RELIABILITY. Running a full backup force-kills the app's process. On 2026-09-07 the
+                Pixel's 01:59 `full_backup_package dev.astraedus.nudge` killed Nudge (am_proc_died
+                reason 100); the OS rescheduled both services and Settings reported "Enabled, but
+                your phone stopped it, turn it off and back on to restart blocking". A blocker that
+                is killed nightly by a backup it does not want is a blocker that stops blocking
+                nightly.
+
+             The backup path users actually have is Settings -> Export rules / Import rules
+             (docs/architecture/export-import.md), which is explicit, inspectable, carries usage
+             history, and does not leave the device unless the user sends it somewhere.
+
+             dataExtractionRules covers API 31+, where allowBackup alone no longer governs
+             device-to-device transfer; fullBackupContent covers API 26-30. -->
     <application
         android:name=".NudgeApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/java/com/astraedus/nudge/MainActivity.kt
+++ b/app/src/main/java/com/astraedus/nudge/MainActivity.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.lifecycle.lifecycleScope
 import com.astraedus.nudge.data.preferences.NudgePreferences
+import com.astraedus.nudge.service.NudgeMonitorService
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import com.astraedus.nudge.ui.theme.NudgeTheme
 import com.astraedus.nudge.ui.navigation.NudgeNavGraph
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,6 +22,16 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // The monitor service used to have exactly one starter, BootReceiver, so a fresh install
+        // ran no foreground service, and therefore had nothing that could notice the accessibility
+        // service had been stopped, until the phone was next rebooted. Opening the app is the
+        // other moment we reliably get, so it syncs too.
+        lifecycleScope.launch {
+            NudgeMonitorService.sync(
+                applicationContext,
+                nudgePreferences.isGlobalEnabled.first()
+            )
+        }
         enableEdgeToEdge()
         setContent {
             NudgeTheme {

--- a/app/src/main/java/com/astraedus/nudge/domain/block/CooldownGate.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/block/CooldownGate.kt
@@ -1,0 +1,41 @@
+package com.astraedus.nudge.domain.block
+
+/**
+ * Whether an auto-kick cooldown may still block a package.
+ *
+ * ## Why this is a gate and not an `if`
+ * `evaluateForegroundPackage` launches the block overlay for a package in cooldown **before** it
+ * looks up a single rule, and that branch writes no `UsageEvent` — so it is the one enforcement
+ * path in the app that can put Nudge's UI in front of an app the user has no rule for, and leave no
+ * trace in the stats that it did. The cooldown is armed by [AutoKickExecutor] and lives in
+ * `InteractionTracker`'s in-memory map; the rule that justified it lives in the database. Delete the
+ * rule (or turn its auto-kick off) while a cooldown is armed and the two disagree: the map keeps
+ * ejecting the user from an app nothing is configured to block, for the whole cooldown, with the
+ * overlay naming a rule that no longer exists.
+ *
+ * The repo has been here before. Every other enforcement decision is a function of a rule that
+ * currently matches the foreground package; this one was a function of state left behind by a rule
+ * that used to. The gate makes the cooldown's authority *derived* rather than *remembered*: no cache
+ * entry for the package means no rule wants anything from it, so there is nothing to enforce.
+ *
+ * Pure, so the rule can be a unit test instead of a device session.
+ */
+object CooldownGate {
+
+    /**
+     * @param hasRuleEntry whether the counter cache currently holds an entry for this package, i.e.
+     *   some enabled rule still wants foreground awareness of it. This is the authority.
+     * @param isInCooldown whether an auto-kick cooldown timer is still running for the package.
+     * @return true only when both agree. A cooldown without a rule behind it is stale state, and
+     *   the caller must clear it rather than act on it.
+     */
+    fun shouldEnforce(hasRuleEntry: Boolean, isInCooldown: Boolean): Boolean =
+        hasRuleEntry && isInCooldown
+
+    /**
+     * True when a cooldown is armed for a package no rule covers any more — the caller should drop
+     * it so the map cannot accumulate enforcement authority for deleted rules.
+     */
+    fun isStale(hasRuleEntry: Boolean, isInCooldown: Boolean): Boolean =
+        !hasRuleEntry && isInCooldown
+}

--- a/app/src/main/java/com/astraedus/nudge/domain/health/ServiceHealth.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/health/ServiceHealth.kt
@@ -1,0 +1,63 @@
+package com.astraedus.nudge.domain.health
+
+/**
+ * What Nudge should be *saying about itself* right now.
+ *
+ * ## Why this exists
+ * On 2026-09-07 the Pixel's nightly `full_backup_package dev.astraedus.nudge` killed the process
+ * (`am_proc_died` reason 100) and Android's own Settings screen said, correctly:
+ *
+ * > "Accessibility Service: Enabled, but your phone stopped it, turn it off and back on to restart
+ * > blocking"
+ *
+ * Nudge said nothing. Worse, its permanent foreground notification carried the hardcoded text
+ * "Nudge is active / Monitoring app usage" throughout — a blocker that had stopped blocking was
+ * still telling the user it was blocking. Every enforcement path in this app hangs off the
+ * accessibility service being *bound*, and "enabled in Settings" is not the same question.
+ *
+ * Three states, three different sentences, one function that maps between them. It is pure so the
+ * whole truth table is a unit test rather than a device session — and so no caller can invent a
+ * fourth state in a `when` branch's `else`.
+ */
+enum class ServiceHealth {
+    /** Master toggle off. A disabled Nudge must behave as if uninstalled — including saying nothing. */
+    DISABLED,
+
+    /** The user never granted (or has revoked) the accessibility permission. Nothing is enforced. */
+    PERMISSION_MISSING,
+
+    /**
+     * Granted in Settings, but our service is not connected: the OS killed the process (backup,
+     * memory pressure, "force stop") and the rebind has not landed. **Blocking is down and the user
+     * cannot tell from inside the app.** This is the state the whole file exists for.
+     */
+    STOPPED_BY_SYSTEM,
+
+    /** Granted, bound, enforcing. */
+    ACTIVE;
+
+    /** True when Nudge is not currently enforcing anything despite the user having asked it to. */
+    val isDegraded: Boolean
+        get() = this == PERMISSION_MISSING || this == STOPPED_BY_SYSTEM
+
+    companion object {
+        /**
+         * @param globalEnabled the master toggle (`NudgePreferences.isGlobalEnabled`).
+         * @param permissionGranted whether our service is listed in
+         *   `Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES`. This is what the *user* controls.
+         * @param serviceConnected whether our `AccessibilityService` instance is live in this
+         *   process right now (`onServiceConnected` ran, `onDestroy` has not). This is what the
+         *   *system* controls, and the two disagree for minutes at a time after a process kill.
+         */
+        fun evaluate(
+            globalEnabled: Boolean,
+            permissionGranted: Boolean,
+            serviceConnected: Boolean
+        ): ServiceHealth = when {
+            !globalEnabled -> DISABLED
+            !permissionGranted -> PERMISSION_MISSING
+            !serviceConnected -> STOPPED_BY_SYSTEM
+            else -> ACTIVE
+        }
+    }
+}

--- a/app/src/main/java/com/astraedus/nudge/domain/health/ServiceHealthCopy.kt
+++ b/app/src/main/java/com/astraedus/nudge/domain/health/ServiceHealthCopy.kt
@@ -1,0 +1,37 @@
+package com.astraedus.nudge.domain.health
+
+/**
+ * The one place a [ServiceHealth] becomes words the user reads.
+ *
+ * Separate from the notification code because the defect this subsystem exists to fix was a
+ * *sentence* ("Nudge is active" while Nudge was not active), not a mechanism, and a sentence that
+ * lives inside an Android class is a sentence no JVM test can read. Every state is spelled out here
+ * with no `else` branch, so adding a state to [ServiceHealth] fails to compile rather than falling
+ * into a default that says the reassuring thing.
+ */
+data class ServiceHealthCopy(val title: String, val body: String)
+
+/**
+ * Copy for the ongoing foreground-service notification.
+ *
+ * [ServiceHealth.DISABLED] has copy even though the service stops itself in that state: the value
+ * has to exist for the exhaustiveness test to mean anything, and a stop is not instantaneous.
+ */
+fun ServiceHealth.notificationCopy(): ServiceHealthCopy = when (this) {
+    ServiceHealth.DISABLED -> ServiceHealthCopy(
+        title = "Nudge is off",
+        body = "Blocking is turned off"
+    )
+    ServiceHealth.PERMISSION_MISSING -> ServiceHealthCopy(
+        title = "Nudge is not blocking",
+        body = "Accessibility access is off. Tap to turn it on."
+    )
+    ServiceHealth.STOPPED_BY_SYSTEM -> ServiceHealthCopy(
+        title = "Nudge is not blocking",
+        body = "Your phone stopped Nudge. Tap to turn accessibility off and on again."
+    )
+    ServiceHealth.ACTIVE -> ServiceHealthCopy(
+        title = "Nudge is active",
+        body = "Blocking is on"
+    )
+}

--- a/app/src/main/java/com/astraedus/nudge/service/AccessibilityStatusProvider.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/AccessibilityStatusProvider.kt
@@ -1,0 +1,54 @@
+package com.astraedus.nudge.service
+
+import android.content.ComponentName
+import android.content.Context
+import android.provider.Settings
+import android.text.TextUtils
+
+/**
+ * The two independent facts that decide whether Nudge is actually enforcing anything.
+ *
+ * Split behind an interface so [NudgeMonitorService]'s health poll is testable without a device,
+ * and so the distinction stays legible: [isPermissionGranted] is what the USER controls (the
+ * Settings toggle), [isServiceConnected] is what the SYSTEM controls (the bind). They disagree for
+ * minutes after a process kill, and that disagreement is exactly the failure this reports.
+ */
+interface AccessibilityStatusProvider {
+    /** Our service is listed in `Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES`. */
+    fun isPermissionGranted(): Boolean
+
+    /** Our `AccessibilityService` is bound and live in this process right now. */
+    fun isServiceConnected(): Boolean
+}
+
+class AndroidAccessibilityStatusProvider(
+    private val context: Context
+) : AccessibilityStatusProvider {
+
+    /**
+     * Read the raw setting rather than `AccessibilityManager.getEnabledAccessibilityServiceList`:
+     * that list reflects *bound* services on some builds, which would collapse the two questions
+     * into one and hide the exact state we are trying to detect.
+     *
+     * Fails CLOSED on an unreadable setting — reporting "permission missing" nags a working install
+     * at worst, while reporting "granted" would let a genuinely un-granted install look healthy.
+     */
+    override fun isPermissionGranted(): Boolean {
+        val expected = ComponentName(context, NudgeAccessibilityService::class.java)
+        val raw = try {
+            Settings.Secure.getString(
+                context.contentResolver,
+                Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+            )
+        } catch (_: Exception) {
+            null
+        } ?: return false
+
+        val splitter = TextUtils.SimpleStringSplitter(':').apply { setString(raw) }
+        return splitter.any { entry ->
+            ComponentName.unflattenFromString(entry)?.equals(expected) == true
+        }
+    }
+
+    override fun isServiceConnected(): Boolean = NudgeAccessibilityService.isConnected()
+}

--- a/app/src/main/java/com/astraedus/nudge/service/BootReceiver.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/BootReceiver.kt
@@ -34,8 +34,9 @@ class BootReceiver : BroadcastReceiver() {
             entryPoint.nudgePreferences().isGlobalEnabled.first()
         }
 
-        if (globalEnabled) {
-            NudgeMonitorService.start(context)
-        }
+        // sync(), not start(): the service's existence tracks the master toggle everywhere it can
+        // change, so a reboot with Nudge switched off does not resurrect a "Nudge is active"
+        // notification for an app that is enforcing nothing.
+        NudgeMonitorService.sync(context, globalEnabled)
     }
 }

--- a/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/NudgeAccessibilityService.kt
@@ -15,6 +15,7 @@ import com.astraedus.nudge.data.preferences.NudgePreferences
 import com.astraedus.nudge.data.repository.BlockRuleRepository
 import com.astraedus.nudge.data.repository.UsageRepository
 import com.astraedus.nudge.domain.WebDomainMatcher
+import com.astraedus.nudge.domain.block.CooldownGate
 import com.astraedus.nudge.domain.lock.StrictModeEscapeGuard
 import com.astraedus.nudge.domain.model.BlockDecision
 import com.astraedus.nudge.domain.model.BlockMode
@@ -377,6 +378,17 @@ class NudgeAccessibilityService : AccessibilityService() {
          */
         @Volatile
         private var instance: NudgeAccessibilityService? = null
+
+        /**
+         * Is the accessibility service bound and enforcing *right now*?
+         *
+         * Deliberately a different question from "is Nudge listed in
+         * `Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES`". After an OS process kill (the nightly
+         * `full_backup_package`, memory pressure, a force stop) the setting still says yes and this
+         * says no, for as long as it takes the system to rebind. Every block Nudge enforces hangs
+         * off this being true, so [NudgeMonitorService] polls it and tells the user when it is not.
+         */
+        fun isConnected(): Boolean = instance != null
 
         /**
          * Send the user to the home screen. Uses [AccessibilityService.GLOBAL_ACTION_HOME] when the
@@ -819,6 +831,10 @@ class NudgeAccessibilityService : AccessibilityService() {
                 val wasEnabled = globalEnabledCached
                 globalEnabledCached = enabled
                 if (wasEnabled && !enabled) onGlobalDisabled()
+                // The monitor service's existence must track the master toggle, not track whether
+                // the phone has rebooted since install. It is also what tells the user when the OS
+                // has stopped THIS service, so it has to be running whenever Nudge is on.
+                NudgeMonitorService.sync(applicationContext, enabled)
             }
         }
 
@@ -1094,7 +1110,19 @@ class NudgeAccessibilityService : AccessibilityService() {
         }
 
         val tracker = entryPoint.interactionTracker()
-        if (tracker.isInCooldown(packageName)) {
+        // The ONE enforcement path in this service that runs before any rule is looked up, and the
+        // only one that writes no UsageEvent. Its authority must be derived from a rule that still
+        // exists, never remembered from one that used to: delete a rule (or turn its auto-kick off)
+        // with a cooldown armed and the in-memory map would keep ejecting the user from an app
+        // nothing is configured to block, invisibly, for the whole cooldown. See [CooldownGate].
+        val hasRuleEntry = counterCache.hasEntry(packageName)
+        if (CooldownGate.isStale(hasRuleEntry, tracker.isInCooldown(packageName))) {
+            entryPoint.nudgeLogger().i(
+                "stale auto-kick cooldown dropped package=$packageName reason=no_rule_entry"
+            )
+            tracker.clearCooldown(packageName)
+        }
+        if (CooldownGate.shouldEnforce(hasRuleEntry, tracker.isInCooldown(packageName))) {
             val remainingMs = tracker.getCooldownRemainingMs(packageName)
             val remainingSeconds = ((remainingMs + 999) / 1000).toInt().coerceAtLeast(1)
             entryPoint.nudgeLogger().i(
@@ -1277,7 +1305,16 @@ class NudgeAccessibilityService : AccessibilityService() {
     private fun enforceWebCooldown(browserPackage: String, domain: String?): Boolean {
         val key = domain?.let { WebSessionKey.forDomain(it) } ?: return false
         val tracker = entryPoint.interactionTracker()
-        if (!tracker.isInCooldown(key)) return false
+        // Same gate as the app-level cooldown, for the same reason: a cooldown keyed on a domain no
+        // rule enforces on any more is stale state, and acting on it blocks a site nothing blocks.
+        val hasRuleEntry = counterCache.getEntry(key) != null
+        if (CooldownGate.isStale(hasRuleEntry, tracker.isInCooldown(key))) {
+            entryPoint.nudgeLogger().i(
+                "stale web auto-kick cooldown dropped domain=$domain reason=no_rule_entry"
+            )
+            tracker.clearCooldown(key)
+        }
+        if (!CooldownGate.shouldEnforce(hasRuleEntry, tracker.isInCooldown(key))) return false
 
         val remainingMs = tracker.getCooldownRemainingMs(key)
         val remainingSeconds = ((remainingMs + 999) / 1000).toInt().coerceAtLeast(1)

--- a/app/src/main/java/com/astraedus/nudge/service/NudgeMonitorService.kt
+++ b/app/src/main/java/com/astraedus/nudge/service/NudgeMonitorService.kt
@@ -9,15 +9,72 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.astraedus.nudge.MainActivity
+import com.astraedus.nudge.data.preferences.NudgePreferences
+import com.astraedus.nudge.domain.health.ServiceHealth
+import com.astraedus.nudge.domain.health.notificationCopy
+import com.astraedus.nudge.util.NudgeLogger
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
+/**
+ * The foreground service that keeps Nudge's process alive — and, since 2026-09-07, the only thing
+ * in the app that can notice Nudge has stopped working and say so.
+ *
+ * ## What this service is NOT
+ * It does not poll foreground apps, read rules, or make block decisions. Every enforcement decision
+ * in Nudge is made by [NudgeAccessibilityService] from an accessibility event and gated on a rule
+ * that matches the foreground package. **Nothing here may ever start an Activity.** The only
+ * `MainActivity` reference in this file is a `PendingIntent` — a destination for a tap the user
+ * makes, not a launch this service performs. `MonitorServiceContractTest` pins that distinction,
+ * because a service that can put its own UI over another app is indistinguishable from a bug.
+ *
+ * ## The failure it now reports
+ * At 01:59 on 2026-09-07 the Pixel's nightly `full_backup_package dev.astraedus.nudge` killed the
+ * process. The OS rescheduled both services and Android's Settings screen said "Enabled, but your
+ * phone stopped it, turn it off and back on to restart blocking". Nudge's own notification said
+ * "Nudge is active / Monitoring app usage" the whole time, because that text was a constant. An app
+ * blocker that has stopped blocking and still claims it is blocking is worse than one that crashes:
+ * nothing prompts the user to fix it.
+ *
+ * So the notification is now a function of [ServiceHealth], refreshed on a slow poll, and a
+ * degraded state also raises a separate DEFAULT-importance alert that deep-links to accessibility
+ * settings. `allowBackup` is off as of the same change, which removes the nightly kill that
+ * produced this window in the first place — the poll is the belt to that braces.
+ *
+ * Poll rather than observe: "the system unbound our service" fires no callback we can receive in a
+ * process that was not running at the time. 30s is the same interval as the service's own clocks and
+ * costs one settings read plus one string comparison.
+ */
 class NudgeMonitorService : Service() {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface MonitorEntryPoint {
+        fun nudgePreferences(): NudgePreferences
+        fun monitorLogger(): NudgeLogger
+    }
 
     companion object {
         private const val NOTIFICATION_ID = 1
+        private const val HEALTH_NOTIFICATION_ID = 2
         private const val CHANNEL_ID = "nudge_monitor"
+        private const val HEALTH_CHANNEL_ID = "nudge_service_health"
+
+        /** How often the health of the accessibility service is re-checked. */
+        internal const val HEALTH_POLL_INTERVAL_MS = 30_000L
 
         fun start(context: Context) {
             val intent = Intent(context, NudgeMonitorService::class.java)
@@ -27,39 +84,156 @@ class NudgeMonitorService : Service() {
         fun stop(context: Context) {
             context.stopService(Intent(context, NudgeMonitorService::class.java))
         }
+
+        /**
+         * Start the service if Nudge is enabled, stop it if not.
+         *
+         * Called from every place the answer can change — boot, app launch, the master toggle — so
+         * the service's existence tracks the master toggle instead of tracking whether the phone has
+         * been rebooted since install. Before this, `start` had exactly one caller ([BootReceiver])
+         * and `stop` had none: a fresh install never ran the service at all until the next reboot,
+         * and once running it never stopped, so its "Nudge is active" notification outlived the
+         * toggle being switched off.
+         */
+        fun sync(context: Context, globalEnabled: Boolean) {
+            if (globalEnabled) start(context) else stop(context)
+        }
     }
+
+    private val entryPoint: MonitorEntryPoint by lazy {
+        EntryPointAccessors.fromApplication(applicationContext, MonitorEntryPoint::class.java)
+    }
+
+    private val statusProvider: AccessibilityStatusProvider by lazy {
+        AndroidAccessibilityStatusProvider(applicationContext)
+    }
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Last health published, so the log records transitions rather than one line every 30s. */
+    private var lastPublishedHealth: ServiceHealth? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
+        createNotificationChannels()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val notification = buildNotification()
-        startForeground(NOTIFICATION_ID, notification)
+        // Foreground FIRST, unconditionally: the platform kills a service that has not called
+        // startForeground within a few seconds of being started, and after an OS-scheduled restart
+        // this runs with a null intent and no guarantee that anything below it succeeds.
+        startForeground(NOTIFICATION_ID, buildStatusNotification(ServiceHealth.ACTIVE))
+        startHealthPoll()
         return START_STICKY
     }
 
-    private fun createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
+    /**
+     * Re-evaluate health every [HEALTH_POLL_INTERVAL_MS] and publish it.
+     *
+     * The try/catch wraps the ITERATION, not the loop: a single throwing tick must not end the poll
+     * for the life of the process, which is the exact shape that silently killed both auto-kick
+     * clocks (`tasks/lessons.md`, 2026-09-01). The exit reason is logged for the same reason.
+     */
+    private fun startHealthPoll() {
+        if (pollJobStarted) return
+        pollJobStarted = true
+        serviceScope.launch {
+            entryPoint.monitorLogger().i("monitor health poll started")
+            while (isActive) {
+                try {
+                    if (!publishHealth()) return@launch
+                } catch (e: Exception) {
+                    entryPoint.monitorLogger().w("monitor health tick failed", e)
+                }
+                kotlinx.coroutines.delay(HEALTH_POLL_INTERVAL_MS)
+            }
+            entryPoint.monitorLogger().i("monitor health poll ended reason=scope_cancelled")
+        }
+    }
+
+    private var pollJobStarted = false
+
+    /**
+     * Recompute and publish the current health.
+     *
+     * @return false when the service has stopped itself (Nudge disabled) and the poll must end.
+     */
+    private suspend fun publishHealth(): Boolean {
+        val globalEnabled = entryPoint.nudgePreferences().isGlobalEnabled.first()
+        val health = ServiceHealth.evaluate(
+            globalEnabled = globalEnabled,
+            permissionGranted = statusProvider.isPermissionGranted(),
+            serviceConnected = statusProvider.isServiceConnected()
+        )
+
+        if (health != lastPublishedHealth) {
+            entryPoint.monitorLogger().i(
+                "monitor health $lastPublishedHealth -> $health " +
+                    "(enabled=$globalEnabled granted=${statusProvider.isPermissionGranted()} " +
+                    "connected=${statusProvider.isServiceConnected()})"
+            )
+            lastPublishedHealth = health
+        }
+
+        if (health == ServiceHealth.DISABLED) {
+            // A disabled Nudge must behave as if uninstalled, notification included. The controller
+            // in [sync] brings the service back when the toggle flips on.
+            stopSelf()
+            return false
+        }
+
+        val manager = getSystemService(NotificationManager::class.java)
+        manager?.notify(NOTIFICATION_ID, buildStatusNotification(health))
+        if (health.isDegraded) {
+            manager?.notify(HEALTH_NOTIFICATION_ID, buildHealthAlert(health))
+        } else {
+            manager?.cancel(HEALTH_NOTIFICATION_ID)
+        }
+        return true
+    }
+
+    private fun createNotificationChannels() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+
+        manager.createNotificationChannel(
+            NotificationChannel(
                 CHANNEL_ID,
                 getString(com.astraedus.nudge.R.string.notification_channel_name),
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = getString(com.astraedus.nudge.R.string.notification_channel_description)
+                description =
+                    getString(com.astraedus.nudge.R.string.notification_channel_description)
                 setShowBadge(false)
             }
-            val manager = getSystemService(NotificationManager::class.java)
-            manager.createNotificationChannel(channel)
-        }
+        )
+
+        // Separate channel because the importance is the point: the ongoing status notification is
+        // deliberately IMPORTANCE_LOW (it is always there), and a silent low-importance line is
+        // exactly how "blocking is down" went unnoticed for hours. Importance cannot be raised on an
+        // existing channel, so the alert needs its own — and its own, so the user can silence the
+        // permanent one without silencing this.
+        manager.createNotificationChannel(
+            NotificationChannel(
+                HEALTH_CHANNEL_ID,
+                getString(com.astraedus.nudge.R.string.health_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = getString(com.astraedus.nudge.R.string.health_channel_description)
+            }
+        )
     }
 
-    private fun buildNotification(): Notification {
+    /**
+     * The permanent status notification. Tapping it opens Nudge — a destination for the user's tap,
+     * never a launch this service performs.
+     */
+    private fun buildStatusNotification(health: ServiceHealth): Notification {
+        val copy = health.notificationCopy()
         val tapIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
         val pendingIntent = PendingIntent.getActivity(
             this,
@@ -69,13 +243,51 @@ class NudgeMonitorService : Service() {
         )
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("Nudge is active")
-            .setContentText("Monitoring app usage")
+            .setContentTitle(copy.title)
+            .setContentText(copy.body)
             .setSmallIcon(android.R.drawable.ic_lock_idle_lock)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
             .setSilent(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
+    }
+
+    /**
+     * The recovery prompt for a degraded state.
+     *
+     * **A notification, never an Activity.** Recovery needs the user to go and flip a toggle in
+     * Settings; the tempting shortcut is for the service to open that screen (or Nudge's own) by
+     * itself, which is how an app blocker turns into an app that throws its UI over whatever the
+     * user is doing, at a moment it cannot know is convenient. The deep link is the notification's
+     * tap target, so the launch is the user's.
+     */
+    private fun buildHealthAlert(health: ServiceHealth): Notification {
+        val copy = health.notificationCopy()
+        val settingsIntent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            1,
+            settingsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, HEALTH_CHANNEL_ID)
+            .setContentTitle(copy.title)
+            .setContentText(copy.body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(copy.body))
+            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        getSystemService(NotificationManager::class.java)?.cancel(HEALTH_NOTIFICATION_ID)
+        serviceScope.cancel()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="accessibility_service_description">Nudge monitors which app is in the foreground to apply your blocking rules. No data leaves your device.</string>
     <string name="notification_channel_name">Nudge Monitor</string>
     <string name="notification_channel_description">Shows when Nudge is actively monitoring apps</string>
+    <string name="health_channel_name">Blocking stopped</string>
+    <string name="health_channel_description">Alerts you when Nudge has stopped blocking, for example after your phone stops the accessibility service</string>
 </resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  API 26-30 counterpart to data_extraction_rules.xml. allowBackup="false" already stops auto-backup
+  on these releases; this is belt-and-braces so an adb-driven or OEM backup that honours the rules
+  file still finds nothing to take.
+-->
+<full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="external" path="." />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  API 31+. Excludes everything from BOTH transports.
+
+  cloud-backup: Nudge's data must never leave the device (no INTERNET permission, "all data local"
+  in the store listing). device-transfer is excluded too: allowBackup="false" does not govern it on
+  31+, so leaving it open would still copy the whole database to a new phone through Google's
+  transfer flow, and a rule set silently arriving on a device the user never configured is a
+  surprise an app blocker cannot afford.
+
+  Users move their rules with Settings -> Export rules / Import rules.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="file" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="file" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/test/java/com/astraedus/nudge/domain/block/CooldownGateTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/block/CooldownGateTest.kt
@@ -1,0 +1,56 @@
+package com.astraedus.nudge.domain.block
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The auto-kick cooldown is the only enforcement in Nudge that runs before a rule is read and
+ * writes no `UsageEvent`. These four rows say it can never enforce on its own authority.
+ */
+class CooldownGateTest {
+
+    @Test
+    fun `a live cooldown on a package a rule still covers enforces`() {
+        assertTrue(CooldownGate.shouldEnforce(hasRuleEntry = true, isInCooldown = true))
+    }
+
+    @Test
+    fun `a cooldown on a package no rule covers does not enforce`() {
+        // The bug shape: the user deletes the rule (or turns its auto-kick off) while the cooldown
+        // timer is still running. The in-memory map outlives the rule, and acting on it puts a
+        // block overlay over an app nothing is configured to block, leaving no trace in the stats.
+        assertFalse(CooldownGate.shouldEnforce(hasRuleEntry = false, isInCooldown = true))
+    }
+
+    @Test
+    fun `no cooldown never enforces, rule or not`() {
+        assertFalse(CooldownGate.shouldEnforce(hasRuleEntry = true, isInCooldown = false))
+        assertFalse(CooldownGate.shouldEnforce(hasRuleEntry = false, isInCooldown = false))
+    }
+
+    @Test
+    fun `only a rule-less live cooldown is stale`() {
+        assertTrue(CooldownGate.isStale(hasRuleEntry = false, isInCooldown = true))
+        assertFalse(CooldownGate.isStale(hasRuleEntry = true, isInCooldown = true))
+        assertFalse(CooldownGate.isStale(hasRuleEntry = false, isInCooldown = false))
+        assertFalse(CooldownGate.isStale(hasRuleEntry = true, isInCooldown = false))
+    }
+
+    /**
+     * The two functions must never both be true: a cooldown is either enforceable or stale, and a
+     * caller that clears the stale one and then enforces it would be doing both.
+     */
+    @Test
+    fun `enforce and stale are mutually exclusive across the whole table`() {
+        listOf(true, false).forEach { hasRule ->
+            listOf(true, false).forEach { inCooldown ->
+                assertFalse(
+                    "hasRule=$hasRule inCooldown=$inCooldown was both enforceable and stale",
+                    CooldownGate.shouldEnforce(hasRule, inCooldown) &&
+                        CooldownGate.isStale(hasRule, inCooldown)
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/astraedus/nudge/domain/health/ServiceHealthTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/health/ServiceHealthTest.kt
@@ -1,0 +1,142 @@
+package com.astraedus.nudge.domain.health
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The whole truth table, because the bug this replaces was a constant string.
+ *
+ * The case that matters, and the one no previous test could have expressed, is
+ * [permission granted but service not connected]: that is the state the Pixel sat in after the
+ * 01:59 backup kill on 2026-09-07 while the notification said "Nudge is active".
+ */
+class ServiceHealthTest {
+
+    @Test
+    fun `master toggle off outranks everything`() {
+        // Even a perfectly healthy service is DISABLED when the user has switched Nudge off — a
+        // disabled Nudge must behave as if uninstalled, notification included.
+        assertEquals(
+            ServiceHealth.DISABLED,
+            ServiceHealth.evaluate(
+                globalEnabled = false,
+                permissionGranted = true,
+                serviceConnected = true
+            )
+        )
+        assertEquals(
+            ServiceHealth.DISABLED,
+            ServiceHealth.evaluate(
+                globalEnabled = false,
+                permissionGranted = false,
+                serviceConnected = false
+            )
+        )
+    }
+
+    @Test
+    fun `no accessibility permission is reported as not blocking`() {
+        assertEquals(
+            ServiceHealth.PERMISSION_MISSING,
+            ServiceHealth.evaluate(
+                globalEnabled = true,
+                permissionGranted = false,
+                serviceConnected = false
+            )
+        )
+    }
+
+    @Test
+    fun `granted but unbound is STOPPED_BY_SYSTEM — the post-kill window`() {
+        // Settings still lists Nudge (permissionGranted), our instance is gone (not connected).
+        // Nothing is enforced and only this state can say so.
+        assertEquals(
+            ServiceHealth.STOPPED_BY_SYSTEM,
+            ServiceHealth.evaluate(
+                globalEnabled = true,
+                permissionGranted = true,
+                serviceConnected = false
+            )
+        )
+    }
+
+    @Test
+    fun `granted and bound is ACTIVE`() {
+        assertEquals(
+            ServiceHealth.ACTIVE,
+            ServiceHealth.evaluate(
+                globalEnabled = true,
+                permissionGranted = true,
+                serviceConnected = true
+            )
+        )
+    }
+
+    @Test
+    fun `only the two not-blocking-but-asked-to states are degraded`() {
+        assertTrue(ServiceHealth.PERMISSION_MISSING.isDegraded)
+        assertTrue(ServiceHealth.STOPPED_BY_SYSTEM.isDegraded)
+        assertFalse(ServiceHealth.ACTIVE.isDegraded)
+        // DISABLED is not degraded: the user asked for nothing, so there is nothing to alert about.
+        assertFalse(ServiceHealth.DISABLED.isDegraded)
+    }
+
+    /**
+     * The regression this file exists for, stated as a property rather than a case: no state in
+     * which Nudge is not enforcing may carry reassuring copy. "Nudge is active" was shown for
+     * hours while blocking was down; that sentence may only appear for [ServiceHealth.ACTIVE].
+     */
+    @Test
+    fun `a non-enforcing state never claims to be active`() {
+        ServiceHealth.entries.forEach { health ->
+            val copy = health.notificationCopy()
+            if (health != ServiceHealth.ACTIVE) {
+                assertFalse(
+                    "$health must not claim Nudge is active: ${copy.title} / ${copy.body}",
+                    copy.title.contains("is active", ignoreCase = true)
+                )
+            }
+        }
+        assertEquals("Nudge is active", ServiceHealth.ACTIVE.notificationCopy().title)
+    }
+
+    /**
+     * Every state gets its own words. A `when` with an `else` would compile and would quietly give
+     * a new state the reassuring default — the same shape as the one-error-string-for-two-causes
+     * defect this repo has already paid for.
+     */
+    @Test
+    fun `every state has distinct, non-blank copy`() {
+        val copies = ServiceHealth.entries.map { it.notificationCopy() }
+        copies.forEach {
+            assertTrue("title must not be blank", it.title.isNotBlank())
+            assertTrue("body must not be blank", it.body.isNotBlank())
+        }
+        assertEquals(
+            "each state needs its own body — a shared string cannot tell the user what to do",
+            ServiceHealth.entries.size,
+            copies.map { it.body }.distinct().size
+        )
+    }
+
+    /**
+     * A degraded state's copy must tell the user what to DO. "Nudge is not blocking" alone leaves
+     * them where Settings already left them: knowing something is wrong, not knowing the fix.
+     */
+    @Test
+    fun `degraded copy names the recovery action`() {
+        ServiceHealth.entries.filter { it.isDegraded }.forEach { health ->
+            val body = health.notificationCopy().body.lowercase()
+            assertTrue(
+                "$health must tell the user to tap: $body",
+                body.contains("tap")
+            )
+            assertTrue(
+                "$health must name accessibility as the thing to fix: $body",
+                body.contains("accessibility")
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockAfterRestartTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/domain/usecase/EvaluateBlockAfterRestartTest.kt
@@ -1,0 +1,114 @@
+package com.astraedus.nudge.domain.usecase
+
+import com.astraedus.nudge.data.db.entity.BlockRule
+import com.astraedus.nudge.data.preferences.NudgePreferences
+import com.astraedus.nudge.data.repository.BlockRuleRepository
+import com.astraedus.nudge.data.repository.ContentFilter
+import com.astraedus.nudge.data.repository.UsageRepository
+import com.astraedus.nudge.domain.engine.BlockEngine
+import com.astraedus.nudge.domain.engine.RuleEvaluator
+import com.astraedus.nudge.domain.engine.ScheduleEvaluator
+import com.astraedus.nudge.domain.model.BlockDecision
+import com.astraedus.nudge.domain.model.BlockMode
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What Nudge is allowed to do to an app **no rule targets**, including in the window right after the
+ * OS has killed and restarted the process.
+ *
+ * The 2026-09-07 report was that Nudge repeatedly surfaced its own UI over Telegram after the
+ * nightly backup kill, with a single YouTube rule configured and zero block events ever recorded for
+ * Telegram. The absence of those rows is itself evidence about the mechanism: every block this use
+ * case decides writes a `UsageEvent`, so a decision made *here* would have left a trail. These tests
+ * pin the half that is ours to guarantee — an un-ruled package is never blocked, and a rule set that
+ * has not loaded yet is worth nothing rather than everything.
+ */
+class EvaluateBlockAfterRestartTest {
+
+    private val ruledPackage = "com.google.android.youtube"
+    private val unruledPackage = "org.telegram.messenger"
+
+    private lateinit var blockRuleRepository: BlockRuleRepository
+    private lateinit var usageRepository: UsageRepository
+    private lateinit var preferences: NudgePreferences
+    private lateinit var contentFilter: ContentFilter
+    private lateinit var useCase: EvaluateBlockUseCase
+
+    @Before
+    fun setUp() {
+        blockRuleRepository = mockk()
+        usageRepository = mockk()
+        preferences = mockk()
+        contentFilter = mockk()
+
+        every { blockRuleRepository.getAllGroups() } returns flowOf(emptyList())
+        every { usageRepository.getDailyForegroundTimeMs(any()) } returns 0L
+
+        useCase = EvaluateBlockUseCase(
+            blockRuleRepository = blockRuleRepository,
+            usageRepository = usageRepository,
+            blockEngine = BlockEngine(ScheduleEvaluator()),
+            ruleEvaluator = RuleEvaluator(),
+            preferences = preferences,
+            contentFilter = contentFilter
+        )
+    }
+
+    /** The exact configuration on the device that produced the report: one YouTube DELAY rule. */
+    private val youtubeDelayRule = BlockRule(
+        id = 1L,
+        packageName = ruledPackage,
+        mode = BlockMode.DELAY.name,
+        delaySeconds = 15,
+        enabled = true
+    )
+
+    @Test
+    fun `an app with no rule is not blocked, even while another app has one`() = runTest {
+        every { blockRuleRepository.getEnabledRules() } returns flowOf(listOf(youtubeDelayRule))
+
+        assertTrue(
+            "Telegram has no rule and must be allowed",
+            useCase.invoke(unruledPackage) is BlockDecision.Allow
+        )
+        assertTrue(
+            "the one configured rule must still fire, or this test proves nothing",
+            useCase.invoke(ruledPackage) is BlockDecision.Block
+        )
+    }
+
+    /**
+     * The post-kill window, at its worst: the process has restarted and the rule set has not loaded.
+     * An empty rule set must enforce **nothing** — never "block until we know better".
+     */
+    @Test
+    fun `an empty rule set enforces nothing`() = runTest {
+        every { blockRuleRepository.getEnabledRules() } returns flowOf(emptyList())
+
+        listOf(unruledPackage, ruledPackage, "com.android.chrome", "com.android.settings")
+            .forEach { pkg ->
+                assertTrue(
+                    "$pkg must be allowed when no rules are loaded",
+                    useCase.invoke(pkg) is BlockDecision.Allow
+                )
+            }
+    }
+
+    /**
+     * A rule that exists but is disabled is the same as no rule. `getEnabledRules` is the only
+     * source, so this is really a guard against someone widening it to `getAllRules` for
+     * convenience — which would resurrect every rule a user has ever switched off.
+     */
+    @Test
+    fun `a disabled rule blocks nothing`() = runTest {
+        every { blockRuleRepository.getEnabledRules() } returns flowOf(emptyList())
+
+        assertTrue(useCase.invoke(ruledPackage) is BlockDecision.Allow)
+    }
+}

--- a/app/src/test/java/com/astraedus/nudge/service/MonitorServiceContractTest.kt
+++ b/app/src/test/java/com/astraedus/nudge/service/MonitorServiceContractTest.kt
@@ -1,0 +1,286 @@
+package com.astraedus.nudge.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Source-level guard on what a *service* is allowed to do to the user's screen, and on the app's
+ * backup posture.
+ *
+ * ## The report this came from
+ * A QA session on 2026-09-07 reported Nudge "throwing MainActivity in front of Telegram" during the
+ * window after the nightly backup killed the process, with no rule targeting Telegram and no block
+ * events recorded — and attributed it to [NudgeMonitorService] relaunching the UI. The source says
+ * otherwise: nothing in this app has ever called `startActivity` with `MainActivity`, and the
+ * monitor service reads no rules and makes no decisions. That the explanation was *plausible* is
+ * the point. A foreground service that could surface its own UI over an arbitrary app would be
+ * indistinguishable, from outside, from exactly this report — so the property is worth pinning
+ * before someone adds it for a good-sounding reason (a "service stopped, tap to restart" prompt is
+ * the obvious one, and it belongs in a notification).
+ *
+ * None of this is JVM-testable behaviourally: `Service`, `NotificationManager` and the accessibility
+ * bind are all platform. The defect class lives in the SHAPE of the code, so this pins the shape,
+ * the way `HomeScreenPassthroughContractTest` and `OverlayBackAndInsetsContractTest` already do.
+ */
+class MonitorServiceContractTest {
+
+    private fun sourceRoot(): File =
+        listOf(File("src/main"), File("app/src/main")).firstOrNull { it.isDirectory }
+            ?: error("main source set not found from working dir ${File("").absolutePath}")
+
+    private fun read(relativePath: String): String {
+        val file = File(sourceRoot(), relativePath)
+        assertTrue("$relativePath must exist", file.exists())
+        return file.readText()
+    }
+
+    private val monitorService = "java/com/astraedus/nudge/service/NudgeMonitorService.kt"
+    private val accessibilityService =
+        "java/com/astraedus/nudge/service/NudgeAccessibilityService.kt"
+
+    private fun serviceSources(): List<File> =
+        File(sourceRoot(), "java/com/astraedus/nudge/service")
+            .walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+    /** Strip `//` line comments and `/* */` blocks so prose about a pattern is not read as the pattern. */
+    private fun code(text: String): String = text
+        .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
+        .lines().joinToString("\n") { it.substringBefore("//") }
+
+    // --- 1. No service may put Nudge's own main UI over another app -------------------------------
+
+    /**
+     * The rule, stated over the whole package rather than the one file that was accused: no class
+     * in `service/` may pass a `MainActivity` intent to `startActivity`. A `PendingIntent` is
+     * explicitly fine — that is a destination for a tap the *user* makes.
+     */
+    @Test
+    fun `no service starts MainActivity`() {
+        serviceSources().forEach { file ->
+            val body = code(file.readText())
+            if (!body.contains("MainActivity")) return@forEach
+
+            // Every MainActivity intent in a service must be consumed by PendingIntent.getActivity.
+            assertTrue(
+                "${file.name} references MainActivity but never builds a PendingIntent from it — " +
+                    "a service may only offer Nudge's UI as a notification tap target",
+                body.contains("PendingIntent.getActivity(")
+            )
+            Regex("""startActivity\(([^)]*)\)""").findAll(body).forEach { match ->
+                assertFalse(
+                    "${file.name} calls startActivity(${match.groupValues[1].trim()}) with a " +
+                        "MainActivity intent — a service must never surface Nudge's own UI over " +
+                        "whatever the user is doing",
+                    match.groupValues[1].contains("MainActivity", ignoreCase = true)
+                )
+            }
+        }
+    }
+
+    /**
+     * Sharper still for the monitor service: it holds a notification and polls health. It has no
+     * business launching anything, so it contains no `startActivity` call of any kind.
+     */
+    @Test
+    fun `the monitor service launches no activity at all`() {
+        val body = code(read(monitorService))
+        assertFalse(
+            "NudgeMonitorService must not call startActivity — recovery prompts go through a " +
+                "notification, never an Activity launch from a service",
+            body.contains("startActivity(")
+        )
+        assertTrue(
+            "the only MainActivity use here is a notification tap target",
+            body.contains("PendingIntent.getActivity(")
+        )
+    }
+
+    /**
+     * And it makes no enforcement decisions. The QA read assumed it "independently polls foreground
+     * app usage"; it must stay the case that it cannot, because a second, rule-less decision maker
+     * is precisely how a blocker starts blocking apps nobody configured.
+     */
+    @Test
+    fun `the monitor service reads no rules and evaluates nothing`() {
+        val body = code(read(monitorService))
+        listOf(
+            "BlockRule",
+            "ruleRepository",
+            "RuleRepository",
+            "EvaluateBlockUseCase",
+            "BlockOverlayActivity",
+            "usageStatsManager",
+            "UsageStatsManager"
+        ).forEach { forbidden ->
+            assertFalse(
+                "NudgeMonitorService must not reference $forbidden — all enforcement belongs to " +
+                    "NudgeAccessibilityService, gated on a rule matching the foreground package",
+                body.contains(forbidden)
+            )
+        }
+    }
+
+    // --- 2. The recovery prompt is a notification -------------------------------------------------
+
+    /**
+     * The degraded states must actually reach the user. An `IMPORTANCE_LOW` line on the permanent
+     * channel is how "blocking is down" stayed invisible for hours, so a second, higher-importance
+     * channel has to exist and the deep link has to go to accessibility settings.
+     */
+    @Test
+    fun `a degraded state raises a separate accessibility-settings notification`() {
+        val body = code(read(monitorService))
+        assertTrue(
+            "a second notification channel is needed: importance cannot be raised on an existing one",
+            body.contains("IMPORTANCE_DEFAULT")
+        )
+        assertTrue(
+            "the recovery prompt must deep-link to accessibility settings",
+            body.contains("Settings.ACTION_ACCESSIBILITY_SETTINGS")
+        )
+        assertTrue(
+            "the alert must be gated on ServiceHealth.isDegraded, not on any single cause",
+            body.contains("isDegraded")
+        )
+    }
+
+    /**
+     * Notification copy is a function of health, not a constant. The original defect was literally a
+     * hardcoded "Nudge is active" that outlived the service being active.
+     */
+    @Test
+    fun `notification text is derived from ServiceHealth`() {
+        val body = code(read(monitorService))
+        assertTrue(
+            "copy must come from ServiceHealth.notificationCopy()",
+            body.contains("notificationCopy()")
+        )
+        assertFalse(
+            "no hardcoded status string may survive in the service — that was the bug",
+            body.contains("\"Nudge is active\"") || body.contains("\"Monitoring app usage\"")
+        )
+    }
+
+    // --- 3. The monitor service's lifecycle tracks the master toggle -------------------------------
+
+    /**
+     * `start()` used to have one caller (boot) and `stop()` none. A fresh install therefore ran no
+     * foreground service until the next reboot — so nothing could have noticed the accessibility
+     * service was down — and once running it never stopped, so it kept claiming to be active after
+     * the user switched Nudge off.
+     */
+    @Test
+    fun `every place the master toggle can change syncs the monitor service`() {
+        mapOf(
+            "java/com/astraedus/nudge/service/BootReceiver.kt" to "boot",
+            "java/com/astraedus/nudge/MainActivity.kt" to "app launch",
+            accessibilityService to "the master toggle"
+        ).forEach { (path, occasion) ->
+            assertTrue(
+                "$path must call NudgeMonitorService.sync — the service's existence has to track " +
+                    "the master toggle at $occasion",
+                code(read(path)).contains("NudgeMonitorService.sync(")
+            )
+        }
+    }
+
+    /**
+     * Health is polled, not observed: "the system unbound our service" fires no callback we can
+     * receive in a process that was not running when it happened.
+     */
+    @Test
+    fun `health is polled and the tick is individually guarded`() {
+        val body = code(read(monitorService))
+        assertTrue("a poll interval must exist", body.contains("HEALTH_POLL_INTERVAL_MS"))
+        assertTrue(
+            "the try must wrap the ITERATION, not the loop: one throwing tick must not end the " +
+                "poll for the life of the process (tasks/lessons.md, 2026-09-01)",
+            body.contains("while (isActive)") && body.indexOf("while (isActive)") <
+                body.indexOf("catch (e: Exception)")
+        )
+    }
+
+    // --- 4. Enforcement stays gated on a rule that still exists ------------------------------------
+
+    /**
+     * The auto-kick cooldown is the one path that blocks before reading a rule and writes no
+     * `UsageEvent`. Both instances of it (app and web) go through [com.astraedus.nudge.domain.block.CooldownGate].
+     */
+    @Test
+    fun `both cooldown paths are gated on a live rule entry`() {
+        val body = code(read(accessibilityService))
+        assertEquals(
+            "both the app-level and the web cooldown must ask CooldownGate.shouldEnforce",
+            2,
+            Regex("""CooldownGate\.shouldEnforce\(""").findAll(body).count()
+        )
+        assertEquals(
+            "both must also drop a cooldown left behind by a deleted rule",
+            2,
+            Regex("""CooldownGate\.isStale\(""").findAll(body).count()
+        )
+        assertFalse(
+            "no cooldown branch may test isInCooldown on its own again",
+            Regex("""if\s*\(\s*!?tracker\.isInCooldown\(""").containsMatchIn(body)
+        )
+    }
+
+    // --- 5. Backup posture -------------------------------------------------------------------------
+
+    /**
+     * Two reasons, one attribute. Privacy: a no-INTERNET app advertising "all data local" must not
+     * have Google silently holding a copy of every rule and every usage row. Reliability: running a
+     * full backup force-kills the process, which is what produced the 01:59 window where Settings
+     * said "Enabled, but your phone stopped it".
+     */
+    @Test
+    fun `auto backup is off on every API level`() {
+        val manifest = File(sourceRoot(), "AndroidManifest.xml").readText()
+        assertTrue(
+            "allowBackup must be false — a nightly full_backup kills an always-on blocker, and " +
+                "uploads a local-only app's database to Google Drive",
+            manifest.contains("""android:allowBackup="false"""")
+        )
+        assertTrue(
+            "API 31+ needs dataExtractionRules: allowBackup alone no longer governs device transfer",
+            manifest.contains("""android:dataExtractionRules="@xml/data_extraction_rules"""")
+        )
+        assertTrue(
+            "API 26-30 needs fullBackupContent",
+            manifest.contains("""android:fullBackupContent="@xml/backup_rules"""")
+        )
+    }
+
+    /**
+     * The rules files must exclude everything from BOTH transports. An exclusion list that names
+     * only `database` would still ship DataStore preferences (the master toggle, Strict Mode state)
+     * to a new phone.
+     */
+    @Test
+    fun `both backup rule files exclude every domain`() {
+        val domains = listOf("root", "database", "sharedpref", "file", "external")
+
+        val extraction = File(sourceRoot(), "res/xml/data_extraction_rules.xml").readText()
+        listOf("cloud-backup", "device-transfer").forEach { transport ->
+            val section = extraction.substringAfter("<$transport>").substringBefore("</$transport>")
+            assertTrue("$transport section must exist", section.isNotBlank())
+            domains.forEach { domain ->
+                assertTrue(
+                    "$transport must exclude domain=$domain",
+                    section.contains("""domain="$domain"""")
+                )
+            }
+        }
+
+        val fullBackup = File(sourceRoot(), "res/xml/backup_rules.xml").readText()
+        domains.forEach { domain ->
+            assertTrue(
+                "full-backup-content must exclude domain=$domain",
+                fullBackup.contains("""domain="$domain"""")
+            )
+        }
+    }
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -206,3 +206,59 @@ fired" being indistinguishable is what cost a release cycle.*
   test asserting "exactly one event loop", scoped to `ScreenTimeProvider`. The FOURTH copy sat in
   `UsageRepository`, uncapped open tail and all, and was the clock behind the auto-kick and every
   daily budget. Scope the invariant to the CODEBASE, not to the file you were editing.
+
+## The mechanism a bug report names is a hypothesis, not a finding (2026-09-07)
+
+A QA session on the shared Pixel reported Nudge "throwing its MainActivity in front of Telegram
+repeatedly" after the nightly backup killed the process, with one YouTube rule configured, zero block
+events ever recorded for Telegram, and one "keeps stopping" dialog. The written-up cause was
+`NudgeMonitorService`, described as a foreground service that "independently polls foreground-app
+usage and can relaunch Nudge's UI".
+
+It does not, and it never has. The file was 81 lines: create a channel, `startForeground`, return
+`START_STICKY`. Its only `MainActivity` reference was a notification `contentIntent`. A grep for
+`startActivity` across the whole app finds **no** programmatic `MainActivity` launch anywhere, so the
+only routes to that screen are the launcher icon and the ongoing notification's own tap target, which
+is very reachable on a device being driven blind over ADB. The `am_crash` in the same logcat is
+`RemoteServiceException: shell-induced crash` -- the QA session's own induced crash -- and the two
+`FATAL EXCEPTION`s are `UiAutomationService ... already registered` collisions from two ADB drivers,
+the one-agent-per-device lesson from 2026-08-20 showing up again.
+
+- **Settle the mechanism in the source before fixing the mechanism.** Three greps (`startActivity`,
+  `MainActivity`, the accused file itself) were enough, and they cost less than one device session.
+  Fixing the reported cause here would have meant rewriting a file that had no defect in it.
+- **Read the reporter's evidence for what it RULES OUT, not just what it shows.** "Zero block events
+  for Telegram" is a strong negative: every decision `EvaluateBlockUseCase` makes writes a
+  `UsageEvent`, so the absence of rows proves the block path was not involved. That pointed straight
+  at the one enforcement branch that writes no event -- the auto-kick cooldown.
+- **An induced crash in a logcat is not a crash.** `shell-induced` and `UiAutomation` in a stack trace
+  mean the harness, not the app. Grepping for `FATAL EXCEPTION` and reporting the count is how a QA
+  artifact becomes a phantom P0.
+
+Four real defects came out of root-causing it anyway, and they are the useful part:
+
+1. **A blocker that stops blocking must say so.** After the kill, Android's Settings said "Enabled,
+   but your phone stopped it" while Nudge's permanent notification read "Nudge is active" -- because
+   that string was a constant. `ServiceHealth` (pure, four states, no `else`) now drives the copy, and
+   a degraded state raises a separate `IMPORTANCE_DEFAULT` alert deep-linking to accessibility
+   settings. **The recovery prompt is a notification, never an Activity**: a service that opens a
+   screen over whatever the user is doing is the very thing the report described.
+2. **"Enabled" and "connected" are different questions**, and they disagree for minutes after a
+   process kill. `Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES` is what the user controls;
+   `NudgeAccessibilityService.isConnected()` is what the system controls. Collapsing them hides the
+   whole failure window.
+3. **`android:allowBackup="true"` on a no-INTERNET, "all data local" app.** It uploaded the database
+   to Google Drive, and running the backup force-killed the process nightly -- the trigger for
+   everything above. Off now on every API level (`allowBackup` + `dataExtractionRules` +
+   `fullBackupContent`, every domain excluded on both cloud-backup and device-transfer).
+4. **The auto-kick cooldown enforced on remembered authority.** It is the only branch that blocks
+   before reading a rule and writes no `UsageEvent`; delete the rule while the timer runs and it kept
+   ejecting the user from an app nothing was configured to block, invisibly. `CooldownGate` makes the
+   authority derived (a live counter-cache entry) instead of remembered, in **both** places the
+   pattern existed -- the app path and the web path.
+
+Also fixed in passing: `NudgeMonitorService.start` had exactly one caller (`BootReceiver`) and `stop`
+had none, so a fresh install ran no foreground service until the next reboot and the notification
+outlived the master toggle. `sync(context, enabled)` is now called from boot, app launch, and the
+toggle collector. **A `stop()` with no callers is a lifecycle that was never finished, not dead code
+to delete.**


### PR DESCRIPTION
## The reported cause was not the cause

A QA session on the Pixel reported Nudge "throwing its MainActivity in front of Telegram repeatedly"
in the window after the nightly `full_backup_package dev.astraedus.nudge` killed the process, and
attributed it to `NudgeMonitorService` "independently polling foreground-app usage".

The source rules that out:

- `NudgeMonitorService` was 81 lines: create a channel, `startForeground`, return `START_STICKY`. No
  polling, no rule reads, no decisions.
- A repo-wide grep for `startActivity` finds **no programmatic `MainActivity` launch anywhere**. Its
  only `MainActivity` reference was the notification's `contentIntent`, so the only ways to that
  screen are the launcher icon and a tap on the persistent notification.
- The `am_crash` in the same logcat is `android.app.RemoteServiceException: shell-induced crash`, and
  both `FATAL EXCEPTION`s are `UiAutomationService ... already registered` collisions from two ADB
  drivers. Neither is a crash in our code.
- Zero `usage_events` rows for Telegram is itself evidence: every decision `EvaluateBlockUseCase`
  makes writes one, so the block path was not involved. That pointed at the one enforcement branch
  that writes no event.

Root-causing it turned up four real defects, all fixed here at the mechanism level.

## What is fixed

**1. A blocker that has stopped blocking now says so.** Android unbinds the accessibility service
after a backup, memory pressure or a force stop. Settings said "Enabled, but your phone stopped it,
turn it off and back on to restart blocking" while Nudge's permanent notification read "Nudge is
active" — because that string was a constant. `ServiceHealth` (pure, four states, no `else`) drives
the copy now, refreshed on a 30s poll, and a degraded state raises a separate `IMPORTANCE_DEFAULT`
alert that deep-links to accessibility settings.

**The recovery prompt is a notification, never an Activity launched from a service.** Opening a
screen over whatever the user is doing is exactly what the bug report described, and it is the
tempting shortcut here, so `MonitorServiceContractTest` pins it shut.

"Enabled in Settings" and "bound in this process" are kept as separate questions
(`AccessibilityStatusProvider`). They disagree for minutes after a kill, and that disagreement is the
entire failure window.

**2. `allowBackup` is off.** Nudge holds no `INTERNET` permission and its listing promises "all data
local", yet Android Auto Backup was uploading the whole Room database — every rule, every blocked
app, the full usage history — to Google Drive. Running that backup also force-kills the process,
which is what produced defect 1 in the first place. Off on every API level now: `allowBackup="false"`
plus `dataExtractionRules` (31+, where `allowBackup` no longer governs device transfer) and
`fullBackupContent` (26-30), every domain excluded on both `cloud-backup` and `device-transfer`.
Export/import stays the backup path users actually have.

**3. The auto-kick cooldown no longer enforces on remembered authority.** It is the only branch that
blocks before reading a rule and writes no `UsageEvent`. Delete the rule (or turn its auto-kick off)
while the timer is running and the in-memory map kept ejecting the user from an app nothing was
configured to block, for the whole cooldown, invisibly. `CooldownGate` makes the authority *derived*
from a live counter-cache entry instead of *remembered*, and drops the stale cooldown — in **both**
places the pattern existed, the app path and the web path.

**4. The monitor service's lifecycle tracks the master toggle.** `start()` had exactly one caller
(`BootReceiver`) and `stop()` had none, so a fresh install ran no foreground service until the next
reboot, and once running it never stopped, so "Nudge is active" outlived the toggle being switched
off. `sync(context, enabled)` is now called from boot, app launch, and the global-enabled collector.

## Tests

1098 to 1124, 0 failures on both `testDebugUnitTest` and `testReleaseUnitTest`.

| Test | Pins |
|---|---|
| `ServiceHealthTest` | The whole truth table, plus "a non-enforcing state never claims to be active" and "degraded copy names the recovery action" |
| `CooldownGateTest` | A cooldown without a live rule enforces nothing; enforce and stale are mutually exclusive |
| `EvaluateBlockAfterRestartTest` | An un-ruled app is allowed while a ruled one still blocks; an empty rule set enforces nothing |
| `MonitorServiceContractTest` | No service starts `MainActivity`; the monitor launches nothing and reads no rules; recovery is a notification; both cooldown paths gated; backup off with every domain excluded on both transports |

Four mutations were run to prove the contract tests are not vacuous. Each fails only the intended
test: injecting a `startActivity` into the monitor service, reverting one cooldown gate to the bare
`isInCooldown` check, flipping `allowBackup` back to `true`, and giving a degraded state the
"Nudge is active" title.

The merged manifest was checked after the build, not just the source, so no library re-enables
backup: `allowBackup="false"`, `dataExtractionRules`, `fullBackupContent` all present.

## Release

Version bumped to 1.15.4 / versionCode 47 with a CHANGELOG entry, so the tag is a one-liner later.
**No tag in this PR** — 1.15.3 is in review on Play production. Cut v1.15.4 once 1.15.3 shows
PUBLISHED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx552g3mDDbwcKkMD3rCnu
